### PR TITLE
Build crashpad_handler as a "Windows" application

### DIFF
--- a/premake/premake5.crashpad.lua
+++ b/premake/premake5.crashpad.lua
@@ -590,7 +590,7 @@ project "crashpad_minidump"
 
 
 project "crashpad_handler"
-  kind "ConsoleApp"
+  kind "WindowedApp"
   crashpad_common()
   links {
     "crashpad_minichromium_base",


### PR DESCRIPTION
This stops the command window from being shown when it is executed.