### PR TITLE
feat: Add user consent tracking

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -595,6 +595,11 @@ SENTRY_API void sentry_user_consent_give(void);
 SENTRY_API void sentry_user_consent_revoke(void);
 
 /*
+ * Resets the user consent (back to unknown)
+ */
+SENTRY_API void sentry_user_consent_reset(void);
+
+/*
  * Checks the current state of user consent.
  */
 SENTRY_API sentry_user_consent_t sentry_user_consent_get(void);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -239,6 +239,15 @@ typedef enum sentry_level_e {
 } sentry_level_t;
 
 /*
+ * The state of user consent.
+ */
+typedef enum {
+    SENTRY_USER_CONSENT_UNKNOWN = -1,
+    SENTRY_USER_CONSENT_GIVEN = 1,
+    SENTRY_USER_CONSENT_REVOKED = 0,
+} sentry_user_consent_t;
+
+/*
  * creates a new empty event value.
  */
 SENTRY_API sentry_value_t sentry_value_new_event(void);
@@ -498,6 +507,21 @@ SENTRY_API void sentry_options_set_debug(sentry_options_t *opts, int debug);
 SENTRY_API int sentry_options_get_debug(const sentry_options_t *opts);
 
 /*
+ * Enables or disabled user consent requirements for uploads.
+ *
+ * This disables uploads until the user has given the consent to the SDK.
+ * Consent itself is given with `sentry_user_consent_give` and
+ * `sentry_user_consent_revoke`.
+ */
+SENTRY_API void sentry_options_set_require_user_consent(sentry_options_t *opts,
+                                                        int val);
+/*
+ * returns true if user consent is required.
+ */
+SENTRY_API int sentry_options_get_require_user_consent(
+    const sentry_options_t *opts);
+
+/*
  * adds a new attachment to be sent along
  */
 SENTRY_API void sentry_options_add_attachment(sentry_options_t *opts,
@@ -559,6 +583,21 @@ SENTRY_API void sentry_shutdown(void);
  * Returns the client options.
  */
 SENTRY_API const sentry_options_t *sentry_get_options(void);
+
+/*
+ * Gives user consent
+ */
+SENTRY_API void sentry_user_consent_give(void);
+
+/*
+ * Revokes user consent
+ */
+SENTRY_API void sentry_user_consent_revoke(void);
+
+/*
+ * Checks the current state of user consent.
+ */
+SENTRY_API sentry_user_consent_t sentry_user_consent_get(void);
 
 /*
  * Sends a sentry event.

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -78,7 +78,11 @@ void sentry_user_consent_give(void) {
     sentry::FileIoWriter w;
     if (w.open(consent_path)) {
         w.write_char('1');
+        w.write_char('\n');
         g_options->user_consent = SENTRY_USER_CONSENT_GIVEN;
+        if (g_options->backend) {
+            g_options->backend->user_consent_changed();
+        }
     }
 }
 
@@ -88,7 +92,11 @@ void sentry_user_consent_revoke(void) {
     sentry::FileIoWriter w;
     if (w.open(consent_path)) {
         w.write_char('0');
+        w.write_char('\n');
         g_options->user_consent = SENTRY_USER_CONSENT_REVOKED;
+        if (g_options->backend) {
+            g_options->backend->user_consent_changed();
+        }
     }
 }
 
@@ -96,6 +104,9 @@ void sentry_user_consent_reset(void) {
     sentry::Path consent_path = g_options->database_path.join("user-consent");
     consent_path.remove();
     g_options->user_consent = SENTRY_USER_CONSENT_UNKNOWN;
+    if (g_options->backend) {
+        g_options->backend->user_consent_changed();
+    }
 }
 
 sentry_user_consent_t sentry_user_consent_get(void) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -73,6 +73,7 @@ void sentry_shutdown(void) {
 }
 
 void sentry_user_consent_give(void) {
+    g_options->database_path.create_directories();
     sentry::Path consent_path = g_options->database_path.join("user-consent");
     sentry::FileIoWriter w;
     if (w.open(consent_path)) {
@@ -82,6 +83,7 @@ void sentry_user_consent_give(void) {
 }
 
 void sentry_user_consent_revoke(void) {
+    g_options->database_path.create_directories();
     sentry::Path consent_path = g_options->database_path.join("user-consent");
     sentry::FileIoWriter w;
     if (w.open(consent_path)) {
@@ -93,6 +95,7 @@ void sentry_user_consent_revoke(void) {
 void sentry_user_consent_reset(void) {
     sentry::Path consent_path = g_options->database_path.join("user-consent");
     consent_path.remove();
+    g_options->user_consent = SENTRY_USER_CONSENT_UNKNOWN;
 }
 
 sentry_user_consent_t sentry_user_consent_get(void) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -6,6 +6,7 @@
 #include "attachment.hpp"
 #include "cleanup.hpp"
 #include "internal.hpp"
+#include "io.hpp"
 #include "modulefinder.hpp"
 #include "options.hpp"
 #include "scope.hpp"
@@ -38,10 +39,16 @@ int sentry_init(sentry_options_t *options) {
     }
     cleanup_old_runs();
 
-    // Check for user consent
-    sentry::Path consent_path = database_path.join("user-consent-given");
-    if (consent_path.is_file()) {
-        // read file
+    // Check for stored user consent
+    sentry::Path consent_path = options->database_path.join("user-consent");
+    sentry::FileIoReader r;
+    if (r.open(consent_path)) {
+        char c = r.read_char();
+        if (c == '1') {
+            options->user_consent = SENTRY_USER_CONSENT_GIVEN;
+        } else if (c == '0') {
+            options->user_consent = SENTRY_USER_CONSENT_REVOKED;
+        }
     }
 
     // make sure that the scopes are at least flushed once after the backend
@@ -63,6 +70,33 @@ void sentry_shutdown(void) {
         sentry_options_free(g_options);
     }
     g_options = nullptr;
+}
+
+void sentry_user_consent_give(void) {
+    sentry::Path consent_path = g_options->database_path.join("user-consent");
+    sentry::FileIoWriter w;
+    if (w.open(consent_path)) {
+        w.write_char('1');
+        g_options->user_consent = SENTRY_USER_CONSENT_GIVEN;
+    }
+}
+
+void sentry_user_consent_revoke(void) {
+    sentry::Path consent_path = g_options->database_path.join("user-consent");
+    sentry::FileIoWriter w;
+    if (w.open(consent_path)) {
+        w.write_char('0');
+        g_options->user_consent = SENTRY_USER_CONSENT_REVOKED;
+    }
+}
+
+void sentry_user_consent_reset(void) {
+    sentry::Path consent_path = g_options->database_path.join("user-consent");
+    consent_path.remove();
+}
+
+sentry_user_consent_t sentry_user_consent_get(void) {
+    return g_options->user_consent;
 }
 
 const sentry_options_t *sentry_get_options(void) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -38,6 +38,12 @@ int sentry_init(sentry_options_t *options) {
     }
     cleanup_old_runs();
 
+    // Check for user consent
+    sentry::Path consent_path = database_path.join("user-consent-given");
+    if (consent_path.is_file()) {
+        // read file
+    }
+
     // make sure that the scopes are at least flushed once after the backend
     // is started for the initial data to be written.
     Scope::with_scope_mut([](Scope &) { /* run for side effect */ });

--- a/src/backends/base_backend.hpp
+++ b/src/backends/base_backend.hpp
@@ -21,6 +21,8 @@ class Backend {
     }
     virtual void add_breadcrumb(sentry::Value) {
     }
+    virtual void user_consent_changed() {
+    }
 
    private:
     Backend(const Backend &) = delete;

--- a/src/backends/crashpad_backend.hpp
+++ b/src/backends/crashpad_backend.hpp
@@ -20,6 +20,7 @@ class CrashpadBackend : public Backend {
     void start();
     void flush_scope(const sentry::Scope &scope);
     void add_breadcrumb(sentry::Value breadcrumb);
+    void user_consent_changed();
 
    private:
     Path event_filename;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -32,6 +32,7 @@ FileIoWriter::~FileIoWriter() {
     close();
 }
 
+#ifndef _WIN32
 int mode_to_flags(const char *mode) {
     int flags = 0;
     for (; *mode; mode++) {
@@ -55,6 +56,7 @@ int mode_to_flags(const char *mode) {
     }
     return flags;
 }
+#endif
 
 bool FileIoWriter::open(const Path &path, const char *mode) {
 #ifdef _WIN32

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -103,6 +103,14 @@ void FileIoWriter::close() {
     m_buflen = 0;
 }
 
+bool FileIoWriter::is_closed() const {
+#ifdef _WIN32
+    return m_file == nullptr;
+#else
+    return m_fd == 0;
+#endif
+}
+
 MemoryIoWriter::MemoryIoWriter(size_t bufsize)
     : m_terminated(false),
       m_buf((char *)malloc(bufsize)),
@@ -163,6 +171,7 @@ FileIoReader::FileIoReader() : m_bufoff(0), m_buflen(0) {
 }
 
 FileIoReader::~FileIoReader() {
+    close();
 }
 
 bool FileIoReader::open(const Path &path, const char *mode) {
@@ -176,11 +185,24 @@ bool FileIoReader::open(const Path &path, const char *mode) {
 #endif
 }
 
+bool FileIoReader::is_closed() const {
+#ifdef _WIN32
+    return m_file == nullptr;
+#else
+    return m_fd == 0;
+#endif
+}
+
 void FileIoReader::close() {
+    if (is_closed()) {
+        return;
+    }
 #ifdef _WIN32
     fclose(m_file);
+    m_file = nullptr;
 #else
     ::close(m_fd);
+    m_fd = 0;
 #endif
 }
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -43,6 +43,7 @@ class FileIoWriter : public IoWriter {
     void write(const char *buf, size_t len);
     void flush();
     void close();
+    bool is_closed() const;
 
    private:
     static const size_t BUF_SIZE = 1024;
@@ -94,6 +95,7 @@ class FileIoReader : public IoReader {
 
     bool open(const Path &path, const char *mode = "rb");
     void close();
+    bool is_closed() const;
     size_t read_into(char *buf, size_t len);
 
    private:

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -40,7 +40,6 @@ class FileIoWriter : public IoWriter {
     FileIoWriter();
     ~FileIoWriter();
     bool open(const Path &path, const char *mode = "wb");
-    bool is_closed() const;
     void write(const char *buf, size_t len);
     void flush();
     void close();
@@ -71,6 +70,41 @@ class MemoryIoWriter : public IoWriter {
     bool m_terminated;
     char *m_buf;
     size_t m_bufcap;
+    size_t m_buflen;
+};
+
+class IoReader {
+   public:
+    IoReader();
+    virtual ~IoReader();
+
+    virtual size_t read_into(char *buf, size_t len) = 0;
+    virtual char read_char() {
+        char buf[1] = {0};
+        read_into(buf, 1);
+        return buf[0];
+    }
+    virtual void close(){};
+};
+
+class FileIoReader : public IoReader {
+   public:
+    FileIoReader();
+    ~FileIoReader();
+
+    bool open(const Path &path, const char *mode = "rb");
+    void close();
+    size_t read_into(char *buf, size_t len);
+
+   private:
+    static const size_t BUF_SIZE = 1024;
+#ifdef _WIN32
+    FILE *m_file;
+#else
+    int m_fd;
+#endif
+    char m_buf[BUF_SIZE];
+    size_t m_bufoff;
     size_t m_buflen;
 };
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -26,6 +26,7 @@ struct sentry_options_s {
     sentry::Path handler_path;
     sentry::Path database_path;
     bool system_crash_reporter_enabled;
+    bool require_user_consent;
 
     std::function<sentry::Value(sentry::Value, void *hint)> before_send;
     sentry::transports::Transport *transport;
@@ -34,6 +35,7 @@ struct sentry_options_s {
     // internal options
     std::string run_id;
     sentry::Path runs_folder;
+    sentry_user_consent_t user_consent;
 };
 
 #endif

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -36,6 +36,11 @@ struct sentry_options_s {
     std::string run_id;
     sentry::Path runs_folder;
     sentry_user_consent_t user_consent;
+
+    bool should_upload() const {
+        return !require_user_consent ||
+               user_consent == SENTRY_USER_CONSENT_GIVEN;
+    }
 };
 
 #endif

--- a/src/transports/libcurl_transport.cpp
+++ b/src/transports/libcurl_transport.cpp
@@ -65,7 +65,7 @@ void LibcurlTransport::send_envelope(Envelope envelope) {
     this->m_worker.submit_task([this, envelope]() {
         envelope.for_each_request([this](PreparedHttpRequest prepared_request) {
             const sentry_options_t *opts = sentry_get_options();
-            if (opts->dsn.disabled()) {
+            if (opts->dsn.disabled() || opts->should_upload()) {
                 return false;
             }
 

--- a/src/transports/winhttp_transport.cpp
+++ b/src/transports/winhttp_transport.cpp
@@ -53,7 +53,7 @@ void WinHttpTransport::send_envelope(Envelope envelope) {
     this->m_worker.submit_task([this, envelope]() {
         envelope.for_each_request([this](PreparedHttpRequest prepared_request) {
             const sentry_options_t *opts = sentry_get_options();
-            if (opts->dsn.disabled()) {
+            if (opts->dsn.disabled() || !opts->should_upload()) {
                 return false;
             }
 
@@ -81,8 +81,9 @@ void WinHttpTransport::send_envelope(Envelope envelope) {
                     m_session = WinHttpOpen(
                         user_agent.c_str(), WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
                         WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
-                    // On windows 7, WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY does not work
-                    // on error we fallback to WINHTTP_ACCESS_TYPE_NO_PROXY
+                    // On windows 7, WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY does
+                    // not work on error we fallback to
+                    // WINHTTP_ACCESS_TYPE_NO_PROXY
                     if (!m_session) {
                         m_session = WinHttpOpen(
                             user_agent.c_str(), WINHTTP_ACCESS_TYPE_NO_PROXY,

--- a/tests/test_consent.cpp
+++ b/tests/test_consent.cpp
@@ -11,6 +11,8 @@ static void init_consenting_sentry() {
 }
 
 TEST_CASE("basic consent tracking", "[api]") {
+    sentry::Path(".test-db").remove_all();
+
     init_consenting_sentry();
     REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_UNKNOWN);
     sentry_shutdown();

--- a/tests/test_consent.cpp
+++ b/tests/test_consent.cpp
@@ -3,8 +3,13 @@
 #include <vendor/catch.hpp>
 
 static void init_consenting_sentry() {
+#ifdef __ANDROID__
+#define PREFIX "/data/local/tmp"
+#else
+#define PREFIX "."
+#endif
     sentry_options_t *opts = sentry_options_new();
-    sentry_options_set_database_path(opts, ".test-db");
+    sentry_options_set_database_path(opts, PREFIX "/.test-db");
     sentry_options_set_dsn(opts, "http://foo@127.0.0.1/42");
     sentry_options_set_require_user_consent(opts, true);
     sentry_init(opts);

--- a/tests/test_consent.cpp
+++ b/tests/test_consent.cpp
@@ -1,0 +1,39 @@
+#include <sentry.h>
+#include <path.hpp>
+#include <vendor/catch.hpp>
+
+static void init_consenting_sentry() {
+    sentry_options_t *opts = sentry_options_new();
+    sentry_options_set_database_path(opts, ".test-db");
+    sentry_options_set_dsn(opts, "http://foo@127.0.0.1/42");
+    sentry_options_set_require_user_consent(opts, true);
+    sentry_init(opts);
+}
+
+TEST_CASE("basic consent tracking", "[api]") {
+    init_consenting_sentry();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_UNKNOWN);
+    sentry_shutdown();
+
+    init_consenting_sentry();
+    sentry_user_consent_give();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_GIVEN);
+    sentry_shutdown();
+    init_consenting_sentry();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_GIVEN);
+
+    sentry_user_consent_revoke();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_REVOKED);
+    sentry_shutdown();
+    init_consenting_sentry();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_REVOKED);
+
+    sentry_user_consent_reset();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_UNKNOWN);
+    sentry_shutdown();
+    init_consenting_sentry();
+    REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_UNKNOWN);
+    sentry_shutdown();
+
+    sentry::Path(".test-db").remove_all();
+}

--- a/tests/test_consent.cpp
+++ b/tests/test_consent.cpp
@@ -4,19 +4,19 @@
 
 static void init_consenting_sentry() {
 #ifdef __ANDROID__
-#define PREFIX "/data/local/tmp"
+#define PREFIX "/data/local/tmp/"
 #else
-#define PREFIX "."
+#define PREFIX ""
 #endif
     sentry_options_t *opts = sentry_options_new();
-    sentry_options_set_database_path(opts, PREFIX "/.test-db");
+    sentry_options_set_database_path(opts, PREFIX ".test-db");
     sentry_options_set_dsn(opts, "http://foo@127.0.0.1/42");
     sentry_options_set_require_user_consent(opts, true);
     sentry_init(opts);
 }
 
 TEST_CASE("basic consent tracking", "[api]") {
-    sentry::Path(".test-db").remove_all();
+    sentry::Path(PREFIX ".test-db").remove_all();
 
     init_consenting_sentry();
     REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_UNKNOWN);
@@ -42,5 +42,5 @@ TEST_CASE("basic consent tracking", "[api]") {
     REQUIRE(sentry_user_consent_get() == SENTRY_USER_CONSENT_UNKNOWN);
     sentry_shutdown();
 
-    sentry::Path(".test-db").remove_all();
+    sentry::Path(PREFIX ".test-db").remove_all();
 }

--- a/tests/unittests/test_io.cpp
+++ b/tests/unittests/test_io.cpp
@@ -3,8 +3,14 @@
 #include <path.hpp>
 #include <vendor/catch.hpp>
 
+#ifdef __ANDROID__
+#define PREFIX "/data/local/tmp/"
+#else
+#define PREFIX ""
+#endif
+
 TEST_CASE("basic file reading and writing", "[io]") {
-    sentry::Path path("testfile.txt");
+    sentry::Path path(PREFIX "testfile.txt");
     sentry::FileIoWriter w;
     REQUIRE(w.open(path) == true);
     for (int i = 0; i < 2048; i++) {

--- a/tests/unittests/test_io.cpp
+++ b/tests/unittests/test_io.cpp
@@ -1,0 +1,22 @@
+#include <internal.hpp>
+#include <io.hpp>
+#include <path.hpp>
+#include <vendor/catch.hpp>
+
+TEST_CASE("basic file reading and writing", "[io]") {
+    sentry::Path path("testfile.txt");
+    sentry::FileIoWriter w;
+    REQUIRE(w.open(path) == true);
+    for (int i = 0; i < 2048; i++) {
+        w.write_int32(i % 10);
+    }
+
+    sentry::FileIoReader r;
+    REQUIRE(r.open(path) == true);
+
+    for (int i = 0; i < 2048; i++) {
+        REQUIRE(r.read_char() - '0' == i % 10);
+    }
+
+    path.remove();
+}


### PR DESCRIPTION
This adds user consent tracking for uploads.  Currently this is only
reflected in the crashpad backend.