### PR TITLE
fix: Add an explicit log when crashes have been captured

### DIFF
--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -122,6 +122,7 @@ sentry__breakpad_backend_callback(
     if (transport) {
         sentry__transport_dump_queue(transport);
     }
+    SENTRY_DEBUG("crash has been captured");
 
     sentry__leave_signal_handler();
     return succeeded;

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -183,6 +183,7 @@ handle_ucontext(sentry_ucontext_t *uctx)
     if (transport) {
         sentry__transport_dump_queue(transport);
     }
+    SENTRY_DEBUG("crash has been captured");
 
     // reset signal handlers and invoke the original ones.  This will then tear
     // down the process.  In theory someone might have some other handler here


### PR DESCRIPTION
CC @marandaneto 