### PR TITLE
build(example): add cmake target for example and add DSN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,3 +106,6 @@ add_executable("sentry_tests"
 )
 target_compile_definitions("sentry_tests" PUBLIC -DSENTRY_UNITTEST)
 target_link_libraries("sentry_tests" ${LINK_LIBRARIES})
+
+add_executable("example" "./examples/example.c")
+target_link_libraries("example" "sentry")

--- a/examples/example.c
+++ b/examples/example.c
@@ -3,9 +3,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-int main(void) {
+int
+main(void)
+{
     sentry_options_t *options = sentry_options_new();
 
+    sentry_options_set_dsn(
+        options, "http://a9c8c48ae72643a0affaeb4b15548768@localhost:8000/1");
     sentry_options_set_environment(options, "Production");
     sentry_options_set_release(options, "5fd7a6cd");
     sentry_options_set_debug(options, 1);
@@ -22,15 +26,15 @@ int main(void) {
 
     sentry_value_t user = sentry_value_new_object();
     sentry_value_set_by_key(user, "id", sentry_value_new_int32(42));
-    sentry_value_set_by_key(user, "username",
-                            sentry_value_new_string("some_name"));
+    sentry_value_set_by_key(
+        user, "username", sentry_value_new_string("some_name"));
     sentry_set_user(user);
 
     // memset((char *)0x0, 1, 100);
 
     sentry_value_t event = sentry_value_new_event();
-    sentry_value_set_by_key(event, "message",
-                            sentry_value_new_string("Hello World!"));
+    sentry_value_set_by_key(
+        event, "message", sentry_value_new_string("Hello World!"));
     sentry_capture_event(event);
 
     // make sure everything flushes


### PR DESCRIPTION
The DSN is hardcoded for now, as it is not yet fetched via ENV by default