### PR TITLE
fix: Apply small fixes

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -163,20 +163,17 @@ void sentry_remove_context(const char *key) {
 }
 
 void sentry_set_fingerprint(const char *fingerprint, ...) {
-    WITH_LOCKED_SCOPE;
+    Value fingerprint_value = Value::new_list();
+
     va_list va;
     va_start(va, fingerprint);
-
-    g_scope.fingerprint = Value::new_list();
-    if (fingerprint) {
-        g_scope.fingerprint.append(Value::new_string(fingerprint));
-        for (const char *arg; (arg = va_arg(va, const char *));) {
-            g_scope.fingerprint.append(Value::new_string(arg));
-        }
+    for (; fingerprint; fingerprint = va_arg(va, const char *)) {
+        fingerprint_value.append(Value::new_string(fingerprint));
     }
-
     va_end(va);
 
+    WITH_LOCKED_SCOPE;
+    g_scope.fingerprint = fingerprint_value;
     flush_scope();
 }
 

--- a/src/backends/crashpad_backend.cpp
+++ b/src/backends/crashpad_backend.cpp
@@ -111,7 +111,7 @@ void CrashpadBackend::start() {
 
 void CrashpadBackend::flush_scope_state(const sentry::Scope &scope) {
     mpack_writer_t writer;
-    mpack_writer_init_stdfile(&writer, m_impl->event_filename.open("w"), true);
+    mpack_writer_init_stdfile(&writer, m_impl->event_filename.open("wb"), true);
     Value event = Value::new_event();
     scope.apply_to_event(event, SENTRY_SCOPE_NONE);
     event.to_msgpack(&writer);
@@ -138,7 +138,7 @@ void CrashpadBackend::add_breadcrumb(sentry::Value breadcrumb) {
 
     std::string mpack = breadcrumb.to_msgpack();
     FILE *file = m_impl->breadcrumb_filename.open(
-        m_impl->breadcrumbs_in_segment == 0 ? "w" : "a");
+        m_impl->breadcrumbs_in_segment == 0 ? "wb" : "a");
     if (file) {
         fwrite(mpack.c_str(), 1, mpack.size(), file);
         fclose(file);

--- a/src/backends/crashpad_backend.cpp
+++ b/src/backends/crashpad_backend.cpp
@@ -113,7 +113,7 @@ void CrashpadBackend::flush_scope_state(const sentry::Scope &scope) {
     mpack_writer_t writer;
     mpack_writer_init_stdfile(&writer, m_impl->event_filename.open("w"), true);
     Value event = Value::new_event();
-    scope.apply_to_event(event, false);
+    scope.apply_to_event(event, SENTRY_SCOPE_NONE);
     event.to_msgpack(&writer);
     mpack_error_t err = mpack_writer_destroy(&writer);
     if (err != mpack_ok) {

--- a/src/scope.hpp
+++ b/src/scope.hpp
@@ -8,6 +8,14 @@
 #include "value.hpp"
 
 namespace sentry {
+enum ScopeMode {
+    SENTRY_SCOPE_NONE = 0x0,
+    SENTRY_SCOPE_BREADCRUMBS = 0x1,
+    SENTRY_SCOPE_MODULES = 0x2,
+    SENTRY_SCOPE_STACKTRACES = 0x4,
+    SENTRY_SCOPE_ALL = 0x7,
+};
+
 struct Scope {
     Scope()
         : level(SENTRY_LEVEL_ERROR),
@@ -18,9 +26,9 @@ struct Scope {
           fingerprint(Value::new_list()) {
     }
 
-    void apply_to_event(Value &event, bool with_breadcrumbs) const;
+    void apply_to_event(Value &event, ScopeMode mode) const;
     void apply_to_event(Value &event) const {
-        apply_to_event(event, true);
+        apply_to_event(event, SENTRY_SCOPE_ALL);
     }
 
     std::string transaction;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -134,7 +134,7 @@ void json_serialize_string(const char *ptr, Out &out) {
     for (; *ptr; ptr++) {
         switch (*ptr) {
             case '\\':
-                out << "\\";
+                out << "\\\\";
                 break;
             case '"':
                 out << "\\\"";

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -84,7 +84,7 @@ void Value::to_msgpack(mpack_writer_t *writer) const {
             mpack_write_bool(writer, this->as_bool());
             break;
         case SENTRY_VALUE_TYPE_INT32:
-            mpack_write_int(writer, (int64_t)this->as_int32());
+            mpack_write_i32(writer, this->as_int32());
             break;
         case SENTRY_VALUE_TYPE_DOUBLE:
             mpack_write_double(writer, this->as_double());
@@ -114,6 +114,10 @@ void Value::to_msgpack(mpack_writer_t *writer) const {
             mpack_finish_map(writer);
             break;
         }
+        default:
+            // Be defensive to avoid invalid msgpack.
+            mpack_write_nil(writer);
+            break;
     }
 }
 


### PR DESCRIPTION
Contains various smaller fixes for issues mostly occurring on Windows:

 - Fix in the JSON serializer to properly escape backslashes in strings
 - Open files msgpack files in binary mode to avoid escaping of newlines
 - Reduce lock time for `set_fingerprint`
 - Do not serialize modules or stack frames for minidump event supplements
 - Simplify msgpack write logic slightly