### PR TITLE
fix: Send sessions as envelopes to the correct endpoint

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -96,6 +96,10 @@ main(int argc, char **argv)
         sentry_add_breadcrumb(debug_crumb);
     }
 
+    if (has_arg(argc, argv, "start-session")) {
+        sentry_start_session();
+    }
+
     if (has_arg(argc, argv, "overflow-breadcrumbs")) {
         for (size_t i = 0; i < 101; i++) {
             char buffer[4];

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -365,7 +365,7 @@ try_append_module(sentry_value_t modules, const sentry_module_t *module)
     }
 
     SENTRY_TRACEF(
-        "inspecting module \"%.*s\"", module->file.len, module->file.ptr);
+        "inspecting module \"%.*s\"", (int)module->file.len, module->file.ptr);
     sentry_value_t mod_val = sentry__procmaps_module_to_value(module);
     if (!sentry_value_is_null(mod_val)) {
         sentry_value_append(modules, mod_val);

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -313,6 +313,18 @@ sentry__dsn_get_store_url(const sentry_dsn_t *dsn)
 }
 
 char *
+sentry__dsn_get_envelope_url(const sentry_dsn_t *dsn)
+{
+    if (!dsn || dsn->empty) {
+        return NULL;
+    }
+    sentry_stringbuilder_t sb;
+    init_string_builder_for_url(&sb, dsn);
+    sentry__stringbuilder_append(&sb, "/envelope/");
+    return sentry__stringbuilder_into_string(&sb);
+}
+
+char *
 sentry__dsn_get_minidump_url(const sentry_dsn_t *dsn)
 {
     if (!dsn || dsn->empty) {

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -69,18 +69,22 @@ void sentry__dsn_cleanup(sentry_dsn_t *dsn);
 char *sentry__dsn_get_auth_header(const sentry_dsn_t *dsn);
 
 /**
- * This returns a new string, with the URL for normal event and envelope
- * uploads.
+ * Returns a new string with the URL for normal event uploads.
  */
 char *sentry__dsn_get_store_url(const sentry_dsn_t *dsn);
 
 /**
- * This returns a new string, with the URL for minidump uploads.
+ * Returns a new string with the URL for envelope uploads.
+ */
+char *sentry__dsn_get_envelope_url(const sentry_dsn_t *dsn);
+
+/**
+ * Returns a new string with the URL for minidump uploads.
  */
 char *sentry__dsn_get_minidump_url(const sentry_dsn_t *dsn);
 
 /**
- * This returns a new string, with the URL for attachment uploads.
+ * Returns a new string with the URL for attachment uploads.
  */
 char *sentry__dsn_get_attachment_url(
     const sentry_dsn_t *dsn, const sentry_uuid_t *event_id);

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -146,8 +146,8 @@ class Envelope(object):
 
     def get_event(self):
         # type: (...) -> Optional[Event]
-        for items in self.items:
-            event = items.get_event()
+        for item in self.items:
+            event = item.get_event()
             if event is not None:
                 return event
         return None
@@ -232,7 +232,7 @@ class Item(object):
         headers = json.loads(line)
         length = headers["length"]
         payload = f.read(length)
-        if headers.get("type") == "event":
+        if headers.get("type") == "event" or headers.get("type") == "session":
             rv = cls(headers=headers, payload=PayloadRef(json=json.loads(payload)))
         else:
             rv = cls(headers=headers, payload=payload)

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -6,6 +6,7 @@ def matches(actual, expected):
 
 
 def assert_session(envelope, extra_assertion=None):
+    session = None
     for item in envelope:
         if item.headers.get("type") == "session" and item.payload.json is not None:
             session = item.payload.json
@@ -84,7 +85,6 @@ def assert_attachment(envelope):
 def assert_minidump(envelope):
     expected = {
         "type": "attachment",
-        "name": "upload_file_minidump",
         "attachment_type": "event.minidump",
     }
     assert any(matches(item.headers, expected) for item in envelope)

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -5,6 +5,21 @@ def matches(actual, expected):
     return {k: v for (k, v) in actual.items() if k in expected.keys()} == expected
 
 
+def assert_session(envelope, extra_assertion=None):
+    for item in envelope:
+        if item.headers.get("type") == "session" and item.payload.json is not None:
+            session = item.payload.json
+
+    assert session is not None
+    assert session["did"] == "42"
+    assert session["attrs"] == {
+        "release": "test-example-release",
+        "environment": "Production",
+    }
+    if extra_assertion:
+        assert matches(session, extra_assertion)
+
+
 def assert_meta(envelope):
     event = envelope.get_event()
 

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -97,15 +97,15 @@ def test_inproc_crash_http(tmp_path, httpserver):
     )
 
     assert len(httpserver.log) == 2
+    outputs = (httpserver.log[0][0].get_data(), httpserver.log[1][0].get_data())
+    session, event = (
+        outputs if b'"type":"session"' in outputs[0] else (outputs[1], outputs[0])
+    )
 
-    # the session comes first
-    output = httpserver.log[0][0].get_data()
-    envelope = Envelope.deserialize(output)
+    envelope = Envelope.deserialize(session)
     assert_session(envelope, {"status": "crashed", "errors": 0})
 
-    output = httpserver.log[1][0].get_data()
-    envelope = Envelope.deserialize(output)
-
+    envelope = Envelope.deserialize(event)
     assert_meta(envelope)
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
@@ -151,14 +151,15 @@ def test_breakpad_crash_http(tmp_path, httpserver):
     )
 
     assert len(httpserver.log) == 2
+    outputs = (httpserver.log[0][0].get_data(), httpserver.log[1][0].get_data())
+    session, event = (
+        outputs if b'"type":"session"' in outputs[0] else (outputs[1], outputs[0])
+    )
 
-    # the session comes first
-    output = httpserver.log[0][0].get_data()
-    envelope = Envelope.deserialize(output)
+    envelope = Envelope.deserialize(session)
     assert_session(envelope, {"status": "crashed", "errors": 0})
 
-    output = httpserver.log[0][0].get_data()
-    envelope = Envelope.deserialize(output)
+    envelope = Envelope.deserialize(event)
 
     assert_meta(envelope)
     assert_breadcrumb(envelope)

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -85,6 +85,10 @@ SENTRY_TEST(dsn_store_url_with_path)
     char *url = sentry__dsn_get_store_url(&dsn);
     TEST_CHECK_STRING_EQUAL(url, "http://example.com:80/foo/bar/api/42/store/");
     sentry_free(url);
+    url = sentry__dsn_get_envelope_url(&dsn);
+    TEST_CHECK_STRING_EQUAL(
+        url, "http://example.com:80/foo/bar/api/42/envelope/");
+    sentry_free(url);
     url = sentry__dsn_get_minidump_url(&dsn);
     TEST_CHECK_STRING_EQUAL(url,
         "http://example.com:80/foo/bar/api/42/minidump/?sentry_key=username");
@@ -107,6 +111,9 @@ SENTRY_TEST(dsn_store_url_without_path)
         0);
     char *url = sentry__dsn_get_store_url(&dsn);
     TEST_CHECK_STRING_EQUAL(url, "http://example.com:80/api/42/store/");
+    sentry_free(url);
+    url = sentry__dsn_get_envelope_url(&dsn);
+    TEST_CHECK_STRING_EQUAL(url, "http://example.com:80/api/42/envelope/");
     sentry_free(url);
     url = sentry__dsn_get_minidump_url(&dsn);
     TEST_CHECK_STRING_EQUAL(


### PR DESCRIPTION
Lesson learned: Don’t merge code without e2e tests ;-)
Also, I’m very much tempted to just rip out all the endpoint and multipart-related code and just send envelopes *always*. As it is now, regular `capture_event` works with non-relay servers still.

One question I have: A crashed session won’t increase the `errors` count. Is that expected?