### PR TITLE
Support multiple running crashpad_handlers

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -522,6 +522,16 @@ SENTRY_API int sentry_options_get_require_user_consent(
     const sentry_options_t *opts);
 
 /*
+ * Sets that this is the primary sentry instance
+ */
+SENTRY_API void sentry_options_set_primary(sentry_options_t *opts, int primary);
+
+/*
+ * returns whether this is the primary sentry instance
+ */
+SENTRY_API int sentry_options_get_primary(const sentry_options_t *opts);
+
+/*
  * adds a new attachment to be sent along
  */
 SENTRY_API void sentry_options_add_attachment(sentry_options_t *opts,

--- a/src/backends/crashpad_backend.cpp
+++ b/src/backends/crashpad_backend.cpp
@@ -68,6 +68,10 @@ void CrashpadBackend::start() {
     std::vector<std::string> arguments;
     arguments.push_back("--no-rate-limit");
 
+    if (!options->primary) {
+        arguments.push_back("--no-periodic-tasks");
+    }
+
 #ifdef _WIN32
     // Temporary fix for Windows
     arguments.push_back("--no-upload-gzip");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -30,6 +30,7 @@ sentry_options_s::sentry_options_s()
       release(getenv_or_empty("SENTRY_RELEASE")),
       environment(getenv_or_empty("SENTRY_ENVIRONMENT")),
       debug(false),
+      primary(true),
       database_path("./.sentry-native"),
       system_crash_reporter_enabled(false),
       require_user_consent(false),
@@ -145,6 +146,14 @@ void sentry_options_set_require_user_consent(sentry_options_t *opts, int val) {
 
 int sentry_options_get_require_user_consent(const sentry_options_t *opts) {
     return opts->require_user_consent;
+}
+
+void sentry_options_set_primary(sentry_options_t *opts, int val) {
+    opts->primary = !!val;
+}
+
+int sentry_options_get_primary(const sentry_options_t *opts) {
+    return opts->primary;
 }
 
 void sentry_options_add_attachment(sentry_options_t *opts,

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -22,6 +22,7 @@ struct sentry_options_s {
     std::string http_proxy;
     std::string ca_certs;
     bool debug;
+    bool primary;
     std::vector<sentry::Attachment> attachments;
     sentry::Path handler_path;
     sentry::Path database_path;


### PR DESCRIPTION
When running multiple instances of an application that uses SentryNative
, only one instance of the crashpad_handler should send old reports and
prune the database. If the application isn't the first instance, it can
set primary to false and the crashpad_handler will be launched with the
--no-periodic-tasks option.

This option is documented here:
https://github.com/getsentry/crashpad/blob/master/handler/crashpad_handler.md