### PR TITLE
ref(crashpad): Disable the system crash handler

### DIFF
--- a/src/backends/crashpad_backend.cpp
+++ b/src/backends/crashpad_backend.cpp
@@ -77,6 +77,13 @@ void CrashpadBackend::start() {
         return;
     }
 
+    // Disable the system crash reporter. Especially on macOS, it takes
+    // substantial time *after* crashpad has done its job.
+    crashpad::CrashpadInfo *crashpad_info =
+        crashpad::CrashpadInfo::GetCrashpadInfo();
+    crashpad_info->set_system_crash_reporter_forwarding(
+        crashpad::TriState::kDisabled);
+
     std::unique_ptr<crashpad::CrashReportDatabase> db =
         crashpad::CrashReportDatabase::Initialize(database);
 


### PR DESCRIPTION
Disables the system crash reporter. This is only relevant on macOS, where the system handler takes substantial time after crashpad has finished writing a minidump. It leads to delays, which are generally unwanted.