### PR TITLE
feat: Write crash timestamp into a marker file

### DIFF
--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -102,6 +102,7 @@ sentry__breakpad_backend_callback(
     sentry__enter_signal_handler();
 
     const sentry_options_t *options = sentry_get_options();
+    sentry__write_crash_marker(options);
     const char *dump_path = descriptor.path();
 
     // almost identical to enforcing the disk transport, the breakpad

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -168,9 +168,11 @@ handle_signal(int signum, siginfo_t *info, void *user_context)
     // pthread mutex.
     sentry__enter_signal_handler();
 
+    const sentry_options_t *opts = sentry_get_options();
+    sentry__write_crash_marker(opts);
+
     // since we can’t use HTTP in signal handlers, we will swap out the
     // transport here to one that serializes the envelope to disk
-    const sentry_options_t *opts = sentry_get_options();
     sentry_transport_t *transport = opts->transport;
     sentry__enforce_disk_transport();
 

--- a/src/sentry_database.h
+++ b/src/sentry_database.h
@@ -24,4 +24,10 @@ bool sentry__run_clear_session(const sentry_run_t *run);
 
 void sentry__process_old_runs(const sentry_options_t *options);
 
+/**
+ * This will write the current timestamp (ISO formatted) into the
+ * `${database_path}/last_crash` file.
+ */
+bool sentry__write_crash_marker(const sentry_options_t *options);
+
 #endif

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -75,6 +75,10 @@ def assert_minidump(envelope):
     assert any(matches(item.headers, expected) for item in envelope)
 
 
+def assert_timestamp(ts, now=datetime.datetime.utcnow()):
+    assert ts[:11] == now.isoformat()[:11]
+
+
 def assert_event(envelope):
     event = envelope.get_event()
     expected = {
@@ -83,7 +87,7 @@ def assert_event(envelope):
         "message": {"formatted": "Hello World!"},
     }
     assert matches(event, expected)
-    assert event["timestamp"][:11] == datetime.datetime.utcnow().isoformat()[:11]
+    assert_timestamp(event["timestamp"])
 
 
 def assert_crash(envelope):

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import os
 from . import cmake, check_output, run, Envelope
-from .conditions import has_inproc, has_breakpad
+from .conditions import has_inproc, has_breakpad, is_android
 from .assertions import (
     assert_attachment,
     assert_meta,
@@ -80,10 +80,12 @@ def test_inproc_crash_stdout(tmp_path):
     output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
     envelope = Envelope.deserialize(output)
 
-    # the crash file should survive a `sentry_init` and should still be there even after restarts
-    with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
-        crash_timestamp = f.read()
-    assert_timestamp(crash_timestamp)
+    # The crash file should survive a `sentry_init` and should still be there
+    # even after restarts. On Android, we can’t look inside the emulator.
+    if not is_android:
+        with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
+            crash_timestamp = f.read()
+        assert_timestamp(crash_timestamp)
 
     assert_meta(envelope)
     assert_breadcrumb(envelope)

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -12,6 +12,7 @@ from .assertions import (
     assert_event,
     assert_crash,
     assert_minidump,
+    assert_timestamp,
 )
 
 
@@ -79,6 +80,11 @@ def test_inproc_crash_stdout(tmp_path):
     output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
     envelope = Envelope.deserialize(output)
 
+    # the crash file should survive a `sentry_init` and should still be there even after restarts
+    with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
+        crash_timestamp = f.read()
+    assert_timestamp(crash_timestamp)
+
     assert_meta(envelope)
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
@@ -96,6 +102,10 @@ def test_breakpad_crash_stdout(tmp_path):
 
     child = run(tmp_path, "sentry_example", ["attachment", "crash"])
     assert child.returncode  # well, its a crash after all
+
+    with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
+        crash_timestamp = f.read()
+    assert_timestamp(crash_timestamp)
 
     output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
     envelope = Envelope.deserialize(output)


### PR DESCRIPTION
After some discussion with @marandaneto, I think this is useful to have even outside of `sentry-android`.

Please note that `sentry-native` will never read, or delete the file, it is for outside observers only.