### PR TITLE
feat(transport): hook up the curl transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,3 +106,6 @@ add_executable("sentry_tests"
 )
 target_compile_definitions("sentry_tests" PUBLIC -DSENTRY_UNITTEST)
 target_link_libraries("sentry_tests" ${LINK_LIBRARIES})
+
+add_executable("example" "./examples/example.c")
+target_link_libraries("example" "sentry")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_definitions(-DSENTRY_BUILD_SHARED)
 
 FIND_PACKAGE(CURL)
 if(CURL_FOUND)
+	add_definitions(-DSENTRY_WITH_LIBCURL_TRANSPORT)
 	include_directories(${CURL_INCLUDE_DIR})
 	set(LINK_LIBRARIES ${LINK_LIBRARIES} ${CURL_LIBRARIES})
 endif()

--- a/examples/example.c
+++ b/examples/example.c
@@ -3,9 +3,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-int main(void) {
+int
+main(void)
+{
     sentry_options_t *options = sentry_options_new();
 
+    sentry_options_set_dsn(
+        options, "http://a9c8c48ae72643a0affaeb4b15548768@localhost:8000/1");
     sentry_options_set_environment(options, "Production");
     sentry_options_set_release(options, "5fd7a6cd");
     sentry_options_set_debug(options, 1);
@@ -22,15 +26,15 @@ int main(void) {
 
     sentry_value_t user = sentry_value_new_object();
     sentry_value_set_by_key(user, "id", sentry_value_new_int32(42));
-    sentry_value_set_by_key(user, "username",
-                            sentry_value_new_string("some_name"));
+    sentry_value_set_by_key(
+        user, "username", sentry_value_new_string("some_name"));
     sentry_set_user(user);
 
     // memset((char *)0x0, 1, 100);
 
     sentry_value_t event = sentry_value_new_event();
-    sentry_value_set_by_key(event, "message",
-                            sentry_value_new_string("Hello World!"));
+    sentry_value_set_by_key(
+        event, "message", sentry_value_new_string("Hello World!"));
     sentry_capture_event(event);
 
     // make sure everything flushes

--- a/src/sentry_transport.c
+++ b/src/sentry_transport.c
@@ -1,0 +1,13 @@
+#include "sentry_boot.h"
+#ifdef SENTRY_WITH_LIBCURL_TRANSPORT
+#    include "transports/sentry_libcurl_transport.h"
+#endif
+
+sentry_transport_t *
+sentry__transport_new_default(void)
+{
+#ifdef SENTRY_WITH_LIBCURL_TRANSPORT
+    return sentry__new_libcurl_transport();
+#endif
+    return NULL;
+}

--- a/src/sentry_transport.h
+++ b/src/sentry_transport.h
@@ -1,0 +1,8 @@
+#ifndef SENTRY_TRANSPORT_H_INCLUDED
+#define SENTRY_TRANSPORT_H_INCLUDED
+
+#include "sentry_boot.h"
+
+sentry_transport_t *sentry__transport_new_default(void);
+
+#endif

--- a/src/transports/sentry_libcurl_transport.c
+++ b/src/transports/sentry_libcurl_transport.c
@@ -126,6 +126,9 @@ for_each_request_callback(sentry_prepared_http_request_t *req,
 
     CURL *curl = ts->transport_state->curl_handle;
     curl_easy_reset(curl);
+    if (opts->debug) {
+        curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
+    }
     curl_easy_setopt(curl, CURLOPT_URL, req->url);
     curl_easy_setopt(curl, CURLOPT_POST, (long)1);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);


### PR DESCRIPTION
Hook up the curl transport as a default, and fix a deadlock when sending events

With this changes, submitting an event is actually possible