### PR TITLE
build(win32): Fix SafeSEH build on Win32

### DIFF
--- a/premake/premake5.crashpad.lua
+++ b/premake/premake5.crashpad.lua
@@ -469,6 +469,9 @@ project "crashpad_util"
       "winhttp.lib",
     }
 
+  filter {"files:**.asm", "platforms:Win32"}
+    exceptionhandling 'SEH'
+
   filter {}
 
   disable_for_android()


### PR DESCRIPTION
When building with enabled Safe SEH on Windows x86, linking failed with the following error:

```
error LNK2026: module unsafe for SAFESEH image
```

This is due to a missing compile flag to `cl` when building MASM modules for crashpad_util. Crashpad sets this by adding `/safeseh` to ASM options. In premake, this is possible by setting `exceptionhandling 'SEH'` on ASM files for the Win32 platform. It took me a little to find the correct filter, but now it generates this in the VS project XML (which builds fine):

```
<Masm Include="..\crashpad\build\crashpad\util\misc\capture_context_win.asm">
  <UseSafeExceptionHandlers Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</UseSafeExceptionHandlers>
  <UseSafeExceptionHandlers Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</UseSafeExceptionHandlers>
</Masm>
```

Fixes https://github.com/getsentry/sentry-native/issues/56