### PR TITLE
fix: Add tests and fix various bugs

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -503,6 +503,16 @@ SENTRY_API void sentry_set_extra(const char *key, sentry_value_t value);
 SENTRY_API void sentry_remove_extra(const char *key);
 
 /*
+ * Sets a context object.
+ */
+SENTRY_API void sentry_set_context(const char *key, sentry_value_t value);
+
+/*
+ * Removes the context object with the specified key.
+ */
+SENTRY_API void sentry_remove_context(const char *key, sentry_value_t value);
+
+/*
  * Sets the event fingerprint.
  */
 SENTRY_API void sentry_set_fingerprint(const char *fingerprint, ...);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -150,6 +150,18 @@ void sentry_remove_extra(const char *key) {
     flush_scope();
 }
 
+void sentry_set_context(const char *key, sentry_value_t value) {
+    WITH_LOCKED_SCOPE;
+    g_scope.contexts.set_by_key(key, Value::consume(value));
+    flush_scope();
+}
+
+void sentry_remove_context(const char *key) {
+    WITH_LOCKED_SCOPE;
+    g_scope.contexts.remove_by_key(key);
+    flush_scope();
+}
+
 void sentry_set_fingerprint(const char *fingerprint, ...) {
     WITH_LOCKED_SCOPE;
     va_list va;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -31,6 +31,8 @@ sentry_options_s::sentry_options_s()
       backend(new sentry::backends::CrashpadBackend()),
 #elif defined(SENTRY_WITH_BREAKPAD_BACKEND)
       backend(new sentry::backends::BreakpadBackend()),
+#else
+      backend(nullptr),
 #endif
       before_send([](sentry::Value event, void *hint) { return event; }) {
     std::random_device seed;

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -117,6 +117,7 @@ void Scope::apply_to_event(Value &event, bool with_breadcrumbs) const {
 
     event.merge_key("tags", tags);
     event.merge_key("extra", extra);
+    event.merge_key("contexts", contexts);
 
     if (fingerprint.type() == SENTRY_VALUE_TYPE_LIST &&
         fingerprint.length() > 0) {

--- a/src/scope.hpp
+++ b/src/scope.hpp
@@ -13,6 +13,7 @@ struct Scope {
         : level(SENTRY_LEVEL_ERROR),
           extra(Value::new_object()),
           tags(Value::new_object()),
+          contexts(Value::new_object()),
           breadcrumbs(Value::new_list()),
           fingerprint(Value::new_list()) {
     }
@@ -27,6 +28,7 @@ struct Scope {
     sentry::Value user;
     sentry::Value tags;
     sentry::Value extra;
+    sentry::Value contexts;
     sentry::Value breadcrumbs;
     sentry_level_t level;
 };

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -264,7 +264,6 @@ Value Value::new_addr(uint64_t addr) {
 
 Value Value::new_event() {
     Value rv = Value::new_object();
-    rv.set_by_key("level", Value::new_string("error"));
 
     sentry_uuid_t uuid = sentry_uuid_new_v4();
     char uuid_str[40];
@@ -326,12 +325,12 @@ bool Value::merge_key(const char *key, Value value) {
         return true;
     }
 
-    Value existing = get_by_key(key);
-
     switch (value.type()) {
         case SENTRY_VALUE_TYPE_LIST: {
+            Value existing = get_by_key(key);
             if (existing.is_null()) {
                 existing = Value::new_list();
+                set_by_key(key, existing);
             } else if (existing.type() != SENTRY_VALUE_TYPE_LIST) {
                 return false;
             }
@@ -342,8 +341,10 @@ bool Value::merge_key(const char *key, Value value) {
             break;
         }
         case SENTRY_VALUE_TYPE_OBJECT: {
+            Value existing = get_by_key(key);
             if (existing.is_null()) {
                 existing = Value::new_object();
+                set_by_key(key, existing);
             } else if (existing.type() != SENTRY_VALUE_TYPE_OBJECT) {
                 return false;
             }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -298,7 +298,7 @@ Value Value::new_breadcrumb(const char *type, const char *message) {
     return rv;
 }
 
-Value Value::navigate(const char *path) {
+Value Value::navigate(const char *path) const {
     size_t len = strlen(path);
     size_t ident_start = 0;
     Value rv = *this;

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -482,7 +482,7 @@ class Value {
         } else if (thing && thing->type() == THING_TYPE_STRING) {
             return ((const std::string *)thing->ptr())->size();
         }
-        return (size_t)-1;
+        return -1;
     }
 
     void to_msgpack(mpack_writer_t *writer) const;

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -376,7 +376,7 @@ class Value {
         return false;
     }
 
-    Value navigate(const char *path);
+    Value navigate(const char *path) const;
 
     bool set_by_key(const char *key, Value value) {
         Thing *thing = as_thing();
@@ -439,33 +439,10 @@ class Value {
         return Value::new_null();
     }
 
-    Value get_by_key(const char *key) {
-        Thing *thing = as_thing();
-        if (thing && thing->type() == THING_TYPE_OBJECT) {
-            Object *object = (Object *)thing->ptr();
-            Object::iterator iter = object->find(key);
-            if (iter != object->end()) {
-                return iter->second;
-            }
-        }
-        return Value::new_null();
-    }
-
     Value get_by_index(size_t index) const {
         Thing *thing = as_thing();
         if (thing && thing->type() == THING_TYPE_LIST) {
             const List *list = (const List *)thing->ptr();
-            if (index < list->size()) {
-                return (*list)[index];
-            }
-        }
-        return Value::new_null();
-    }
-
-    Value get_by_index(size_t index) {
-        Thing *thing = as_thing();
-        if (thing && thing->type() == THING_TYPE_LIST) {
-            List *list = (List *)thing->ptr();
             if (index < list->size()) {
                 return (*list)[index];
             }

--- a/tests/testutils.hpp
+++ b/tests/testutils.hpp
@@ -19,6 +19,7 @@ struct SentryGuard {
     SentryGuard(sentry_options_t *options) {
         if (!options) {
             options = sentry_options_new();
+            sentry_options_set_dsn(options, "https://publickey@127.0.0.1/1");
         }
         mock_transport = MockTransportData();
         sentry_options_set_transport(options, send_event, nullptr);


### PR DESCRIPTION
This PR adds separate tests for most of the API and fixes a few bugs along the way:

 - **NEW**: Add `sentry_set_context` and `sentry_remove_context` as per unified API spec
 - **FIX**: Uninitialized backend in the standalone build
 - **FIX**: `tags`, and `extra` not merged due to a bug in `merge_key`
 - **FIX**: Internal `const` qualifiers on the `Value` C++ API
 - **TEST**: Initialize with DSN to ensure that the SDK is in active mode
