### PR TITLE
build: Fix build configs for crashpad and breakpad

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,13 +3,10 @@
     {
       "name": "Mac",
       "includePath": [
-        "${workspaceFolder}/**",
-        "../crashpad-Darwin/include/",
-        "./include",
-        "../vendor",
-        "../breakpad-Darwin/include/client/mac/handler",
-        "../breakpad-Darwin/include/",
-        "../breakpad-Linux/common/linux"
+        "${workspaceFolder}/include",
+        "${workspaceFolder}/crashpad/build/crashpad",
+        "${workspaceFolder}/crashpad/build/crashpad/third_party/mini_chromium/mini_chromium",
+        "${workspaceFolder}/breakpad/build/breakpad/src"
       ],
       "macFrameworkPath": [
         "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks"

--- a/premake/premake5.crashpad.lua
+++ b/premake/premake5.crashpad.lua
@@ -338,19 +338,7 @@ project "crashpad_util"
       MACOS_SYSROOT..'/usr/include/mach/notify.defs',
       MACOS_SYSROOT..'/usr/include/mach/mach_exc.defs',
       MACOS_SYSROOT..'/usr/include/mach/exc.defs',
-
       -- End MIG inputs
-
-      -- MIG
-      gen_dir.."/util/mach/excUser.c",
-      gen_dir.."/util/mach/excServer.c",
-      gen_dir.."/util/mach/mach_excUser.c",
-      gen_dir.."/util/mach/mach_excServer.c",
-      gen_dir.."/util/mach/notifyUser.c",
-      gen_dir.."/util/mach/notifyServer.c",
-      gen_dir.."/util/mach/child_portUser.c",
-      gen_dir.."/util/mach/child_portServer.c",
-      -- End MIG
     }
 
   filter "system:linux"

--- a/premake/premake5.sentry.lua
+++ b/premake/premake5.sentry.lua
@@ -78,9 +78,9 @@ project "sentry_crashpad"
   defines {
     "SENTRY_WITH_CRASHPAD_BACKEND"
   }
+
   includedirs {
     CRASHPAD_PKG,
-    CRASHPAD_PKG.."/include",
     CRASHPAD_PKG.."/third_party/mini_chromium/mini_chromium",
   }
 
@@ -116,7 +116,7 @@ project "sentry_breakpad"
     "-fvisibility=hidden",
   }
   includedirs {
-    BREAKPAD_PKG.."/include",
+    BREAKPAD_PKG.."/src",
   }
 
   -- Breakpad


### PR DESCRIPTION
Fixes include paths in libsentry_breakpad and removes redundant rules for crashpad utils.