### PR TITLE
fix: Use absolute paths for the database

### DIFF
--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -7,6 +7,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <libgen.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/errno.h>
@@ -89,6 +90,16 @@ sentry__filelock_unlock(sentry_filelock_t *lock)
     flock(lock->fd, LOCK_UN);
     close(lock->fd);
     lock->is_locked = false;
+}
+
+sentry_path_t *
+sentry__path_absolute(const sentry_path_t *path)
+{
+    char full[PATH_MAX];
+    if (!realpath(path->path, full)) {
+        return NULL;
+    }
+    return sentry__path_from_str(full);
 }
 
 sentry_path_t *

--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -92,6 +92,16 @@ path_with_len(size_t len)
 }
 
 sentry_path_t *
+sentry__path_absolute(const sentry_path_t *path)
+{
+    wchar_t full[_MAX_PATH];
+    if (!_wfullpath(full, path->path, _MAX_PATH)) {
+        return NULL;
+    }
+    return sentry__path_from_wstr(full);
+}
+
+sentry_path_t *
 sentry__path_current_exe(void)
 {
     // inspired by:

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -61,6 +61,17 @@ sentry_init(sentry_options_t *options)
     sentry_shutdown();
     sentry__mutex_lock(&g_options_mutex);
     g_options = options;
+
+    sentry_path_t *database_path = options->database_path;
+    options->database_path = sentry__path_absolute(database_path);
+    if (options->database_path) {
+        sentry__path_free(database_path);
+    } else {
+        options->database_path = database_path;
+    }
+    SENTRY_DEBUGF("Using database path \"%" SENTRY_PATH_PRI "\"",
+        options->database_path->path);
+
     sentry__path_create_dir_all(options->database_path);
     load_user_consent(options);
     sentry__mutex_unlock(&g_options_mutex);

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -62,6 +62,7 @@ sentry_init(sentry_options_t *options)
     sentry__mutex_lock(&g_options_mutex);
     g_options = options;
 
+    sentry__path_create_dir_all(options->database_path);
     sentry_path_t *database_path = options->database_path;
     options->database_path = sentry__path_absolute(database_path);
     if (options->database_path) {
@@ -72,7 +73,6 @@ sentry_init(sentry_options_t *options)
     SENTRY_DEBUGF("Using database path \"%" SENTRY_PATH_PRI "\"",
         options->database_path->path);
 
-    sentry__path_create_dir_all(options->database_path);
     load_user_consent(options);
     sentry__mutex_unlock(&g_options_mutex);
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -68,6 +68,7 @@ sentry_init(sentry_options_t *options)
     if (options->database_path) {
         sentry__path_free(database_path);
     } else {
+        SENTRY_DEBUG("falling back to non-absolute database path");
         options->database_path = database_path;
     }
     SENTRY_DEBUGF("Using database path \"%" SENTRY_PATH_PRI "\"",

--- a/src/sentry_path.h
+++ b/src/sentry_path.h
@@ -27,6 +27,11 @@ typedef struct sentry_path_s sentry_path_t;
 typedef struct sentry_pathiter_s sentry_pathiter_t;
 typedef struct sentry_filelock_s sentry_filelock_t;
 
+/**
+ * Creates a new path by making `path` into an absolute path.
+ */
+sentry_path_t *sentry__path_absolute(const sentry_path_t *path);
+
 sentry_path_t *sentry__path_current_exe(void);
 sentry_path_t *sentry__path_dir(const sentry_path_t *path);
 sentry_path_t *sentry__path_from_str(const char *s);


### PR DESCRIPTION
This way, sentry is resilient to cwd changes, as mentioned in #220.