### PR TITLE
feat: Expose envelopes to C and change refcounting semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ test: configure
 	$(PREMAKE_DIR)/bin/Release/test_sentry
 .PHONY: test
 
+lldb-test: configure
+	$(MAKE) -C $(PREMAKE_DIR) -j$(CPUS) config=debug test_sentry
+	lldb $(PREMAKE_DIR)/bin/Debug/test_sentry
+.PHONY: lldb-test
+
 $(PREMAKE_DIR)/Makefile: $(PREMAKE_DIR)/$(PREMAKE) $(wildcard $(PREMAKE_DIR)/*.lua)
 	@cd $(PREMAKE_DIR) && ./$(PREMAKE) gmake2
 	@touch $@

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -90,6 +90,12 @@ typedef union sentry_value_u sentry_value_t;
 /* frees an allocated value */
 SENTRY_API void sentry_value_free(sentry_value_t value);
 
+/* increments the reference count on the value */
+SENTRY_API void sentry_value_incref(sentry_value_t value);
+
+/* decrements the reference count on the value */
+SENTRY_API void sentry_value_decref(sentry_value_t value);
+
 /* creates a null value */
 SENTRY_API sentry_value_t sentry_value_new_null(void);
 
@@ -157,6 +163,10 @@ SENTRY_API int sentry_value_remove_by_index(sentry_value_t value, size_t index);
    `sentry_value_free`. */
 SENTRY_API sentry_value_t sentry_value_get_by_key(sentry_value_t value,
                                                   const char *k);
+
+/* like `sentry_value_get_by_key` but borrows the value instead */
+SENTRY_API sentry_value_t sentry_value_get_by_key_b(sentry_value_t value,
+                                                    const char *k);
 
 /* looks up a value in a list by index.  If missing a null value is returned.
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -308,8 +308,32 @@ SENTRY_API void sentry_uuid_as_string(const sentry_uuid_t *uuid, char str[37]);
 struct sentry_options_s;
 typedef struct sentry_options_s sentry_options_t;
 
+struct sentry_envelope_s;
+typedef struct sentry_envelope_s sentry_envelope_t;
+
+/* given an envelope returns the embedded event if there is one */
+SENTRY_API sentry_value_t
+sentry_envelope_get_event(const sentry_envelope_t *envelope);
+
+/*
+ * serializes the envelope
+ *
+ * The return value needs to be freed with sentry_string_free().
+ */
+SENTRY_API char *sentry_envelope_serialize(const sentry_envelope_t *envelope,
+                                           size_t *size_out);
+
+/*
+ * serializes the envelope into a file
+ *
+ * returns 0 on success.
+ */
+SENTRY_API int sentry_envelope_write_to_file(const sentry_envelope_t *envelope,
+                                             const char *path);
+
 /* type of the callback for transports */
-typedef void (*sentry_transport_function_t)(sentry_value_t event, void *data);
+typedef void (*sentry_transport_function_t)(const sentry_envelope_t *envelope,
+                                            void *data);
 
 /* type of the callback for modifying events */
 typedef sentry_value_t (*sentry_event_function_t)(sentry_value_t event,

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -327,7 +327,9 @@ typedef struct sentry_options_s sentry_options_t;
 struct sentry_envelope_s;
 typedef struct sentry_envelope_s sentry_envelope_t;
 
-/* given an envelope returns the embedded event if there is one */
+/* given an envelope returns the embedded event if there is one.
+
+   This returns a borrowed value to the event in the envelope. */
 SENTRY_API sentry_value_t
 sentry_envelope_get_event(const sentry_envelope_t *envelope);
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdarg.h>
+#include <fstream>
 #include <mutex>
 #include "attachment.hpp"
 #include "cleanup.hpp"
@@ -7,6 +8,7 @@
 #include "modulefinder.hpp"
 #include "options.hpp"
 #include "scope.hpp"
+#include "transports/base_transport.hpp"
 #include "unwind.hpp"
 #include "uuid.hpp"
 #include "value.hpp"
@@ -203,4 +205,33 @@ void sentry_string_free(char *str) {
 
 size_t sentry_unwind_stack(void *addr, void **stacktrace_out, size_t max_len) {
     return unwind_stack(addr, stacktrace_out, max_len);
+}
+
+sentry_value_t sentry_envelope_get_event(const sentry_envelope_t *envelope) {
+    const transports::Envelope *e = (const transports::Envelope *)envelope;
+    return e->get_event().lower();
+}
+
+char *sentry_envelope_serialize(const sentry_envelope_t *envelope,
+                                size_t *size_out) {
+    std::stringstream ss;
+    const transports::Envelope *e = (const transports::Envelope *)envelope;
+    e->serialize_into(ss);
+    std::string s = ss.str();
+    char *rv = (char *)malloc(s.size() + 1);
+    memcpy(rv, s.c_str(), s.size() + 1);
+    return rv;
+}
+
+int sentry_envelope_write_to_file(const sentry_envelope_t *envelope,
+                                  const char *path) {
+    const transports::Envelope *e = (const transports::Envelope *)envelope;
+    std::ofstream f;
+    f.open(path,
+           std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
+    if (f.fail()) {
+        return 1;
+    }
+    e->serialize_into(f);
+    return 0;
 }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -209,7 +209,7 @@ size_t sentry_unwind_stack(void *addr, void **stacktrace_out, size_t max_len) {
 
 sentry_value_t sentry_envelope_get_event(const sentry_envelope_t *envelope) {
     const transports::Envelope *e = (const transports::Envelope *)envelope;
-    return e->get_event().lower();
+    return e->get_event().lower_decref();
 }
 
 char *sentry_envelope_serialize(const sentry_envelope_t *envelope,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -53,7 +53,9 @@ void sentry_options_set_transport(sentry_options_t *opts,
                                   void *data) {
     delete opts->transport;
     opts->transport = new sentry::transports::FunctionTransport(
-        [func, data](sentry::Value value) { func(value.lower(), data); });
+        [func, data](sentry::transports::Envelope envelope) {
+            func((const sentry_envelope_t *)&envelope, data);
+        });
 }
 
 void sentry_options_set_before_send(sentry_options_t *opts,

--- a/src/transports/function_transport.cpp
+++ b/src/transports/function_transport.cpp
@@ -3,15 +3,6 @@
 using namespace sentry;
 using namespace transports;
 
-void FunctionTransport::send_event(Value event) {
-    m_func(event);
-}
-
 void FunctionTransport::send_envelope(Envelope envelope) {
-    sentry::Value event = envelope.get_event();
-    if (!event.is_null()) {
-        send_event(event);
-    } else {
-        SENTRY_LOG("This transport cannot send these payloads. Dropped");
-    }
+    m_func(envelope);
 }

--- a/src/transports/function_transport.hpp
+++ b/src/transports/function_transport.hpp
@@ -8,13 +8,12 @@ namespace sentry {
 namespace transports {
 class FunctionTransport : public Transport {
    public:
-    FunctionTransport(std::function<void(sentry::Value)> func) : m_func(func) {
+    FunctionTransport(std::function<void(Envelope)> func) : m_func(func) {
     }
-    void send_event(sentry::Value value);
     void send_envelope(Envelope envelope);
 
    private:
-    std::function<void(sentry::Value)> m_func;
+    std::function<void(Envelope)> m_func;
 };
 }  // namespace transports
 }  // namespace sentry

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -416,10 +416,6 @@ sentry_value_t sentry_value_new_object() {
     return Value::new_object().lower();
 }
 
-void sentry_value_free(sentry_value_t value) {
-    Value::consume(value);
-}
-
 void sentry_value_incref(sentry_value_t value) {
     Value(value).incref();
 }
@@ -457,14 +453,20 @@ int sentry_value_remove_by_index(sentry_value_t value, size_t index) {
 }
 
 sentry_value_t sentry_value_get_by_key(sentry_value_t value, const char *k) {
-    return Value(value).get_by_key(k).lower();
-}
-
-sentry_value_t sentry_value_get_by_key_b(sentry_value_t value, const char *k) {
     return Value(value).get_by_key(k).lower_decref();
 }
 
+sentry_value_t sentry_value_get_by_key_owned(sentry_value_t value,
+                                             const char *k) {
+    return Value(value).get_by_key(k).lower();
+}
+
 sentry_value_t sentry_value_get_by_index(sentry_value_t value, size_t index) {
+    return Value(value).get_by_index(index).lower_decref();
+}
+
+sentry_value_t sentry_value_get_by_index_owned(sentry_value_t value,
+                                               size_t index) {
     return Value(value).get_by_index(index).lower();
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -420,6 +420,14 @@ void sentry_value_free(sentry_value_t value) {
     Value::consume(value);
 }
 
+void sentry_value_incref(sentry_value_t value) {
+    Value(value).incref();
+}
+
+void sentry_value_decref(sentry_value_t value) {
+    Value::consume(value);
+}
+
 sentry_value_type_t sentry_value_get_type(sentry_value_t value) {
     return Value(value).type();
 }
@@ -450,6 +458,10 @@ int sentry_value_remove_by_index(sentry_value_t value, size_t index) {
 
 sentry_value_t sentry_value_get_by_key(sentry_value_t value, const char *k) {
     return Value(value).get_by_key(k).lower();
+}
+
+sentry_value_t sentry_value_get_by_key_b(sentry_value_t value, const char *k) {
+    return Value(value).get_by_key(k).lower_decref();
 }
 
 sentry_value_t sentry_value_get_by_index(sentry_value_t value, size_t index) {

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -55,6 +55,10 @@ class Thing {
         }
     }
 
+    size_t refcount() const {
+        return m_refcount;
+    }
+
     ThingType type() const {
         return m_type;
     }
@@ -177,6 +181,15 @@ class Value {
         Thing *thing = as_thing();
         if (thing) {
             thing->decref();
+        }
+    }
+
+    size_t refcount() const {
+        Thing *thing = as_thing();
+        if (thing) {
+            return thing->refcount();
+        } else {
+            return (size_t)-1;
         }
     }
 
@@ -470,6 +483,15 @@ class Value {
 
     sentry_value_t lower() {
         sentry_value_t rv;
+        rv._bits = m_repr._bits;
+        set_null_unsafe();
+        return rv;
+    }
+
+    sentry_value_t lower_decref() {
+        sentry_value_t rv;
+        // if we're a thing, decref
+        decref();
         rv._bits = m_repr._bits;
         set_null_unsafe();
         return rv;

--- a/tests/test_values.cpp
+++ b/tests/test_values.cpp
@@ -26,7 +26,7 @@ TEST_CASE("primitive null behavior", "[value]") {
     REQUIRE(sentry_value_is_true(val) == false);
     REQUIRE_VALUE_JSON(val, "null");
     REQUIRE_VALUE_MSGPACK(val, "\xc0");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }
 
 TEST_CASE("primitive bool behavior", "[value]") {
@@ -37,7 +37,7 @@ TEST_CASE("primitive bool behavior", "[value]") {
     REQUIRE(sentry_value_is_true(val) == true);
     REQUIRE_VALUE_JSON(val, "true");
     REQUIRE_VALUE_MSGPACK(val, "\xc3");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 
     val = sentry_value_new_bool(false);
     REQUIRE(sentry_value_get_type(val) == SENTRY_VALUE_TYPE_BOOL);
@@ -46,7 +46,7 @@ TEST_CASE("primitive bool behavior", "[value]") {
     REQUIRE(sentry_value_is_true(val) == false);
     REQUIRE_VALUE_JSON(val, "false");
     REQUIRE_VALUE_MSGPACK(val, "\xc2");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }
 
 TEST_CASE("primitive int32 behavior", "[value]") {
@@ -57,14 +57,14 @@ TEST_CASE("primitive int32 behavior", "[value]") {
     REQUIRE(sentry_value_is_true(val) == true);
     REQUIRE_VALUE_JSON(val, "42");
     REQUIRE_VALUE_MSGPACK(val, "*");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 
     val = sentry_value_new_int32(-1);
     REQUIRE(sentry_value_get_type(val) == SENTRY_VALUE_TYPE_INT32);
     REQUIRE(sentry_value_as_int32(val) == -1);
     REQUIRE(sentry_value_is_true(val) == true);
     REQUIRE_VALUE_MSGPACK(val, "\xff");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }
 
 TEST_CASE("primitive double behavior", "[value]") {
@@ -76,7 +76,7 @@ TEST_CASE("primitive double behavior", "[value]") {
     REQUIRE_VALUE_MSGPACK(val,
                           "\xcb@E\x06"
                           "fffff");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }
 
 TEST_CASE("primitive string behavior", "[value]") {
@@ -86,7 +86,7 @@ TEST_CASE("primitive string behavior", "[value]") {
     REQUIRE(sentry_value_as_string(val) == std::string("Hello World!\n\t\r\f"));
     REQUIRE_VALUE_JSON(val, "\"Hello World!\\n\\t\\r\\f\"");
     REQUIRE_VALUE_MSGPACK(val, "\xb0Hello World!\n\t\r\x0c");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }
 
 TEST_CASE("list value behavior", "[value]") {
@@ -107,13 +107,13 @@ TEST_CASE("list value behavior", "[value]") {
     REQUIRE(sentry_value_is_true(val) == true);
     REQUIRE_VALUE_JSON(val, "[0,1,2,3,4,5,6,7,8,9]");
     REQUIRE_VALUE_MSGPACK(val, "\x9a\x00\x01\x02\x03\x04\x05\x06\x07\x08\t");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 
     val = sentry_value_new_list();
     REQUIRE(sentry_value_is_true(val) == false);
     REQUIRE_VALUE_JSON(val, "[]");
     REQUIRE_VALUE_MSGPACK(val, "\x90");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 
     val = sentry_value_new_list();
     sentry_value_set_by_index(val, 5, sentry_value_new_int32(100));
@@ -121,7 +121,7 @@ TEST_CASE("list value behavior", "[value]") {
     REQUIRE_VALUE_JSON(val, "[null,null,10,null,null,100]");
     sentry_value_remove_by_index(val, 2);
     REQUIRE_VALUE_JSON(val, "[null,null,null,null,100]");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }
 
 TEST_CASE("object value behavior", "[value]") {
@@ -152,11 +152,11 @@ TEST_CASE("object value behavior", "[value]") {
         val,
         "\x8a\xa4key0\x00\xa4key1\x01\xa4key2\x02\xa4key3\x03\xa4key4\x04\xa4ke"
         "y5\x05\xa4key6\x06\xa4key7\x07\xa4key8\x08\xa4key9\t");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 
     val = sentry_value_new_object();
     REQUIRE(sentry_value_is_true(val) == false);
     REQUIRE_VALUE_JSON(val, "{}");
     REQUIRE_VALUE_MSGPACK(val, "\x80");
-    sentry_value_free(val);
+    sentry_value_decref(val);
 }

--- a/tests/testutils.hpp
+++ b/tests/testutils.hpp
@@ -13,7 +13,7 @@ extern MockTransportData mock_transport;
 
 static void send_envelope(const sentry_envelope_t *envelope, void *data) {
     mock_transport.events.push_back(
-        sentry::Value::consume(sentry_envelope_get_event(envelope)));
+        sentry::Value(sentry_envelope_get_event(envelope)));
 }
 
 struct SentryGuard {

--- a/tests/testutils.hpp
+++ b/tests/testutils.hpp
@@ -11,8 +11,9 @@ struct MockTransportData {
 
 extern MockTransportData mock_transport;
 
-static void send_event(sentry_value_t event, void *data) {
-    mock_transport.events.push_back(sentry::Value(event));
+static void send_envelope(const sentry_envelope_t *envelope, void *data) {
+    mock_transport.events.push_back(
+        sentry::Value::consume(sentry_envelope_get_event(envelope)));
 }
 
 struct SentryGuard {
@@ -22,7 +23,7 @@ struct SentryGuard {
             sentry_options_set_dsn(options, "https://publickey@127.0.0.1/1");
         }
         mock_transport = MockTransportData();
-        sentry_options_set_transport(options, send_event, nullptr);
+        sentry_options_set_transport(options, send_envelope, nullptr);
         sentry_init(options);
         m_done = false;
     }

--- a/tests/unittests/test_value.cpp
+++ b/tests/unittests/test_value.cpp
@@ -35,3 +35,35 @@ TEST_CASE("value from hexstring", "[value]") {
     sentry::Value val = sentry::Value::new_hexstring(bytes, 16);
     REQUIRE(val.as_cstr() == std::string("f391fdc0bb2743b18c0c183bc217d42b"));
 }
+
+TEST_CASE("value refcounting", "[value]") {
+    // we start out with a refcount of 1
+    sentry::Value val = sentry::Value::new_object();
+    REQUIRE(val.refcount() == 1);
+    val.set_by_key("key1", sentry::Value::new_string("value1"));
+
+    // if i make a second value the refcount increases
+    sentry::Value val2(val);
+    REQUIRE(val.refcount() == 2);
+    REQUIRE(val2.refcount() == 2);
+
+    // when i lower to the value_t type the refcount stays the same
+    // but the specific instance lowered nulls out.
+    sentry_value_t val_l = val2.lower();
+    REQUIRE(val.refcount() == 2);
+    REQUIRE(val2.is_null());
+
+    // using the CABI to access a value bumps the refcount:
+    sentry_value_t child_val_l = sentry_value_get_by_key(val_l, "key1");
+    REQUIRE(!sentry_value_is_null(child_val_l));
+
+    // refcount is 3: 1 for the value itself, 2 for the return value of
+    // get_by_key and one because we call sentry::Value on it to get the
+    // refcount which bumps it by one as well.
+    REQUIRE(sentry::Value(child_val_l).refcount() == 3);
+
+    // when I consume a value it inherits the refcount.
+    val2 = sentry::Value::consume(val_l);
+    REQUIRE(val.refcount() == 2);
+    REQUIRE(val2.refcount() == 2);
+}

--- a/tests/unittests/test_value.cpp
+++ b/tests/unittests/test_value.cpp
@@ -41,6 +41,11 @@ TEST_CASE("value refcounting", "[value]") {
     sentry::Value val = sentry::Value::new_object();
     REQUIRE(val.refcount() == 1);
     val.set_by_key("key1", sentry::Value::new_string("value1"));
+    sentry::Value list = sentry::Value::new_list();
+    list.append(sentry::Value::new_string("1"));
+    list.append(sentry::Value::new_string("2"));
+    list.append(sentry::Value::new_string("3"));
+    val.set_by_key("key2", list);
 
     // if i make a second value the refcount increases
     sentry::Value val2(val);
@@ -67,6 +72,16 @@ TEST_CASE("value refcounting", "[value]") {
     REQUIRE(sentry::Value(child_val_l).refcount() == 3);
     sentry_value_decref(child_val_l);
     REQUIRE(sentry::Value(child_val_l).refcount() == 2);
+
+    // same with lists.
+    child_val_l = sentry_value_get_by_key(val_l, "key2");
+    child_val2_l = sentry_value_get_by_index(child_val_l, 0);
+    REQUIRE(sentry::Value(child_val2_l).refcount() == 2);
+    REQUIRE(sentry::Value(child_val2_l).refcount() == 2);
+
+    child_val2_l = sentry_value_get_by_index_owned(child_val_l, 0);
+    REQUIRE(sentry::Value(child_val2_l).refcount() == 3);
+    sentry_value_decref(child_val2_l);
 
     // when I consume a value it inherits the refcount.
     val2 = sentry::Value::consume(val_l);


### PR DESCRIPTION
This exposes the envelopes to the C layer and changes the way we handle memory on the C layer.

The tests showed we used memory management already incorrectly around our own API and from the user's perspective it's nicer for lookups in structures to return borrowed values instead of owned ones. This now removes `sentry_value_free` and instead adds `sentry_value_incref` and `senty_value_decref`.

I removed `free` so that people upgrading are more likely to run into memory management issues. They were already required to call free so all they need to do now is to remove that call most likely and potentially call incref if they keep the value around.