### PR TITLE
fix: Use CURLOPT_CAINFO to specify path to CA bundle

### DIFF
--- a/src/transports/libcurl_transport.cpp
+++ b/src/transports/libcurl_transport.cpp
@@ -99,7 +99,7 @@ void LibcurlTransport::send_envelope(Envelope envelope) {
                                  opts->http_proxy.c_str());
             }
             if (!opts->ca_certs.empty()) {
-                curl_easy_setopt(this->m_curl, CURLOPT_CAPATH,
+                curl_easy_setopt(this->m_curl, CURLOPT_CAINFO,
                                  opts->ca_certs.c_str());
             }
 


### PR DESCRIPTION
Closes #99 