### PR TITLE
Fixes initializing random on windows

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,4 @@ IndentPPDirectives: AfterHash
 ColumnLimit: 80
 AlwaysBreakAfterDefinitionReturnType: All
 PointerAlignment: Right
-ForEachMacros: ['SENTRY_WITH_SCOPE', 'SENTRY_WITH_SCOPE_MUT', 'SENTRY_CTOR']
+ForEachMacros: ['SENTRY_WITH_SCOPE', 'SENTRY_WITH_SCOPE_MUT']

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -96,23 +96,4 @@ char *sentry__msec_time_to_iso8601(uint64_t time);
 #define SENTRY_CONCAT_IMPL(A, B) A##B
 #define SENTRY_CONCAT(A, B) SENTRY_CONCAT_IMPL(A, B)
 
-/* utility to declare a constructor function */
-#ifdef _MSC_VER
-#    pragma section(".CRT$XIU", long, read)
-#    define SENTRY_CTOR(Name)                                                  \
-        static void Name(void);                                                \
-        static int SENTRY_CONCAT(_ctor_1_, Name)(void)                         \
-        {                                                                      \
-            Name();                                                            \
-            return 0;                                                          \
-        }                                                                      \
-        __pragma(data_seg(".CRT$XIU")) static int (                            \
-            *SENTRY_CONCAT(_ctor_2_, Name))()                                  \
-            = SENTRY_CONCAT(_ctor_1_, Name);                                   \
-        __pragma(data_seg()) static void Name(void)
-#else
-#    define SENTRY_CTOR(Name)                                                  \
-        __attribute__((constructor)) static void Name(void)
-#endif
-
 #endif


### PR DESCRIPTION
The SENTRY_CTOR isn't working for me and afaik it is not safe to call LoadLibraryA outside of main() ie during static initialization or DLLMain. Switching this to initialize on the first call to random instead.