### PR TITLE
FIX memory leak

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -258,7 +258,13 @@ sentry_value_t sentry_envelope_get_event(const sentry_envelope_t *envelope) {
 char *sentry_envelope_serialize(const sentry_envelope_t *envelope,
                                 size_t *size_out) {
     const transports::Envelope *e = (const transports::Envelope *)envelope;
-    return e->serialize(size_out);
+
+    std::string data = e->serialize(size_out);
+    char* pdata = (char*)calloc(data.size() + 1, sizeof(char));
+    if(pdata) {
+        memcpy(pdata, data.c_str(), data.size());
+    }
+    return pdata;
 }
 
 int sentry_envelope_write_to_file(const sentry_envelope_t *envelope,

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -146,11 +146,9 @@ void MemoryIoWriter::write(const char *buf, size_t len) {
     m_terminated = false;
 }
 
-char *MemoryIoWriter::take() {
+std::string MemoryIoWriter::take() {
     flush();
-    char *rv = m_buf;
-    m_buf = nullptr;
-    return rv;
+    return std::string(m_buf, m_buflen);
 }
 
 const char *MemoryIoWriter::buf() const {

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -165,7 +165,7 @@ IoReader::IoReader() {
 IoReader::~IoReader() {
 }
 
-FileIoReader::FileIoReader() : m_bufoff(0), m_buflen(0) {
+FileIoReader::FileIoReader() : m_fd(-1), m_bufoff(0), m_buflen(0) {
 }
 
 FileIoReader::~FileIoReader() {
@@ -187,7 +187,7 @@ bool FileIoReader::is_closed() const {
 #ifdef _WIN32
     return m_file == nullptr;
 #else
-    return m_fd == 0;
+    return m_fd < 0;
 #endif
 }
 
@@ -200,7 +200,7 @@ void FileIoReader::close() {
     m_file = nullptr;
 #else
     ::close(m_fd);
-    m_fd = 0;
+    m_fd = -1;
 #endif
 }
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -63,7 +63,7 @@ class MemoryIoWriter : public IoWriter {
     void write(const char *buf, size_t len);
     void flush();
 
-    char *take();
+    std::string take();
     const char *buf() const;
     size_t len() const;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -78,6 +78,9 @@ void sentry_options_set_before_send(sentry_options_t *opts,
 
 void sentry_options_free(sentry_options_t *opts) {
     if (opts) {
+        if(opts->transport) {
+	    delete opts->transport;
+	}
         delete opts;
     }
 }

--- a/src/transports/envelopes.cpp
+++ b/src/transports/envelopes.cpp
@@ -245,7 +245,7 @@ void Envelope::for_each_request(
                              content_type.c_str(), payload));
 }
 
-char *Envelope::serialize(size_t *size_out) const {
+std::string Envelope::serialize(size_t *size_out) const {
     MemoryIoWriter writer;
     serialize_into(writer);
     *size_out = writer.len();

--- a/src/transports/envelopes.hpp
+++ b/src/transports/envelopes.hpp
@@ -79,7 +79,7 @@ class Envelope {
         std::function<bool(PreparedHttpRequest &&)> func) const;
 
     void serialize_into(IoWriter &writer) const;
-    char *serialize(size_t *size_out) const;
+    std::string serialize(size_t *size_out) const;
 
    protected:
     sentry::Value m_headers;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -211,7 +211,7 @@ void Value::to_json(JsonWriter &jw) const {
     }
 }
 
-char *Value::to_json() const {
+std::string Value::to_json() const {
     MemoryIoWriter writer;
     to_json(writer);
     return writer.take();
@@ -513,9 +513,9 @@ sentry_value_t sentry_value_new_breadcrumb(const char *type,
 
 char *sentry_value_to_json(sentry_value_t value) {
     std::string out = Value(value).to_json();
-    char *rv = (char *)malloc(out.length() + 1);
+    char *rv = (char *)calloc(out.length() + 1, sizeof(char));
     if (rv) {
-        memcpy(rv, out.c_str(), out.length() + 1);
+        memcpy(rv, out.c_str(), out.length());
     }
     return rv;
 }

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -553,7 +553,7 @@ class Value {
     char *to_msgpack_string(size_t *size_out) const;
     void to_json(sentry::IoWriter &out) const;
     void to_json(sentry::JsonWriter &out) const;
-    char *to_json() const;
+    std::string to_json() const;
 
     sentry_value_t lower() {
         sentry_value_t rv;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -32,6 +32,7 @@ void BackgroundWorker::start() {
                 m_wake.wait_for(lock, std::chrono::seconds(5));
             } else if (task) {
                 (*task)();
+		delete task;
             } else {
                 m_running = false;
                 m_wake.notify_one();


### PR DESCRIPTION
This fix 3 memory leaks:
- 1) In background worker -> create new task to process which are never deleted
- 2) In delete of option object, transport was not deleted
- 3) MemoryWriter was unreferencing allocated data and so memory was leaked. Delete was called on wrong nullptr address in destructor. 