### PR TITLE
fix: Expose a method to clear the module cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,6 @@ stages:
             displayName: Installing Android SDK Dependencies
           - script: |
               bash scripts/start-android.sh
-            timeoutInMinutes: 5 # because gettings things wrong here can hang the job for up to an hour…
             condition: variables['ANDROID_API']
             displayName: Starting Android Simulator
           # - script: choco install --no-progress msys2

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -538,7 +538,8 @@ SENTRY_API void sentry_options_set_http_proxy(
 /*
  * returns the configured http proxy
  */
-SENTRY_API const char *sentry_options_get_http_proxy(sentry_options_t *opts);
+SENTRY_API const char *sentry_options_get_http_proxy(
+    const sentry_options_t *opts);
 
 /*
  * configures the path to a file containing ssl certificates for
@@ -633,6 +634,15 @@ SENTRY_API int sentry_init(sentry_options_t *options);
  * Shuts down the sentry client and forces transports to flush out.
  */
 SENTRY_API void sentry_shutdown(void);
+
+/**
+ * For performance reasons, sentry will cache the list of loaded libraries when
+ * capturing events. This cache can get out-of-date when loading or unloading
+ * libraries at runtime. It is therefore recommended to call
+ * `sentry_clear_modulecache` when doing so, to make sure that the next call to
+ * `sentry_capture_event` will have an up-to-date module list.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_clear_modulecache(void);
 
 /*
  * Returns the client options.

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -114,6 +114,12 @@ sentry_shutdown(void)
     sentry__modulefinder_cleanup();
 }
 
+void
+sentry_clear_modulecache(void)
+{
+    sentry__modulefinder_cleanup();
+}
+
 const sentry_options_t *
 sentry_get_options(void)
 {
@@ -262,7 +268,8 @@ sentry_capture_event(sentry_value_t event)
     return event_id;
 }
 
-void sentry_handle_exception(sentry_ucontext_t *uctx)
+void
+sentry_handle_exception(sentry_ucontext_t *uctx)
 {
     SENTRY_DEBUG("handling exception");
     if (g_options->backend && g_options->backend->except_func) {
@@ -446,7 +453,7 @@ sentry_options_set_http_proxy(sentry_options_t *opts, const char *proxy)
 }
 
 const char *
-sentry_options_get_http_proxy(sentry_options_t *opts)
+sentry_options_get_http_proxy(const sentry_options_t *opts)
 {
     return opts->http_proxy;
 }


### PR DESCRIPTION
fixes #213

Also make `sentry_options_get_http_proxy` const-correct, fixes #214