### PR TITLE
build(cmake): Use crashpad targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,24 +264,29 @@ if(SENTRY_WITH_LIBUNWINDSTACK)
 endif()
 
 if(SENTRY_BACKEND_CRASHPAD)
-	add_subdirectory(external/crashpad EXCLUDE_FROM_ALL)
-	target_include_directories(sentry PRIVATE
-		"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/crashpad>"
-		"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/crashpad/third_party/mini_chromium/mini_chromium>"
-	)
-	# we include a crashpad header, which itself needs C++14 support
-	target_compile_features(sentry PUBLIC cxx_std_14)
-	target_link_libraries(sentry PRIVATE crashpad_client crashpad_util)
-	if(NOT BUILD_SHARED_LIBS)
-		sentry_install(TARGETS crashpad_client crashpad_util crashpad_compat getopt mini_chromium zlib EXPORT sentry
-			LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-			ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	option(SENTRY_CRASHPAD_SYSTEM "Use system crashpad" OFF)
+	if(SENTRY_CRASHPAD_SYSTEM)
+		find_package(crashpad REQUIRED)
+		target_link_libraries(sentry PUBLIC crashpad::client)
+	else()
+		# FIXME: required for cmake 3.12 and lower:
+		# - NEW behavior lets normal variable override option
+		cmake_policy(SET CMP0077 NEW)
+		if(BUILD_SHARED_LIBS)
+			set(CRASHPAD_ENABLE_INSTALL OFF CACHE BOOL "Enable crashpad installation" FORCE)
+		else()
+			set(CRASHPAD_ENABLE_INSTALL ON CACHE BOOL "Enable crashpad installation" FORCE)
+		endif()
+		add_subdirectory(external/crashpad crashpad_build)
+		target_link_libraries(sentry PUBLIC
+			$<BUILD_INTERFACE:crashpad::client>
+			$<INSTALL_INTERFACE:sentry_crashpad::client>
+		)
+		install(EXPORT crashpad_export NAMESPACE sentry_crashpad:: FILE sentry_crashpad-targets.cmake
+			DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
 		)
 	endif()
-	sentry_install(TARGETS crashpad_handler EXPORT sentry
-		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	)
-	add_dependencies(sentry crashpad_handler)
+	add_dependencies(sentry crashpad::handler)
 elseif(SENTRY_BACKEND_BREAKPAD)
 	add_subdirectory(external)
 	target_include_directories(sentry PRIVATE

--- a/sentry-config.cmake.in
+++ b/sentry-config.cmake.in
@@ -1,6 +1,14 @@
 set(SENTRY_BACKEND @SENTRY_BACKEND@)
 set(SENTRY_TRANSPORT @SENTRY_TRANSPORT@)
 
+if(SENTRY_BACKEND STREQUAL "crashpad")
+	if(@SENTRY_CRASHPAD_SYSTEM@)
+		find_package(crashpad REQUIRED)
+	else()
+		include("${CMAKE_CURRENT_LIST_DIR}/sentry_crashpad-targets.cmake")
+	endif()
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/sentry-targets.cmake")
 
 if(SENTRY_TRANSPORT STREQUAL "curl" AND NOT @BUILD_SHARED_LIBS@)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -92,7 +92,9 @@ def cmake(cwd, targets, options=None):
         configcmd.append("-D{}={}".format(key, value))
     if sys.platform == "win32" and os.environ.get("TEST_X86"):
         configcmd.append("-AWin32")
-    configcmd.append(os.getcwd())
+
+    cmakelists_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    configcmd.append(cmakelists_dir)
 
     print("\n{} > {}".format(cwd, " ".join(configcmd)), flush=True)
     subprocess.run(configcmd, cwd=cwd, check=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import re
 from . import cmake, run
@@ -6,7 +7,8 @@ from . import cmake, run
 def enumerate_unittests():
     regexp = re.compile("XX\((.*?)\)")
     # TODO: actually generate the `tests.inc` file with python
-    with open("tests/unit/tests.inc", "r") as testsfile:
+    curdir = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(curdir, "unit/tests.inc"), "r") as testsfile:
         for line in testsfile:
             match = regexp.match(line)
             if match:


### PR DESCRIPTION
This pr is in tandem with https://github.com/getsentry/crashpad/pull/7

Should make #205 unnecessary
Fixes #204 

I've changed the crashpad submodule to my repo to let CI succeed (🤞)
I'll remove it once https://github.com/getsentry/crashpad/pull/7 gets merged.

