### PR TITLE
build: add -fPIC flag when building static lib on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,8 @@ if(BUILD_SHARED_LIBS)
 		sentry_install(FILES "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:$<TARGET_PDB_FILE:sentry>>"
 			DESTINATION "${CMAKE_INSTALL_BINDIR}")
 	endif()
+elseif(LINUX)
+	target_compile_options(sentry PRIVATE -fPIC)
 endif()
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
Without this, we get the following linker error:
```
make: Entering directory '.../build'
  SOLINK_MODULE(target) Debug/obj.target/addon.node
/usr/bin/ld: .../lib/linux/libsentry.a(sentry_core.c.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
addon.target.mk:211: recipe for target 'Debug/obj.target/addon.node' failed
make: *** [Debug/obj.target/addon.node] Error 1
make: Leaving directory '.../build'
```
