### PR TITLE
include release with crashpad minidump upload via crashpad_handler

### DIFF
--- a/src/backends/crashpad_backend.cpp
+++ b/src/backends/crashpad_backend.cpp
@@ -59,6 +59,10 @@ void CrashpadBackend::start() {
     std::map<std::string, std::string> annotations;
     std::map<std::string, base::FilePath> file_attachments;
 
+    if (sentry_options_get_release(options)) {
+        annotations["sentry[release]"] = sentry_options_get_release(options);
+    }
+
     for (const sentry::Attachment &attachment : options->attachments) {
         file_attachments.emplace(attachment.name(),
                                  base::FilePath(attachment.path().as_osstr()));


### PR DESCRIPTION
This includes the release set via sentry_options_set_release in the minidump uploaded via crashpad_handler to tie in the crash report to the correct release.