### PR TITLE
feat: Dump in-flight requests in case of a crash

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -95,6 +95,17 @@ main(int argc, char **argv)
         }
     }
 
+    if (has_arg(argc, argv, "capture-multiple")) {
+        for (size_t i = 0; i < 10; i++) {
+            char buffer[10];
+            snprintf(buffer, 10, "Event #%zu", i);
+
+            sentry_value_t event = sentry_value_new_message_event(
+                SENTRY_LEVEL_INFO, NULL, buffer);
+            sentry_capture_event(event);
+        }
+    }
+
     if (has_arg(argc, argv, "crash")) {
         memset((char *)0x0, 1, 100);
     }

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -6,7 +6,9 @@ extern "C" {
 #include "sentry_core.h"
 #include "sentry_envelope.h"
 #include "sentry_path.h"
+#include "sentry_sync.h"
 #include "sentry_transport.h"
+#include "sentry_unix_pageallocator.h"
 }
 
 #ifdef __GNUC__

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -96,6 +96,9 @@ sentry__breakpad_backend_callback(
     const google_breakpad::MinidumpDescriptor &descriptor,
     void *UNUSED(context), bool succeeded)
 {
+    sentry__page_allocator_enable();
+    sentry__enter_signal_handler();
+
     const sentry_options_t *options = sentry_get_options();
     const char *dump_path = descriptor.path();
 
@@ -116,6 +119,7 @@ sentry__breakpad_backend_callback(
         sentry__transport_dump_queue(transport);
     }
 
+    sentry__leave_signal_handler();
     return succeeded;
 }
 

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -112,7 +112,9 @@ sentry__breakpad_backend_callback(
 
     // after capturing the crash event, try to dump all the in-flight data of
     // the previous transport
-    sentry__transport_dump_queue(transport);
+    if (transport) {
+        sentry__transport_dump_queue(transport);
+    }
 
     return succeeded;
 }

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -102,12 +102,17 @@ sentry__breakpad_backend_callback(
     // almost identical to enforcing the disk transport, the breakpad
     // transport will serialize the envelope to disk, but will attach the
     // captured minidump as an additional attachment
+    sentry_transport_t *transport = options->transport;
     sentry__enforce_breakpad_transport(options, dump_path);
 
     // after the transport is set up, we will capture an event, which will
     // create an envelope with all the scope, attachments, etc.
     sentry_value_t event = sentry_value_new_event();
     sentry_capture_event(event);
+
+    // after capturing the crash event, try to dump all the in-flight data of
+    // the previous transport
+    sentry__transport_dump_queue(transport);
 
     return succeeded;
 }

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -163,7 +163,7 @@ handle_signal(int signum, siginfo_t *info, void *user_context)
     // give us an allocator we can use safely in signals before we tear down.
     sentry__page_allocator_enable();
 
-    // inform the sentry_sync system that we're in a signal hanlder.  This will
+    // inform the sentry_sync system that we're in a signal handler.  This will
     // make mutexes spin on a spinlock instead as it's no longer safe to use a
     // pthread mutex.
     sentry__enter_signal_handler();
@@ -181,7 +181,9 @@ handle_signal(int signum, siginfo_t *info, void *user_context)
 
     // after capturing the crash event, try to dump all the in-flight data of
     // the previous transport
-    sentry__transport_dump_queue(transport);
+    if (transport) {
+        sentry__transport_dump_queue(transport);
+    }
 
     // reset signal handlers and invoke the original ones.  This will then tear
     // down the process.  In theory someone might have some other handler here

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -167,5 +167,8 @@ int sentry__bgworker_shutdown(sentry_bgworker_t *bgw, uint64_t timeout);
 int sentry__bgworker_submit(sentry_bgworker_t *bgw,
     sentry_task_function_t exec_func, sentry_task_function_t cleanup_func,
     void *data);
+int sentry__bgworker_foreach_matching(sentry_bgworker_t *bgw,
+    sentry_task_function_t exec_func,
+    bool (*callback)(void *task_data, void *data), void *data);
 
 #endif

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -61,7 +61,7 @@ typedef CONDITION_VARIABLE sentry_cond_t;
 
 /* on unix systems signal handlers can interrupt anything which means that
    we're restricted in what we can do.  In particular it's possible that
-   we would end up dead locking outselves.  While we cannot fully prevent
+   we would end up dead locking ourselves.  While we cannot fully prevent
    races we have a logic here that while the signal handler is active we're
    disabling our mutexes so that our signal handler can access what otherwise
    would be protected by the mutex but everyone else needs to wait for the

--- a/src/sentry_transport.h
+++ b/src/sentry_transport.h
@@ -5,4 +5,6 @@
 
 sentry_transport_t *sentry__transport_new_default(void);
 
+void sentry__transport_dump_queue(sentry_transport_t *transport);
+
 #endif

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -226,3 +226,31 @@ sentry__transport_new_default(void)
 
     return transport;
 }
+
+static bool
+sentry__curl_dump(void *task_data, void *UNUSED(data))
+{
+    struct task_state *ts = task_data;
+    const sentry_options_t *opts = sentry_get_options();
+
+    sentry__run_write_envelope(opts->run, ts->envelope);
+
+    return true;
+}
+
+void
+sentry__transport_dump_queue(sentry_transport_t *transport)
+{
+    // make sure to only dump when it is actually *this* transport which is in
+    // use
+    if (transport->send_envelope_func != send_envelope) {
+        return;
+    }
+
+    sentry_bgworker_t *bgworker
+        = ((struct transport_state *)transport->data)->bgworker;
+
+    size_t dumped = sentry__bgworker_foreach_matching(
+        bgworker, task_exec_func, sentry__curl_dump, NULL);
+    SENTRY_TRACEF("Dumped %zu in-flight envelopes to disk", dumped);
+}

--- a/src/transports/sentry_transport_none.c
+++ b/src/transports/sentry_transport_none.c
@@ -5,3 +5,8 @@ sentry__transport_new_default(void)
 {
     return NULL;
 }
+
+void
+sentry__transport_dump_queue(sentry_transport_t *UNUSED(transport))
+{
+}

--- a/src/transports/sentry_transport_none.c
+++ b/src/transports/sentry_transport_none.c
@@ -1,3 +1,4 @@
+#include "sentry_core.h"
 #include "sentry_transport.h"
 
 sentry_transport_t *

--- a/src/transports/sentry_transport_winhttp.c
+++ b/src/transports/sentry_transport_winhttp.c
@@ -286,3 +286,8 @@ sentry__transport_new_default(void)
 
     return transport;
 }
+
+void
+sentry__transport_dump_queue(sentry_transport_t *UNUSED(transport))
+{
+}

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -1,0 +1,11 @@
+import sys
+import os
+
+is_android = os.environ.get("ANDROID_API")
+is_x86 = os.environ.get("TEST_X86")
+
+has_crashpad = sys.platform != "linux" and not is_android
+# 32-bit linux has no proper curl support
+has_http = not is_android and not is_x86
+has_inproc = sys.platform != "win32"
+has_breakpad = sys.platform == "linux"

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -1,6 +1,5 @@
 import pytest
-import sys
-import os
+from .conditions import has_crashpad
 from . import cmake
 
 # TODO:
@@ -9,6 +8,6 @@ from . import cmake
 #   - crash
 #   - expect report via http
 
-@pytest.mark.skipif(sys.platform == "linux" or os.environ.get("ANDROID_API"), reason="crashpad not supported on linux")
+@pytest.mark.skipif(not has_crashpad, reason="test needs crashpad backend")
 def test_crashpad_build(tmp_path):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND":"crashpad", "SENTRY_TRANSPORT":"none"})

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -33,7 +33,7 @@ def test_capture_http(tmp_path, httpserver):
 
 @pytest.mark.skipif(sys.platform == "win32" or os.environ.get("ANDROID_API") or os.environ.get("TEST_X86"),
     reason="Android has no default http transport, Windows has no inproc backend")
-def test_inproc_enqueue_http(tmp_path, httpserver):
+def test_inproc_crash_http(tmp_path, httpserver):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND": "inproc"})
 
     child = run(tmp_path, "sentry_example", ["attachment", "crash"])
@@ -59,9 +59,29 @@ def test_inproc_enqueue_http(tmp_path, httpserver):
 
     assert_crash(envelope)
 
+@pytest.mark.skipif(sys.platform == "win32" or os.environ.get("ANDROID_API") or os.environ.get("TEST_X86"),
+    reason="Android has no default http transport, Windows has no inproc backend")
+def test_inproc_dump_inflight(tmp_path, httpserver):
+    cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND": "inproc"})
+
+    httpserver.expect_request(
+        "/api/123456/store/", headers={
+            "x-sentry-auth": "Sentry sentry_key=uiaeosnrtdy, sentry_version=7, sentry_client=sentry.native/0.2.1"
+        }).respond_with_data('OK')
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    child = run(tmp_path, "sentry_example", ["capture-multiple", "crash"], env=env)
+    assert child.returncode # well, its a crash after all
+
+    run(tmp_path, "sentry_example", ["no-setup"],
+        check=True, env=env)
+
+    # we trigger 10 normal events, and 1 crash
+    assert len(httpserver.log) >= 11
+
 @pytest.mark.skipif(sys.platform != "linux" or os.environ.get("TEST_X86"),
     reason="breadpad only supported on linux")
-def test_breakpad_enqueue_http(tmp_path, httpserver):
+def test_breakpad_crash_http(tmp_path, httpserver):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND": "breakpad"})
 
     child = run(tmp_path, "sentry_example", ["attachment", "crash"])
@@ -86,3 +106,23 @@ def test_breakpad_enqueue_http(tmp_path, httpserver):
     assert_attachment(envelope)
 
     assert_minidump(envelope)
+
+@pytest.mark.skipif(sys.platform != "linux" or os.environ.get("TEST_X86"),
+    reason="breadpad only supported on linux")
+def test_breakpad_dump_inflight(tmp_path, httpserver):
+    cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND": "breakpad"})
+
+    httpserver.expect_request(
+        "/api/123456/store/", headers={
+            "x-sentry-auth": "Sentry sentry_key=uiaeosnrtdy, sentry_version=7, sentry_client=sentry.native/0.2.1"
+        }).respond_with_data('OK')
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    child = run(tmp_path, "sentry_example", ["capture-multiple", "crash"], env=env)
+    assert child.returncode # well, its a crash after all
+
+    run(tmp_path, "sentry_example", ["no-setup"],
+        check=True, env=env)
+
+    # we trigger 10 normal events, and 1 crash
+    assert len(httpserver.log) >= 11

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -34,7 +34,7 @@ def test_capture_stdout(tmp_path):
     assert_event(envelope)
 
 @pytest.mark.skipif(sys.platform == "win32", reason="no inproc backend on windows")
-def test_inproc_enqueue_stdout(tmp_path):
+def test_inproc_crash_stdout(tmp_path):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND":"inproc", "SENTRY_TRANSPORT":"none"})
 
     child = run(tmp_path, "sentry_example", ["attachment", "crash"])
@@ -50,7 +50,7 @@ def test_inproc_enqueue_stdout(tmp_path):
     assert_crash(envelope)
 
 @pytest.mark.skipif(sys.platform != "linux", reason="breakpad only supported on linux")
-def test_breakpad_enqueue_stdout(tmp_path):
+def test_breakpad_crash_stdout(tmp_path):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND":"breakpad", "SENTRY_TRANSPORT":"none"})
 
     child = run(tmp_path, "sentry_example", ["attachment", "crash"])

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import os
 from . import cmake, check_output, run, Envelope
+from .conditions import has_inproc, has_breakpad
 from .assertions import assert_attachment, assert_meta, assert_breadcrumb, assert_stacktrace, assert_event, assert_crash, assert_minidump
 
 def test_capture_stdout(tmp_path):
@@ -33,7 +34,7 @@ def test_capture_stdout(tmp_path):
 
     assert_event(envelope)
 
-@pytest.mark.skipif(sys.platform == "win32", reason="no inproc backend on windows")
+@pytest.mark.skipif(not has_inproc, reason="test needs inproc backend")
 def test_inproc_crash_stdout(tmp_path):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND":"inproc", "SENTRY_TRANSPORT":"none"})
 
@@ -49,7 +50,7 @@ def test_inproc_crash_stdout(tmp_path):
 
     assert_crash(envelope)
 
-@pytest.mark.skipif(sys.platform != "linux", reason="breakpad only supported on linux")
+@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout(tmp_path):
     cmake(tmp_path, ["sentry_example"], {"SENTRY_BACKEND":"breakpad", "SENTRY_TRANSPORT":"none"})
 


### PR DESCRIPTION
The inproc and breakpad backends will invoke the default transports dump method,
that method will first check that it is actually the transport responsible,
and will then dump all the envelopes in matching tasks.
The bg worker is changed in a way that it only pops tasks *after* they are completed.
That way, in case of a race, we end up with duplicate events rather than dropped events.