### PR TITLE
[MinGW] Missing errno.h

### DIFF
--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -6,6 +6,7 @@
 #include "sentry_string.h"
 #include "sentry_utils.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <io.h>
 #include <shlwapi.h>


### PR DESCRIPTION
Complementary to https://github.com/getsentry/crashpad/pull/11. My latest build attempt http://zonme.to2x.ovh:8090/job/sentry-native/job/master/9/console also highlighted a missing header reference.