### PR TITLE
ci: Test on android API 18

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,9 +69,9 @@ stages:
       - job: Android
         strategy:
           matrix:
-            #API18:
-            #  ANDROID_API: 18
-            #  ANDROID_NDK: 19.2.5345600
+            API18:
+             ANDROID_API: 18
+             ANDROID_NDK: 19.2.5345600
             API29:
               ANDROID_API: 29
               ANDROID_NDK: 21.0.6113669

--- a/scripts/start-android.sh
+++ b/scripts/start-android.sh
@@ -17,7 +17,7 @@ echo "Starting emulator..."
 
 # Start emulator in background
 nohup $ANDROID_HOME/emulator/emulator -avd $AVD_EMULATOR_NAME -no-snapshot > /dev/null 2>&1 &
-$ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+$ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
 $ANDROID_HOME/platform-tools/adb devices
 
 echo "Emulator started."


### PR DESCRIPTION
So far, 18 is the lowest we can go. We would need to find an alternative to `getauxval` to get to 16.