### PR TITLE
fix(modulefinder): Reset errno before read() to prevent infinite loop

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -403,6 +403,7 @@ load_modules(sentry_value_t modules)
     sentry_stringbuilder_t sb;
     sentry__stringbuilder_init(&sb);
     while (true) {
+        errno = 0;
         ssize_t n = read(fd, buf, 4096);
         if (n <= 0) {
             if (errno == EAGAIN || errno == EINTR) {


### PR DESCRIPTION
The `while` loop within `load_modules()` would forever read 0 bytes -- `errno` was set to `EINTR` at some point but was never cleared. 