### PR TITLE
style: Make format for all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,16 +62,11 @@ setup-venv: .venv/bin/python
 	.venv/bin/pip install --upgrade --requirement tests/requirements.txt
 
 format: setup-venv
-	@clang-format -i \
-		examples/*.c \
-		include/*.h \
-		src/*.c \
-		src/*.h \
-		src/*/*.c \
-		src/*/*.cpp \
-		src/*/*.h \
-		tests/unit/*.c \
-		tests/unit/*.h
+	@find . -type f \
+		-name "*.h" \
+        -o -name "*.c" \
+        -o -name "*.cpp" \
+        | xargs clang-format -i -style=file
 	@.venv/bin/black tests
 .PHONY: format
 

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -27,7 +27,6 @@
 #ifndef ACUTEST_H__
 #define ACUTEST_H__
 
-
 /************************
  *** Public interface ***
  ************************/
@@ -57,8 +56,7 @@
  *
  *   void test_func(void);
  */
-#define TEST_LIST               const struct test__ test_list__[]
-
+#define TEST_LIST const struct test__ test_list__[]
 
 /* Macros for testing whether an unit test succeeds or fails. These macros
  * can be used arbitrarily in functions implementing the unit tests.
@@ -79,9 +77,9 @@
  *       TEST_CHECK(ptr->member2 > 200);
  *   }
  */
-#define TEST_CHECK_(cond,...)   test_check__((cond), __FILE__, __LINE__, __VA_ARGS__)
-#define TEST_CHECK(cond)        test_check__((cond), __FILE__, __LINE__, "%s", #cond)
-
+#define TEST_CHECK_(cond, ...)                                                 \
+    test_check__((cond), __FILE__, __LINE__, __VA_ARGS__)
+#define TEST_CHECK(cond) test_check__((cond), __FILE__, __LINE__, "%s", #cond)
 
 /* These macros are the same as TEST_CHECK_ and TEST_CHECK except that if the
  * condition fails, the currently executed unit test is immediately aborted.
@@ -98,17 +96,16 @@
  * effects to the outside world (e.g. communicating with some server, inserting
  * into a database etc.).
  */
-#define TEST_ASSERT_(cond,...)                                                 \
+#define TEST_ASSERT_(cond, ...)                                                \
     do {                                                                       \
         if (!test_check__((cond), __FILE__, __LINE__, __VA_ARGS__))            \
             test_abort__();                                                    \
-    } while(0)
+    } while (0)
 #define TEST_ASSERT(cond)                                                      \
     do {                                                                       \
         if (!test_check__((cond), __FILE__, __LINE__, "%s", #cond))            \
             test_abort__();                                                    \
-    } while(0)
-
+    } while (0)
 
 #ifdef __cplusplus
 /* Macros to verify that the code (the 1st argument) throws exception of given
@@ -125,40 +122,40 @@
  * If the function throws anything incompatible with ExpectedExceptionType
  * (or if it does not thrown an exception at all), the check fails.
  */
-#define TEST_EXCEPTION(code, exctype)                                          \
-    do {                                                                       \
-        bool exc_ok__ = false;                                                 \
-        const char *msg__ = NULL;                                              \
-        try {                                                                  \
-            code;                                                              \
-            msg__ = "No exception thrown.";                                    \
-        } catch(exctype const&) {                                              \
-            exc_ok__= true;                                                    \
-        } catch(...) {                                                         \
-            msg__ = "Unexpected exception thrown.";                            \
-        }                                                                      \
-        test_check__(exc_ok__, __FILE__, __LINE__, #code " throws " #exctype); \
-        if(msg__ != NULL)                                                      \
-            test_message__("%s", msg__);                                       \
-    } while(0)
-#define TEST_EXCEPTION_(code, exctype, ...)                                    \
-    do {                                                                       \
-        bool exc_ok__ = false;                                                 \
-        const char *msg__ = NULL;                                              \
-        try {                                                                  \
-            code;                                                              \
-            msg__ = "No exception thrown.";                                    \
-        } catch(exctype const&) {                                              \
-            exc_ok__= true;                                                    \
-        } catch(...) {                                                         \
-            msg__ = "Unexpected exception thrown.";                            \
-        }                                                                      \
-        test_check__(exc_ok__, __FILE__, __LINE__, __VA_ARGS__);               \
-        if(msg__ != NULL)                                                      \
-            test_message__("%s", msg__);                                       \
-    } while(0)
-#endif  /* #ifdef __cplusplus */
-
+#    define TEST_EXCEPTION(code, exctype)                                      \
+        do {                                                                   \
+            bool exc_ok__ = false;                                             \
+            const char *msg__ = NULL;                                          \
+            try {                                                              \
+                code;                                                          \
+                msg__ = "No exception thrown.";                                \
+            } catch (exctype const &) {                                        \
+                exc_ok__ = true;                                               \
+            } catch (...) {                                                    \
+                msg__ = "Unexpected exception thrown.";                        \
+            }                                                                  \
+            test_check__(                                                      \
+                exc_ok__, __FILE__, __LINE__, #code " throws " #exctype);      \
+            if (msg__ != NULL)                                                 \
+                test_message__("%s", msg__);                                   \
+        } while (0)
+#    define TEST_EXCEPTION_(code, exctype, ...)                                \
+        do {                                                                   \
+            bool exc_ok__ = false;                                             \
+            const char *msg__ = NULL;                                          \
+            try {                                                              \
+                code;                                                          \
+                msg__ = "No exception thrown.";                                \
+            } catch (exctype const &) {                                        \
+                exc_ok__ = true;                                               \
+            } catch (...) {                                                    \
+                msg__ = "Unexpected exception thrown.";                        \
+            }                                                                  \
+            test_check__(exc_ok__, __FILE__, __LINE__, __VA_ARGS__);           \
+            if (msg__ != NULL)                                                 \
+                test_message__("%s", msg__);                                   \
+        } while (0)
+#endif /* #ifdef __cplusplus */
 
 /* Sometimes it is useful to split execution of more complex unit tests to some
  * smaller parts and associate those parts with some names.
@@ -178,9 +175,8 @@
  * implicitly the previous one. To end the test case explicitly (e.g. to end
  * the last test case after exiting the loop), you may use TEST_CASE(NULL).
  */
-#define TEST_CASE_(...)         test_case__(__VA_ARGS__)
-#define TEST_CASE(name)         test_case__("%s", name)
-
+#define TEST_CASE_(...) test_case__(__VA_ARGS__)
+#define TEST_CASE(name) test_case__("%s", name)
 
 /* printf-like macro for outputting an extra information about a failure.
  *
@@ -203,16 +199,14 @@
  * The macro can deal with multi-line output fairly well. It also automatically
  * adds a final new-line if there is none present.
  */
-#define TEST_MSG(...)           test_message__(__VA_ARGS__)
-
+#define TEST_MSG(...) test_message__(__VA_ARGS__)
 
 /* Maximal output per TEST_MSG call. Longer messages are cut.
  * You may define another limit prior including "acutest.h"
  */
 #ifndef TEST_MSG_MAXSIZE
-    #define TEST_MSG_MAXSIZE    1024
+#    define TEST_MSG_MAXSIZE 1024
 #endif
-
 
 /* Macro for dumping a block of memory.
  *
@@ -220,19 +214,18 @@
  * generating any printf-like message, this is for dumping raw block of a
  * memory in a hexadecimal form:
  *
- * TEST_CHECK(size_produced == size_expected && memcmp(addr_produced, addr_expected, size_produced) == 0);
- * TEST_DUMP("Expected:", addr_expected, size_expected);
- * TEST_DUMP("Produced:", addr_produced, size_produced);
+ * TEST_CHECK(size_produced == size_expected && memcmp(addr_produced,
+ * addr_expected, size_produced) == 0); TEST_DUMP("Expected:", addr_expected,
+ * size_expected); TEST_DUMP("Produced:", addr_produced, size_produced);
  */
-#define TEST_DUMP(title, addr, size)    test_dump__(title, addr, size)
+#define TEST_DUMP(title, addr, size) test_dump__(title, addr, size)
 
 /* Maximal output per TEST_DUMP call (in bytes to dump). Longer blocks are cut.
  * You may define another limit prior including "acutest.h"
  */
 #ifndef TEST_DUMP_MAXSIZE
-    #define TEST_DUMP_MAXSIZE   1024
+#    define TEST_DUMP_MAXSIZE 1024
 #endif
-
 
 /**********************
  *** Implementation ***
@@ -241,55 +234,52 @@
 /* The unit test files should not rely on anything below. */
 
 #include <ctype.h>
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <setjmp.h>
 
 #if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-    #define ACUTEST_UNIX__      1
-    #include <errno.h>
-    #include <libgen.h>
-    #include <unistd.h>
-    #include <sys/types.h>
-    #include <sys/wait.h>
-    #include <signal.h>
-    #include <time.h>
+#    define ACUTEST_UNIX__ 1
+#    include <errno.h>
+#    include <libgen.h>
+#    include <signal.h>
+#    include <sys/types.h>
+#    include <sys/wait.h>
+#    include <time.h>
+#    include <unistd.h>
 
-    #if defined CLOCK_PROCESS_CPUTIME_ID  &&  defined CLOCK_MONOTONIC
-        #define ACUTEST_HAS_POSIX_TIMER__       1
-    #endif
+#    if defined CLOCK_PROCESS_CPUTIME_ID && defined CLOCK_MONOTONIC
+#        define ACUTEST_HAS_POSIX_TIMER__ 1
+#    endif
 #endif
 
 #if defined(__gnu_linux__)
-    #define ACUTEST_LINUX__     1
-    #include <fcntl.h>
-    #include <sys/stat.h>
+#    define ACUTEST_LINUX__ 1
+#    include <fcntl.h>
+#    include <sys/stat.h>
 #endif
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
-    #define ACUTEST_WIN__       1
-    #include <windows.h>
-    #include <io.h>
+#    define ACUTEST_WIN__ 1
+#    include <io.h>
+#    include <windows.h>
 #endif
 
 #ifdef __cplusplus
-    #include <exception>
+#    include <exception>
 #endif
-
 
 /* Note our global private identifiers end with '__' to mitigate risk of clash
  * with the unit tests implementation. */
 
-
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
 
-
 struct test__ {
-    const char* name;
+    const char *name;
     void (*func)(void);
 };
 
@@ -306,16 +296,15 @@ enum {
 
 extern const struct test__ test_list__[];
 
-int test_check__(int cond, const char* file, int line, const char* fmt, ...);
-void test_case__(const char* fmt, ...);
-void test_message__(const char* fmt, ...);
-void test_dump__(const char* title, const void* addr, size_t size);
+int test_check__(int cond, const char *file, int line, const char *fmt, ...);
+void test_case__(const char *fmt, ...);
+void test_message__(const char *fmt, ...);
+void test_dump__(const char *title, const void *addr, size_t size);
 void test_abort__(void);
-
 
 #ifndef TEST_NO_MAIN
 
-static char* test_argv0__ = NULL;
+static char *test_argv0__ = NULL;
 static size_t test_list_size__ = 0;
 static struct test_detail__ *test_details__ = NULL;
 static size_t test_count__ = 0;
@@ -332,7 +321,7 @@ static FILE *test_xml_output__ = NULL;
 static int test_stat_failed_units__ = 0;
 static int test_stat_run_units__ = 0;
 
-static const struct test__* test_current_unit__ = NULL;
+static const struct test__ *test_current_unit__ = NULL;
 static int test_current_index__ = 0;
 static char test_case_name__[64] = "";
 static int test_current_already_logged__ = 0;
@@ -345,118 +334,121 @@ static int test_timer__ = 0;
 static int test_abort_has_jmp_buf__ = 0;
 static jmp_buf test_abort_jmp_buf__;
 
-#if defined ACUTEST_WIN__
-    typedef LARGE_INTEGER test_timer_type__;
-    static LARGE_INTEGER test_timer_freq__;
-    static test_timer_type__ test_timer_start__;
-    static test_timer_type__ test_timer_end__;
+#    if defined ACUTEST_WIN__
+typedef LARGE_INTEGER test_timer_type__;
+static LARGE_INTEGER test_timer_freq__;
+static test_timer_type__ test_timer_start__;
+static test_timer_type__ test_timer_end__;
 
-    static void
-    test_timer_init__(void)
-    {
-        QueryPerformanceFrequency(&test_timer_freq__);
-    }
+static void
+test_timer_init__(void)
+{
+    QueryPerformanceFrequency(&test_timer_freq__);
+}
 
-    static void
-    test_timer_get_time__(LARGE_INTEGER* ts)
-    {
-        QueryPerformanceCounter(ts);
-    }
+static void
+test_timer_get_time__(LARGE_INTEGER *ts)
+{
+    QueryPerformanceCounter(ts);
+}
 
-    static double
-    test_timer_diff__(LARGE_INTEGER start, LARGE_INTEGER end)
-    {
-        double duration = (double)(end.QuadPart - start.QuadPart);
-        duration /= (double)test_timer_freq__.QuadPart;
-        return duration;
-    }
+static double
+test_timer_diff__(LARGE_INTEGER start, LARGE_INTEGER end)
+{
+    double duration = (double)(end.QuadPart - start.QuadPart);
+    duration /= (double)test_timer_freq__.QuadPart;
+    return duration;
+}
 
-    static void
-    test_timer_print_diff__(void)
-    {
-        printf("%.6lf secs", test_timer_diff__(test_timer_start__, test_timer_end__));
-    }
-#elif defined ACUTEST_HAS_POSIX_TIMER__
-    static clockid_t test_timer_id__;
-    typedef struct timespec test_timer_type__;
-    static test_timer_type__ test_timer_start__;
-    static test_timer_type__ test_timer_end__;
+static void
+test_timer_print_diff__(void)
+{
+    printf(
+        "%.6lf secs", test_timer_diff__(test_timer_start__, test_timer_end__));
+}
+#    elif defined ACUTEST_HAS_POSIX_TIMER__
+static clockid_t test_timer_id__;
+typedef struct timespec test_timer_type__;
+static test_timer_type__ test_timer_start__;
+static test_timer_type__ test_timer_end__;
 
-    static void
-    test_timer_init__(void)
-    {
-        if(test_timer__ == 1)
-            test_timer_id__ = CLOCK_MONOTONIC;
-        else if(test_timer__ == 2)
-            test_timer_id__ = CLOCK_PROCESS_CPUTIME_ID;
-    }
+static void
+test_timer_init__(void)
+{
+    if (test_timer__ == 1)
+        test_timer_id__ = CLOCK_MONOTONIC;
+    else if (test_timer__ == 2)
+        test_timer_id__ = CLOCK_PROCESS_CPUTIME_ID;
+}
 
-    static void
-    test_timer_get_time__(struct timespec* ts)
-    {
-        clock_gettime(test_timer_id__, ts);
-    }
+static void
+test_timer_get_time__(struct timespec *ts)
+{
+    clock_gettime(test_timer_id__, ts);
+}
 
-    static double
-    test_timer_diff__(struct timespec start, struct timespec end)
-    {
-        double endns;
-        double startns;
+static double
+test_timer_diff__(struct timespec start, struct timespec end)
+{
+    double endns;
+    double startns;
 
-        endns = end.tv_sec;
-        endns *= 1e9;
-        endns += end.tv_nsec;
+    endns = end.tv_sec;
+    endns *= 1e9;
+    endns += end.tv_nsec;
 
-        startns = start.tv_sec;
-        startns *= 1e9;
-        startns += start.tv_nsec;
+    startns = start.tv_sec;
+    startns *= 1e9;
+    startns += start.tv_nsec;
 
-        return ((endns - startns)/ 1e9);
-    }
+    return ((endns - startns) / 1e9);
+}
 
-    static void
-    test_timer_print_diff__(void)
-    {
-        printf("%.6lf secs",
-            test_timer_diff__(test_timer_start__, test_timer_end__));
-    }
-#else
-    typedef int test_timer_type__;
-    static test_timer_type__ test_timer_start__;
-    static test_timer_type__ test_timer_end__;
+static void
+test_timer_print_diff__(void)
+{
+    printf(
+        "%.6lf secs", test_timer_diff__(test_timer_start__, test_timer_end__));
+}
+#    else
+typedef int test_timer_type__;
+static test_timer_type__ test_timer_start__;
+static test_timer_type__ test_timer_end__;
 
-    void
-    test_timer_init__(void)
-    {}
+void
+test_timer_init__(void)
+{
+}
 
-    static void
-    test_timer_get_time__(int* ts)
-    {
-        (void) ts;
-    }
+static void
+test_timer_get_time__(int *ts)
+{
+    (void)ts;
+}
 
-    static double
-    test_timer_diff__(int start, int end)
-    {
-        (void) start;
-        (void) end;
-        return 0.0;
-    }
+static double
+test_timer_diff__(int start, int end)
+{
+    (void)start;
+    (void)end;
+    return 0.0;
+}
 
-    static void
-    test_timer_print_diff__(void)
-    {}
-#endif
+static void
+test_timer_print_diff__(void)
+{
+}
+#    endif
 
-#define TEST_COLOR_DEFAULT__            0
-#define TEST_COLOR_GREEN__              1
-#define TEST_COLOR_RED__                2
-#define TEST_COLOR_DEFAULT_INTENSIVE__  3
-#define TEST_COLOR_GREEN_INTENSIVE__    4
-#define TEST_COLOR_RED_INTENSIVE__      5
+#    define TEST_COLOR_DEFAULT__ 0
+#    define TEST_COLOR_GREEN__ 1
+#    define TEST_COLOR_RED__ 2
+#    define TEST_COLOR_DEFAULT_INTENSIVE__ 3
+#    define TEST_COLOR_GREEN_INTENSIVE__ 4
+#    define TEST_COLOR_RED_INTENSIVE__ 5
 
 static int
-test_print_in_color__(int color, const char* fmt, ...)
+test_print_in_color__(int color, const char *fmt, ...)
 {
     va_list args;
     char buffer[256];
@@ -465,29 +457,41 @@ test_print_in_color__(int color, const char* fmt, ...)
     va_start(args, fmt);
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    buffer[sizeof(buffer)-1] = '\0';
+    buffer[sizeof(buffer) - 1] = '\0';
 
-    if(!test_colorize__) {
+    if (!test_colorize__) {
         return printf("%s", buffer);
     }
 
-#if defined ACUTEST_UNIX__
+#    if defined ACUTEST_UNIX__
     {
-        const char* col_str;
-        switch(color) {
-            case TEST_COLOR_GREEN__:             col_str = "\033[0;32m"; break;
-            case TEST_COLOR_RED__:               col_str = "\033[0;31m"; break;
-            case TEST_COLOR_GREEN_INTENSIVE__:   col_str = "\033[1;32m"; break;
-            case TEST_COLOR_RED_INTENSIVE__:     col_str = "\033[1;31m"; break;
-            case TEST_COLOR_DEFAULT_INTENSIVE__: col_str = "\033[1m"; break;
-            default:                             col_str = "\033[0m"; break;
+        const char *col_str;
+        switch (color) {
+        case TEST_COLOR_GREEN__:
+            col_str = "\033[0;32m";
+            break;
+        case TEST_COLOR_RED__:
+            col_str = "\033[0;31m";
+            break;
+        case TEST_COLOR_GREEN_INTENSIVE__:
+            col_str = "\033[1;32m";
+            break;
+        case TEST_COLOR_RED_INTENSIVE__:
+            col_str = "\033[1;31m";
+            break;
+        case TEST_COLOR_DEFAULT_INTENSIVE__:
+            col_str = "\033[1m";
+            break;
+        default:
+            col_str = "\033[0m";
+            break;
         }
         printf("%s", col_str);
         n = printf("%s", buffer);
         printf("\033[0m");
         return n;
     }
-#elif defined ACUTEST_WIN__
+#    elif defined ACUTEST_WIN__
     {
         HANDLE h;
         CONSOLE_SCREEN_BUFFER_INFO info;
@@ -496,41 +500,56 @@ test_print_in_color__(int color, const char* fmt, ...)
         h = GetStdHandle(STD_OUTPUT_HANDLE);
         GetConsoleScreenBufferInfo(h, &info);
 
-        switch(color) {
-            case TEST_COLOR_GREEN__:             attr = FOREGROUND_GREEN; break;
-            case TEST_COLOR_RED__:               attr = FOREGROUND_RED; break;
-            case TEST_COLOR_GREEN_INTENSIVE__:   attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
-            case TEST_COLOR_RED_INTENSIVE__:     attr = FOREGROUND_RED | FOREGROUND_INTENSITY; break;
-            case TEST_COLOR_DEFAULT_INTENSIVE__: attr = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY; break;
-            default:                             attr = 0; break;
+        switch (color) {
+        case TEST_COLOR_GREEN__:
+            attr = FOREGROUND_GREEN;
+            break;
+        case TEST_COLOR_RED__:
+            attr = FOREGROUND_RED;
+            break;
+        case TEST_COLOR_GREEN_INTENSIVE__:
+            attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+            break;
+        case TEST_COLOR_RED_INTENSIVE__:
+            attr = FOREGROUND_RED | FOREGROUND_INTENSITY;
+            break;
+        case TEST_COLOR_DEFAULT_INTENSIVE__:
+            attr = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
+                | FOREGROUND_INTENSITY;
+            break;
+        default:
+            attr = 0;
+            break;
         }
-        if(attr != 0)
+        if (attr != 0)
             SetConsoleTextAttribute(h, attr);
         n = printf("%s", buffer);
         SetConsoleTextAttribute(h, info.wAttributes);
         return n;
     }
-#else
+#    else
     n = printf("%s", buffer);
     return n;
-#endif
+#    endif
 }
 
 static void
-test_begin_test_line__(const struct test__* test)
+test_begin_test_line__(const struct test__ *test)
 {
-    if(!test_tap__) {
-        if(test_verbose_level__ >= 3) {
-            test_print_in_color__(TEST_COLOR_DEFAULT_INTENSIVE__, "Test %s:\n", test->name);
+    if (!test_tap__) {
+        if (test_verbose_level__ >= 3) {
+            test_print_in_color__(
+                TEST_COLOR_DEFAULT_INTENSIVE__, "Test %s:\n", test->name);
             test_current_already_logged__++;
-        } else if(test_verbose_level__ >= 1) {
+        } else if (test_verbose_level__ >= 1) {
             int n;
             char spaces[48];
 
-            n = test_print_in_color__(TEST_COLOR_DEFAULT_INTENSIVE__, "Test %s... ", test->name);
+            n = test_print_in_color__(
+                TEST_COLOR_DEFAULT_INTENSIVE__, "Test %s... ", test->name);
             memset(spaces, ' ', sizeof(spaces));
-            if(n < (int) sizeof(spaces))
-                printf("%.*s", (int) sizeof(spaces) - n, spaces);
+            if (n < (int)sizeof(spaces))
+                printf("%.*s", (int)sizeof(spaces) - n, spaces);
         } else {
             test_current_already_logged__ = 1;
         }
@@ -540,24 +559,26 @@ test_begin_test_line__(const struct test__* test)
 static void
 test_finish_test_line__(int result)
 {
-    if(test_tap__) {
-        const char* str = (result == 0) ? "ok" : "not ok";
+    if (test_tap__) {
+        const char *str = (result == 0) ? "ok" : "not ok";
 
-        printf("%s %u - %s\n", str, test_current_index__ + 1, test_current_unit__->name);
+        printf("%s %u - %s\n", str, test_current_index__ + 1,
+            test_current_unit__->name);
 
-        if(result == 0  &&  test_timer__) {
+        if (result == 0 && test_timer__) {
             printf("# Duration: ");
             test_timer_print_diff__();
             printf("\n");
         }
     } else {
-        int color = (result == 0) ? TEST_COLOR_GREEN_INTENSIVE__ : TEST_COLOR_RED_INTENSIVE__;
-        const char* str = (result == 0) ? "OK" : "FAILED";
+        int color = (result == 0) ? TEST_COLOR_GREEN_INTENSIVE__
+                                  : TEST_COLOR_RED_INTENSIVE__;
+        const char *str = (result == 0) ? "OK" : "FAILED";
         printf("[ ");
         test_print_in_color__(color, str);
         printf(" ]");
 
-        if(result == 0  &&  test_timer__) {
+        if (result == 0 && test_timer__) {
             printf("  ");
             test_timer_print_diff__();
         }
@@ -572,12 +593,12 @@ test_line_indent__(int level)
     static const char spaces[] = "                ";
     int n = level * 2;
 
-    if(test_tap__  &&  n > 0) {
+    if (test_tap__ && n > 0) {
         n--;
         printf("#");
     }
 
-    while(n > 16) {
+    while (n > 16) {
         printf("%s", spaces);
         n -= 16;
     }
@@ -585,18 +606,18 @@ test_line_indent__(int level)
 }
 
 int
-test_check__(int cond, const char* file, int line, const char* fmt, ...)
+test_check__(int cond, const char *file, int line, const char *fmt, ...)
 {
     const char *result_str;
     int result_color;
     int verbose_level;
 
-    if(cond) {
+    if (cond) {
         result_str = "ok";
         result_color = TEST_COLOR_GREEN__;
         verbose_level = 3;
     } else {
-        if(!test_current_already_logged__  &&  test_current_unit__ != NULL)
+        if (!test_current_already_logged__ && test_current_unit__ != NULL)
             test_finish_test_line__(-1);
 
         result_str = "failed";
@@ -606,32 +627,33 @@ test_check__(int cond, const char* file, int line, const char* fmt, ...)
         test_current_already_logged__++;
     }
 
-    if(test_verbose_level__ >= verbose_level) {
+    if (test_verbose_level__ >= verbose_level) {
         va_list args;
 
-        if(!test_case_current_already_logged__  &&  test_case_name__[0]) {
+        if (!test_case_current_already_logged__ && test_case_name__[0]) {
             test_line_indent__(1);
-            test_print_in_color__(TEST_COLOR_DEFAULT_INTENSIVE__, "Case %s:\n", test_case_name__);
+            test_print_in_color__(
+                TEST_COLOR_DEFAULT_INTENSIVE__, "Case %s:\n", test_case_name__);
             test_current_already_logged__++;
             test_case_current_already_logged__++;
         }
 
         test_line_indent__(test_case_name__[0] ? 2 : 1);
-        if(file != NULL) {
-            if(test_verbose_level__ < 3) {
-#ifdef ACUTEST_WIN__
-                const char* lastsep1 = strrchr(file, '\\');
-                const char* lastsep2 = strrchr(file, '/');
-                if(lastsep1 == NULL)
-                    lastsep1 = file-1;
-                if(lastsep2 == NULL)
-                    lastsep2 = file-1;
+        if (file != NULL) {
+            if (test_verbose_level__ < 3) {
+#    ifdef ACUTEST_WIN__
+                const char *lastsep1 = strrchr(file, '\\');
+                const char *lastsep2 = strrchr(file, '/');
+                if (lastsep1 == NULL)
+                    lastsep1 = file - 1;
+                if (lastsep2 == NULL)
+                    lastsep2 = file - 1;
                 file = (lastsep1 > lastsep2 ? lastsep1 : lastsep2) + 1;
-#else
-                const char* lastsep = strrchr(file, '/');
-                if(lastsep != NULL)
-                    file = lastsep+1;
-#endif
+#    else
+                const char *lastsep = strrchr(file, '/');
+                if (lastsep != NULL)
+                    file = lastsep + 1;
+#    endif
             }
             printf("%s:%d: Check ", file, line);
         }
@@ -651,19 +673,19 @@ test_check__(int cond, const char* file, int line, const char* fmt, ...)
 }
 
 void
-test_case__(const char* fmt, ...)
+test_case__(const char *fmt, ...)
 {
     va_list args;
 
-    if(test_verbose_level__ < 2)
+    if (test_verbose_level__ < 2)
         return;
 
-    if(test_case_name__[0]) {
+    if (test_case_name__[0]) {
         test_case_current_already_logged__ = 0;
         test_case_name__[0] = '\0';
     }
 
-    if(fmt == NULL)
+    if (fmt == NULL)
         return;
 
     va_start(args, fmt);
@@ -671,90 +693,91 @@ test_case__(const char* fmt, ...)
     va_end(args);
     test_case_name__[sizeof(test_case_name__) - 1] = '\0';
 
-    if(test_verbose_level__ >= 3) {
+    if (test_verbose_level__ >= 3) {
         test_line_indent__(1);
-        test_print_in_color__(TEST_COLOR_DEFAULT_INTENSIVE__, "Case %s:\n", test_case_name__);
+        test_print_in_color__(
+            TEST_COLOR_DEFAULT_INTENSIVE__, "Case %s:\n", test_case_name__);
         test_current_already_logged__++;
         test_case_current_already_logged__++;
     }
 }
 
 void
-test_message__(const char* fmt, ...)
+test_message__(const char *fmt, ...)
 {
     char buffer[TEST_MSG_MAXSIZE];
-    char* line_beg;
-    char* line_end;
+    char *line_beg;
+    char *line_end;
     va_list args;
 
-    if(test_verbose_level__ < 2)
+    if (test_verbose_level__ < 2)
         return;
 
     /* We allow extra message only when something is already wrong in the
      * current test. */
-    if(test_current_unit__ == NULL  ||  !test_cond_failed__)
+    if (test_current_unit__ == NULL || !test_cond_failed__)
         return;
 
     va_start(args, fmt);
     vsnprintf(buffer, TEST_MSG_MAXSIZE, fmt, args);
     va_end(args);
-    buffer[TEST_MSG_MAXSIZE-1] = '\0';
+    buffer[TEST_MSG_MAXSIZE - 1] = '\0';
 
     line_beg = buffer;
-    while(1) {
+    while (1) {
         line_end = strchr(line_beg, '\n');
-        if(line_end == NULL)
+        if (line_end == NULL)
             break;
         test_line_indent__(test_case_name__[0] ? 3 : 2);
         printf("%.*s\n", (int)(line_end - line_beg), line_beg);
         line_beg = line_end + 1;
     }
-    if(line_beg[0] != '\0') {
+    if (line_beg[0] != '\0') {
         test_line_indent__(test_case_name__[0] ? 3 : 2);
         printf("%s\n", line_beg);
     }
 }
 
 void
-test_dump__(const char* title, const void* addr, size_t size)
+test_dump__(const char *title, const void *addr, size_t size)
 {
     static const size_t BYTES_PER_LINE = 16;
     size_t line_beg;
     size_t truncate = 0;
 
-    if(test_verbose_level__ < 2)
+    if (test_verbose_level__ < 2)
         return;
 
     /* We allow extra message only when something is already wrong in the
      * current test. */
-    if(test_current_unit__ == NULL  ||  !test_cond_failed__)
+    if (test_current_unit__ == NULL || !test_cond_failed__)
         return;
 
-    if(size > TEST_DUMP_MAXSIZE) {
+    if (size > TEST_DUMP_MAXSIZE) {
         truncate = size - TEST_DUMP_MAXSIZE;
         size = TEST_DUMP_MAXSIZE;
     }
 
     test_line_indent__(test_case_name__[0] ? 3 : 2);
-    printf((title[strlen(title)-1] == ':') ? "%s\n" : "%s:\n", title);
+    printf((title[strlen(title) - 1] == ':') ? "%s\n" : "%s:\n", title);
 
-    for(line_beg = 0; line_beg < size; line_beg += BYTES_PER_LINE) {
+    for (line_beg = 0; line_beg < size; line_beg += BYTES_PER_LINE) {
         size_t line_end = line_beg + BYTES_PER_LINE;
         size_t off;
 
         test_line_indent__(test_case_name__[0] ? 4 : 3);
         printf("%08lx: ", (unsigned long)line_beg);
-        for(off = line_beg; off < line_end; off++) {
-            if(off < size)
-                printf(" %02x", ((unsigned char*)addr)[off]);
+        for (off = line_beg; off < line_end; off++) {
+            if (off < size)
+                printf(" %02x", ((unsigned char *)addr)[off]);
             else
                 printf("   ");
         }
 
         printf("  ");
-        for(off = line_beg; off < line_end; off++) {
-            unsigned char byte = ((unsigned char*)addr)[off];
-            if(off < size)
+        for (off = line_beg; off < line_end; off++) {
+            unsigned char byte = ((unsigned char *)addr)[off];
+            if (off < size)
                 printf("%c", (iscntrl(byte) ? '.' : byte));
             else
                 break;
@@ -763,16 +786,16 @@ test_dump__(const char* title, const void* addr, size_t size)
         printf("\n");
     }
 
-    if(truncate > 0) {
+    if (truncate > 0) {
         test_line_indent__(test_case_name__[0] ? 4 : 3);
-        printf("           ... (and more %u bytes)\n", (unsigned) truncate);
+        printf("           ... (and more %u bytes)\n", (unsigned)truncate);
     }
 }
 
 void
 test_abort__(void)
 {
-    if(test_abort_has_jmp_buf__)
+    if (test_abort_has_jmp_buf__)
         longjmp(test_abort_jmp_buf__, 1);
     else
         abort();
@@ -781,17 +804,17 @@ test_abort__(void)
 static void
 test_list_names__(void)
 {
-    const struct test__* test;
+    const struct test__ *test;
 
     printf("Unit tests:\n");
-    for(test = &test_list__[0]; test->func != NULL; test++)
+    for (test = &test_list__[0]; test->func != NULL; test++)
         printf("  %s\n", test->name);
 }
 
 static void
 test_remember__(int i)
 {
-    if(test_details__[i].flags & TEST_FLAG_RUN__)
+    if (test_details__[i].flags & TEST_FLAG_RUN__)
         return;
 
     test_details__[i].flags |= TEST_FLAG_RUN__;
@@ -801,7 +824,8 @@ test_remember__(int i)
 static void
 test_set_success__(int i, int success)
 {
-    test_details__[i].flags |= success ? TEST_FLAG_SUCCESS__ : TEST_FLAG_FAILURE__;
+    test_details__[i].flags
+        |= success ? TEST_FLAG_SUCCESS__ : TEST_FLAG_FAILURE__;
 }
 
 static void
@@ -811,10 +835,10 @@ test_set_duration__(int i, double duration)
 }
 
 static int
-test_name_contains_word__(const char* name, const char* pattern)
+test_name_contains_word__(const char *name, const char *pattern)
 {
     static const char word_delim[] = " \t-_.";
-    const char* substr;
+    const char *substr;
     size_t pattern_len;
     int starts_on_word_boundary;
     int ends_on_word_boundary;
@@ -822,49 +846,51 @@ test_name_contains_word__(const char* name, const char* pattern)
     pattern_len = strlen(pattern);
 
     substr = strstr(name, pattern);
-    while(substr != NULL) {
-        starts_on_word_boundary = (substr == name || strchr(word_delim, substr[-1]) != NULL);
-        ends_on_word_boundary = (substr[pattern_len] == '\0' || strchr(word_delim, substr[pattern_len]) != NULL);
+    while (substr != NULL) {
+        starts_on_word_boundary
+            = (substr == name || strchr(word_delim, substr[-1]) != NULL);
+        ends_on_word_boundary = (substr[pattern_len] == '\0'
+            || strchr(word_delim, substr[pattern_len]) != NULL);
 
-        if(starts_on_word_boundary && ends_on_word_boundary)
+        if (starts_on_word_boundary && ends_on_word_boundary)
             return 1;
 
-        substr = strstr(substr+1, pattern);
+        substr = strstr(substr + 1, pattern);
     }
 
     return 0;
 }
 
 static int
-test_lookup__(const char* pattern)
+test_lookup__(const char *pattern)
 {
     int i;
     int n = 0;
 
     /* Try exact match. */
-    for(i = 0; i < (int) test_list_size__; i++) {
-        if(strcmp(test_list__[i].name, pattern) == 0) {
+    for (i = 0; i < (int)test_list_size__; i++) {
+        if (strcmp(test_list__[i].name, pattern) == 0) {
             test_remember__(i);
             n++;
             break;
         }
     }
-    if(n > 0)
+    if (n > 0)
         return n;
 
     /* Try word match. */
-    for(i = 0; i < (int) test_list_size__; i++) {
-        if(test_name_contains_word__(test_list__[i].name, pattern)) {
+    for (i = 0; i < (int)test_list_size__; i++) {
+        if (test_name_contains_word__(test_list__[i].name, pattern)) {
             test_remember__(i);
             n++;
         }
     }
-    if(n > 0)
+    if (n > 0)
         return n;
 
     /* Try relaxed match. */
-    for(i = 0; i < (int) test_list_size__; i++) {
-        if(strstr(test_list__[i].name, pattern) != NULL) {
+    for (i = 0; i < (int)test_list_size__; i++) {
+        if (strstr(test_list__[i].name, pattern) != NULL) {
             test_remember__(i);
             n++;
         }
@@ -873,21 +899,20 @@ test_lookup__(const char* pattern)
     return n;
 }
 
-
 /* Called if anything goes bad in Acutest, or if the unit test ends in other
  * way then by normal returning from its function (e.g. exception or some
  * abnormal child process termination). */
 static void
-test_error__(const char* fmt, ...)
+test_error__(const char *fmt, ...)
 {
     va_list args;
 
-    if(test_verbose_level__ == 0)
+    if (test_verbose_level__ == 0)
         return;
 
-    if(test_verbose_level__ >= 2) {
+    if (test_verbose_level__ >= 2) {
         test_line_indent__(1);
-        if(test_verbose_level__ >= 3)
+        if (test_verbose_level__ >= 3)
             test_print_in_color__(TEST_COLOR_RED_INTENSIVE__, "ERROR: ");
         va_start(args, fmt);
         vprintf(fmt, args);
@@ -895,14 +920,14 @@ test_error__(const char* fmt, ...)
         printf("\n");
     }
 
-    if(test_verbose_level__ >= 3) {
+    if (test_verbose_level__ >= 3) {
         printf("\n");
     }
 }
 
 /* Call directly the given test unit function. */
 static int
-test_do_run__(const struct test__* test, int index)
+test_do_run__(const struct test__ *test, int index)
 {
     test_was_aborted__ = 0;
     test_current_unit__ = test;
@@ -913,17 +938,17 @@ test_do_run__(const struct test__* test, int index)
 
     test_begin_test_line__(test);
 
-#ifdef __cplusplus
+#    ifdef __cplusplus
     try {
-#endif
+#    endif
 
         /* This is good to do for case the test unit e.g. crashes. */
         fflush(stdout);
         fflush(stderr);
 
-        if(!test_worker__) {
+        if (!test_worker__) {
             test_abort_has_jmp_buf__ = 1;
-            if(setjmp(test_abort_jmp_buf__) != 0) {
+            if (setjmp(test_abort_jmp_buf__) != 0) {
                 test_was_aborted__ = 1;
                 goto aborted;
             }
@@ -931,17 +956,18 @@ test_do_run__(const struct test__* test, int index)
 
         test_timer_get_time__(&test_timer_start__);
         test->func();
-aborted:
+    aborted:
         test_abort_has_jmp_buf__ = 0;
         test_timer_get_time__(&test_timer_end__);
 
-        if(test_verbose_level__ >= 3) {
+        if (test_verbose_level__ >= 3) {
             test_line_indent__(1);
-            if(test_current_failures__ == 0) {
-                test_print_in_color__(TEST_COLOR_GREEN_INTENSIVE__, "SUCCESS: ");
+            if (test_current_failures__ == 0) {
+                test_print_in_color__(
+                    TEST_COLOR_GREEN_INTENSIVE__, "SUCCESS: ");
                 printf("All conditions have passed.\n");
 
-                if(test_timer__) {
+                if (test_timer__) {
                     test_line_indent__(1);
                     printf("Duration: ");
                     test_timer_print_diff__();
@@ -949,17 +975,17 @@ aborted:
                 }
             } else {
                 test_print_in_color__(TEST_COLOR_RED_INTENSIVE__, "FAILED: ");
-                if(!test_was_aborted__) {
+                if (!test_was_aborted__) {
                     printf("%d condition%s %s failed.\n",
-                            test_current_failures__,
-                            (test_current_failures__ == 1) ? "" : "s",
-                            (test_current_failures__ == 1) ? "has" : "have");
+                        test_current_failures__,
+                        (test_current_failures__ == 1) ? "" : "s",
+                        (test_current_failures__ == 1) ? "has" : "have");
                 } else {
                     printf("Aborted.\n");
                 }
             }
             printf("\n");
-        } else if(test_verbose_level__ >= 1 && test_current_failures__ == 0) {
+        } else if (test_verbose_level__ >= 1 && test_current_failures__ == 0) {
             test_finish_test_line__(0);
         }
 
@@ -967,24 +993,24 @@ aborted:
         test_current_unit__ = NULL;
         return (test_current_failures__ == 0) ? 0 : -1;
 
-#ifdef __cplusplus
-    } catch(std::exception& e) {
-        const char* what = e.what();
+#    ifdef __cplusplus
+    } catch (std::exception &e) {
+        const char *what = e.what();
         test_check__(0, NULL, 0, "Threw std::exception");
-        if(what != NULL)
+        if (what != NULL)
             test_message__("std::exception::what(): %s", what);
 
-        if(test_verbose_level__ >= 3) {
+        if (test_verbose_level__ >= 3) {
             test_line_indent__(1);
             test_print_in_color__(TEST_COLOR_RED_INTENSIVE__, "FAILED: ");
             printf("C++ exception.\n\n");
         }
 
         return -1;
-    } catch(...) {
+    } catch (...) {
         test_check__(0, NULL, 0, "Threw an exception");
 
-        if(test_verbose_level__ >= 3) {
+        if (test_verbose_level__ >= 3) {
             test_line_indent__(1);
             test_print_in_color__(TEST_COLOR_RED_INTENSIVE__, "FAILED: ");
             printf("C++ exception.\n\n");
@@ -992,14 +1018,14 @@ aborted:
 
         return -1;
     }
-#endif
+#    endif
 }
 
 /* Trigger the unit test. If possible (and not suppressed) it starts a child
  * process who calls test_do_run__(), otherwise it calls test_do_run__()
  * directly. */
 static void
-test_run__(const struct test__* test, int index, int master_index)
+test_run__(const struct test__ *test, int index, int master_index)
 {
     int failed = 1;
     test_timer_type__ start, end;
@@ -1008,9 +1034,9 @@ test_run__(const struct test__* test, int index, int master_index)
     test_current_already_logged__ = 0;
     test_timer_get_time__(&start);
 
-    if(!test_no_exec__) {
+    if (!test_no_exec__) {
 
-#if defined(ACUTEST_UNIX__)
+#    if defined(ACUTEST_UNIX__)
 
         pid_t pid;
         int exit_code;
@@ -1020,10 +1046,10 @@ test_run__(const struct test__* test, int index, int master_index)
         fflush(stderr);
 
         pid = fork();
-        if(pid == (pid_t)-1) {
+        if (pid == (pid_t)-1) {
             test_error__("Cannot fork. %s [%d]", strerror(errno), errno);
             failed = 1;
-        } else if(pid == 0) {
+        } else if (pid == 0) {
             /* Child: Do the test. */
             test_worker__ = 1;
             failed = (test_do_run__(test, index) != 0);
@@ -1031,73 +1057,107 @@ test_run__(const struct test__* test, int index, int master_index)
         } else {
             /* Parent: Wait until child terminates and analyze its exit code. */
             waitpid(pid, &exit_code, 0);
-            if(WIFEXITED(exit_code)) {
-                switch(WEXITSTATUS(exit_code)) {
-                    case 0:   failed = 0; break;   /* test has passed. */
-                    case 1:   /* noop */ break;    /* "normal" failure. */
-                    default:  test_error__("Unexpected exit code [%d]", WEXITSTATUS(exit_code));
+            if (WIFEXITED(exit_code)) {
+                switch (WEXITSTATUS(exit_code)) {
+                case 0:
+                    failed = 0;
+                    break; /* test has passed. */
+                case 1: /* noop */
+                    break; /* "normal" failure. */
+                default:
+                    test_error__(
+                        "Unexpected exit code [%d]", WEXITSTATUS(exit_code));
                 }
-            } else if(WIFSIGNALED(exit_code)) {
+            } else if (WIFSIGNALED(exit_code)) {
                 char tmp[32];
-                const char* signame;
-                switch(WTERMSIG(exit_code)) {
-                    case SIGINT:  signame = "SIGINT"; break;
-                    case SIGHUP:  signame = "SIGHUP"; break;
-                    case SIGQUIT: signame = "SIGQUIT"; break;
-                    case SIGABRT: signame = "SIGABRT"; break;
-                    case SIGKILL: signame = "SIGKILL"; break;
-                    case SIGSEGV: signame = "SIGSEGV"; break;
-                    case SIGILL:  signame = "SIGILL"; break;
-                    case SIGTERM: signame = "SIGTERM"; break;
-                    default:      sprintf(tmp, "signal %d", WTERMSIG(exit_code)); signame = tmp; break;
+                const char *signame;
+                switch (WTERMSIG(exit_code)) {
+                case SIGINT:
+                    signame = "SIGINT";
+                    break;
+                case SIGHUP:
+                    signame = "SIGHUP";
+                    break;
+                case SIGQUIT:
+                    signame = "SIGQUIT";
+                    break;
+                case SIGABRT:
+                    signame = "SIGABRT";
+                    break;
+                case SIGKILL:
+                    signame = "SIGKILL";
+                    break;
+                case SIGSEGV:
+                    signame = "SIGSEGV";
+                    break;
+                case SIGILL:
+                    signame = "SIGILL";
+                    break;
+                case SIGTERM:
+                    signame = "SIGTERM";
+                    break;
+                default:
+                    sprintf(tmp, "signal %d", WTERMSIG(exit_code));
+                    signame = tmp;
+                    break;
                 }
                 test_error__("Test interrupted by %s.", signame);
             } else {
-                test_error__("Test ended in an unexpected way [%d].", exit_code);
+                test_error__(
+                    "Test ended in an unexpected way [%d].", exit_code);
             }
         }
 
-#elif defined(ACUTEST_WIN__)
+#    elif defined(ACUTEST_WIN__)
 
-        char buffer[512] = {0};
+        char buffer[512] = { 0 };
         STARTUPINFOA startupInfo;
         PROCESS_INFORMATION processInfo;
         DWORD exitCode;
 
         /* Windows has no fork(). So we propagate all info into the child
          * through a command line arguments. */
-        _snprintf(buffer, sizeof(buffer)-1,
-                 "%s --worker=%d %s --no-exec --no-summary %s --verbose=%d --color=%s -- \"%s\"",
-                 test_argv0__, index, test_timer__ ? "--timer" : "",
-                 test_tap__ ? "--tap" : "", test_verbose_level__,
-                 test_colorize__ ? "always" : "never",
-                 test->name);
+        _snprintf(buffer, sizeof(buffer) - 1,
+            "%s --worker=%d %s --no-exec --no-summary %s --verbose=%d "
+            "--color=%s -- \"%s\"",
+            test_argv0__, index, test_timer__ ? "--timer" : "",
+            test_tap__ ? "--tap" : "", test_verbose_level__,
+            test_colorize__ ? "always" : "never", test->name);
         memset(&startupInfo, 0, sizeof(startupInfo));
         startupInfo.cb = sizeof(STARTUPINFO);
-        if(CreateProcessA(NULL, buffer, NULL, NULL, FALSE, 0, NULL, NULL, &startupInfo, &processInfo)) {
+        if (CreateProcessA(NULL, buffer, NULL, NULL, FALSE, 0, NULL, NULL,
+                &startupInfo, &processInfo)) {
             WaitForSingleObject(processInfo.hProcess, INFINITE);
             GetExitCodeProcess(processInfo.hProcess, &exitCode);
             CloseHandle(processInfo.hThread);
             CloseHandle(processInfo.hProcess);
             failed = (exitCode != 0);
-            if(exitCode > 1) {
-                switch(exitCode) {
-                    case 3:             test_error__("Aborted."); break;
-                    case 0xC0000005:    test_error__("Access violation."); break;
-                    default:            test_error__("Test ended in an unexpected way [%lu].", exitCode); break;
+            if (exitCode > 1) {
+                switch (exitCode) {
+                case 3:
+                    test_error__("Aborted.");
+                    break;
+                case 0xC0000005:
+                    test_error__("Access violation.");
+                    break;
+                default:
+                    test_error__(
+                        "Test ended in an unexpected way [%lu].", exitCode);
+                    break;
                 }
             }
         } else {
-            test_error__("Cannot create unit test subprocess [%ld].", GetLastError());
+            test_error__(
+                "Cannot create unit test subprocess [%ld].", GetLastError());
             failed = 1;
         }
 
-#else
+#    else
 
         /* A platform where we don't know how to run child process. */
         failed = (test_do_run__(test, index) != 0);
 
-#endif
+#    endif
 
     } else {
         /* Child processes suppressed through --no-exec. */
@@ -1108,61 +1168,62 @@ test_run__(const struct test__* test, int index, int master_index)
     test_current_unit__ = NULL;
 
     test_stat_run_units__++;
-    if(failed)
+    if (failed)
         test_stat_failed_units__++;
 
     test_set_success__(master_index, !failed);
     test_set_duration__(master_index, test_timer_diff__(start, end));
 }
 
-#if defined(ACUTEST_WIN__)
+#    if defined(ACUTEST_WIN__)
 /* Callback for SEH events. */
 static LONG CALLBACK
 test_seh_exception_filter__(EXCEPTION_POINTERS *ptrs)
 {
     test_check__(0, NULL, 0, "Unhandled SEH exception");
-    test_message__("Exception code:    0x%08lx", ptrs->ExceptionRecord->ExceptionCode);
-    test_message__("Exception address: 0x%p", ptrs->ExceptionRecord->ExceptionAddress);
+    test_message__(
+        "Exception code:    0x%08lx", ptrs->ExceptionRecord->ExceptionCode);
+    test_message__(
+        "Exception address: 0x%p", ptrs->ExceptionRecord->ExceptionAddress);
 
     fflush(stdout);
     fflush(stderr);
 
     return EXCEPTION_EXECUTE_HANDLER;
 }
-#endif
+#    endif
 
+#    define TEST_CMDLINE_OPTFLAG_OPTIONALARG__ 0x0001
+#    define TEST_CMDLINE_OPTFLAG_REQUIREDARG__ 0x0002
 
-#define TEST_CMDLINE_OPTFLAG_OPTIONALARG__      0x0001
-#define TEST_CMDLINE_OPTFLAG_REQUIREDARG__      0x0002
-
-#define TEST_CMDLINE_OPTID_NONE__               0
-#define TEST_CMDLINE_OPTID_UNKNOWN__            (-0x7fffffff + 0)
-#define TEST_CMDLINE_OPTID_MISSINGARG__         (-0x7fffffff + 1)
-#define TEST_CMDLINE_OPTID_BOGUSARG__           (-0x7fffffff + 2)
+#    define TEST_CMDLINE_OPTID_NONE__ 0
+#    define TEST_CMDLINE_OPTID_UNKNOWN__ (-0x7fffffff + 0)
+#    define TEST_CMDLINE_OPTID_MISSINGARG__ (-0x7fffffff + 1)
+#    define TEST_CMDLINE_OPTID_BOGUSARG__ (-0x7fffffff + 2)
 
 typedef struct TEST_CMDLINE_OPTION__ {
     char shortname;
-    const char* longname;
+    const char *longname;
     int id;
     unsigned flags;
 } TEST_CMDLINE_OPTION__;
 
 static int
-test_cmdline_handle_short_opt_group__(const TEST_CMDLINE_OPTION__* options,
-                    const char* arggroup,
-                    int (*callback)(int /*optval*/, const char* /*arg*/))
+test_cmdline_handle_short_opt_group__(const TEST_CMDLINE_OPTION__ *options,
+    const char *arggroup, int (*callback)(int /*optval*/, const char * /*arg*/))
 {
-    const TEST_CMDLINE_OPTION__* opt;
+    const TEST_CMDLINE_OPTION__ *opt;
     int i;
     int ret = 0;
 
-    for(i = 0; arggroup[i] != '\0'; i++) {
-        for(opt = options; opt->id != 0; opt++) {
-            if(arggroup[i] == opt->shortname)
+    for (i = 0; arggroup[i] != '\0'; i++) {
+        for (opt = options; opt->id != 0; opt++) {
+            if (arggroup[i] == opt->shortname)
                 break;
         }
 
-        if(opt->id != 0  &&  !(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG__)) {
+        if (opt->id != 0
+            && !(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG__)) {
             ret = callback(opt->id, NULL);
         } else {
             /* Unknown option. */
@@ -1170,106 +1231,115 @@ test_cmdline_handle_short_opt_group__(const TEST_CMDLINE_OPTION__* options,
             badoptname[0] = '-';
             badoptname[1] = arggroup[i];
             badoptname[2] = '\0';
-            ret = callback((opt->id != 0 ? TEST_CMDLINE_OPTID_MISSINGARG__ : TEST_CMDLINE_OPTID_UNKNOWN__),
-                            badoptname);
+            ret = callback((opt->id != 0 ? TEST_CMDLINE_OPTID_MISSINGARG__
+                                         : TEST_CMDLINE_OPTID_UNKNOWN__),
+                badoptname);
         }
 
-        if(ret != 0)
+        if (ret != 0)
             break;
     }
 
     return ret;
 }
 
-#define TEST_CMDLINE_AUXBUF_SIZE__  32
+#    define TEST_CMDLINE_AUXBUF_SIZE__ 32
 
 static int
-test_cmdline_read__(const TEST_CMDLINE_OPTION__* options, int argc, char** argv,
-                    int (*callback)(int /*optval*/, const char* /*arg*/))
+test_cmdline_read__(const TEST_CMDLINE_OPTION__ *options, int argc, char **argv,
+    int (*callback)(int /*optval*/, const char * /*arg*/))
 {
 
-    const TEST_CMDLINE_OPTION__* opt;
-    char auxbuf[TEST_CMDLINE_AUXBUF_SIZE__+1];
+    const TEST_CMDLINE_OPTION__ *opt;
+    char auxbuf[TEST_CMDLINE_AUXBUF_SIZE__ + 1];
     int after_doubledash = 0;
     int i = 1;
     int ret = 0;
 
     auxbuf[TEST_CMDLINE_AUXBUF_SIZE__] = '\0';
 
-    while(i < argc) {
-        if(after_doubledash  ||  strcmp(argv[i], "-") == 0) {
+    while (i < argc) {
+        if (after_doubledash || strcmp(argv[i], "-") == 0) {
             /* Non-option argument. */
             ret = callback(TEST_CMDLINE_OPTID_NONE__, argv[i]);
-        } else if(strcmp(argv[i], "--") == 0) {
-            /* End of options. All the remaining members are non-option arguments. */
+        } else if (strcmp(argv[i], "--") == 0) {
+            /* End of options. All the remaining members are non-option
+             * arguments. */
             after_doubledash = 1;
-        } else if(argv[i][0] != '-') {
+        } else if (argv[i][0] != '-') {
             /* Non-option argument. */
             ret = callback(TEST_CMDLINE_OPTID_NONE__, argv[i]);
         } else {
-            for(opt = options; opt->id != 0; opt++) {
-                if(opt->longname != NULL  &&  strncmp(argv[i], "--", 2) == 0) {
+            for (opt = options; opt->id != 0; opt++) {
+                if (opt->longname != NULL && strncmp(argv[i], "--", 2) == 0) {
                     size_t len = strlen(opt->longname);
-                    if(strncmp(argv[i]+2, opt->longname, len) == 0) {
+                    if (strncmp(argv[i] + 2, opt->longname, len) == 0) {
                         /* Regular long option. */
-                        if(argv[i][2+len] == '\0') {
+                        if (argv[i][2 + len] == '\0') {
                             /* with no argument provided. */
-                            if(!(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG__))
+                            if (!(opt->flags
+                                    & TEST_CMDLINE_OPTFLAG_REQUIREDARG__))
                                 ret = callback(opt->id, NULL);
                             else
-                                ret = callback(TEST_CMDLINE_OPTID_MISSINGARG__, argv[i]);
+                                ret = callback(
+                                    TEST_CMDLINE_OPTID_MISSINGARG__, argv[i]);
                             break;
-                        } else if(argv[i][2+len] == '=') {
+                        } else if (argv[i][2 + len] == '=') {
                             /* with an argument provided. */
-                            if(opt->flags & (TEST_CMDLINE_OPTFLAG_OPTIONALARG__ | TEST_CMDLINE_OPTFLAG_REQUIREDARG__)) {
-                                ret = callback(opt->id, argv[i]+2+len+1);
+                            if (opt->flags
+                                & (TEST_CMDLINE_OPTFLAG_OPTIONALARG__
+                                    | TEST_CMDLINE_OPTFLAG_REQUIREDARG__)) {
+                                ret = callback(opt->id, argv[i] + 2 + len + 1);
                             } else {
                                 sprintf(auxbuf, "--%s", opt->longname);
-                                ret = callback(TEST_CMDLINE_OPTID_BOGUSARG__, auxbuf);
+                                ret = callback(
+                                    TEST_CMDLINE_OPTID_BOGUSARG__, auxbuf);
                             }
                             break;
                         } else {
                             continue;
                         }
                     }
-                } else if(opt->shortname != '\0'  &&  argv[i][0] == '-') {
-                    if(argv[i][1] == opt->shortname) {
+                } else if (opt->shortname != '\0' && argv[i][0] == '-') {
+                    if (argv[i][1] == opt->shortname) {
                         /* Regular short option. */
-                        if(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG__) {
-                            if(argv[i][2] != '\0')
-                                ret = callback(opt->id, argv[i]+2);
-                            else if(i+1 < argc)
+                        if (opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG__) {
+                            if (argv[i][2] != '\0')
+                                ret = callback(opt->id, argv[i] + 2);
+                            else if (i + 1 < argc)
                                 ret = callback(opt->id, argv[++i]);
                             else
-                                ret = callback(TEST_CMDLINE_OPTID_MISSINGARG__, argv[i]);
+                                ret = callback(
+                                    TEST_CMDLINE_OPTID_MISSINGARG__, argv[i]);
                             break;
                         } else {
                             ret = callback(opt->id, NULL);
 
                             /* There might be more (argument-less) short options
                              * grouped together. */
-                            if(ret == 0  &&  argv[i][2] != '\0')
-                                ret = test_cmdline_handle_short_opt_group__(options, argv[i]+2, callback);
+                            if (ret == 0 && argv[i][2] != '\0')
+                                ret = test_cmdline_handle_short_opt_group__(
+                                    options, argv[i] + 2, callback);
                             break;
                         }
                     }
                 }
             }
 
-            if(opt->id == 0) {  /* still not handled? */
-                if(argv[i][0] != '-') {
+            if (opt->id == 0) { /* still not handled? */
+                if (argv[i][0] != '-') {
                     /* Non-option argument. */
                     ret = callback(TEST_CMDLINE_OPTID_NONE__, argv[i]);
                 } else {
                     /* Unknown option. */
-                    char* badoptname = argv[i];
+                    char *badoptname = argv[i];
 
-                    if(strncmp(badoptname, "--", 2) == 0) {
+                    if (strncmp(badoptname, "--", 2) == 0) {
                         /* Strip any argument from the long option. */
-                        char* assignment = strchr(badoptname, '=');
-                        if(assignment != NULL) {
+                        char *assignment = strchr(badoptname, '=');
+                        if (assignment != NULL) {
                             size_t len = assignment - badoptname;
-                            if(len > TEST_CMDLINE_AUXBUF_SIZE__)
+                            if (len > TEST_CMDLINE_AUXBUF_SIZE__)
                                 len = TEST_CMDLINE_AUXBUF_SIZE__;
                             strncpy(auxbuf, badoptname, len);
                             auxbuf[len] = '\0';
@@ -1282,7 +1352,7 @@ test_cmdline_read__(const TEST_CMDLINE_OPTION__* options, int argc, char** argv,
             }
         }
 
-        if(ret != 0)
+        if (ret != 0)
             return ret;
         i++;
     }
@@ -1295,23 +1365,30 @@ test_help__(void)
 {
     printf("Usage: %s [options] [test...]\n", test_argv0__);
     printf("\n");
-    printf("Run the specified unit tests; or if the option '--skip' is used, run all\n");
-    printf("tests in the suite but those listed.  By default, if no tests are specified\n");
+    printf("Run the specified unit tests; or if the option '--skip' is used, "
+           "run all\n");
+    printf("tests in the suite but those listed.  By default, if no tests are "
+           "specified\n");
     printf("on the command line, all unit tests in the suite are run.\n");
     printf("\n");
     printf("Options:\n");
-    printf("  -s, --skip            Execute all unit tests but the listed ones\n");
-    printf("      --exec[=WHEN]     If supported, execute unit tests as child processes\n");
-    printf("                          (WHEN is one of 'auto', 'always', 'never')\n");
+    printf(
+        "  -s, --skip            Execute all unit tests but the listed ones\n");
+    printf("      --exec[=WHEN]     If supported, execute unit tests as child "
+           "processes\n");
+    printf("                          (WHEN is one of 'auto', 'always', "
+           "'never')\n");
     printf("  -E, --no-exec         Same as --exec=never\n");
-#if defined ACUTEST_WIN__
+#    if defined ACUTEST_WIN__
     printf("  -t, --timer           Measure test duration\n");
-#elif defined ACUTEST_HAS_POSIX_TIMER__
+#    elif defined ACUTEST_HAS_POSIX_TIMER__
     printf("  -t, --timer           Measure test duration (real time)\n");
-    printf("      --timer=TIMER     Measure test duration, using given timer\n");
+    printf(
+        "      --timer=TIMER     Measure test duration, using given timer\n");
     printf("                          (TIMER is one of 'real', 'cpu')\n");
-#endif
-    printf("      --no-summary      Suppress printing of test results summary\n");
+#    endif
+    printf(
+        "      --no-summary      Suppress printing of test results summary\n");
     printf("      --tap             Produce TAP-compliant output\n");
     printf("                          (See https://testanything.org/)\n");
     printf("  -x, --xml-output=FILE Enable XUnit output to the given file\n");
@@ -1319,197 +1396,213 @@ test_help__(void)
     printf("  -v, --verbose         Make output more verbose\n");
     printf("      --verbose=LEVEL   Set verbose level to LEVEL:\n");
     printf("                          0 ... Be silent\n");
-    printf("                          1 ... Output one line per test (and summary)\n");
-    printf("                          2 ... As 1 and failed conditions (this is default)\n");
-    printf("                          3 ... As 1 and all conditions (and extended summary)\n");
+    printf("                          1 ... Output one line per test (and "
+           "summary)\n");
+    printf("                          2 ... As 1 and failed conditions (this "
+           "is default)\n");
+    printf("                          3 ... As 1 and all conditions (and "
+           "extended summary)\n");
     printf("  -q, --quiet           Same as --verbose=0\n");
     printf("      --color[=WHEN]    Enable colorized output\n");
-    printf("                          (WHEN is one of 'auto', 'always', 'never')\n");
+    printf("                          (WHEN is one of 'auto', 'always', "
+           "'never')\n");
     printf("      --no-color        Same as --color=never\n");
     printf("  -h, --help            Display this help and exit\n");
 
-    if(test_list_size__ < 16) {
+    if (test_list_size__ < 16) {
         printf("\n");
         test_list_names__();
     }
 }
 
-static const TEST_CMDLINE_OPTION__ test_cmdline_options__[] = {
-    { 's',  "skip",         's', 0 },
-    {  0,   "exec",         'e', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
-    { 'E',  "no-exec",      'E', 0 },
-#if defined ACUTEST_WIN__
-    { 't',  "timer",        't', 0 },
-#elif defined ACUTEST_HAS_POSIX_TIMER__
-    { 't',  "timer",        't', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
-#endif
-    {  0,   "no-summary",   'S', 0 },
-    {  0,   "tap",          'T', 0 },
-    { 'l',  "list",         'l', 0 },
-    { 'v',  "verbose",      'v', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
-    { 'q',  "quiet",        'q', 0 },
-    {  0,   "color",        'c', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
-    {  0,   "no-color",     'C', 0 },
-    { 'h',  "help",         'h', 0 },
-    {  0,   "worker",       'w', TEST_CMDLINE_OPTFLAG_REQUIREDARG__ },  /* internal */
-    { 'x',  "xml-output",   'x', TEST_CMDLINE_OPTFLAG_REQUIREDARG__ },
-    {  0,   NULL,            0,  0 }
-};
+static const TEST_CMDLINE_OPTION__ test_cmdline_options__[] = { { 's', "skip",
+                                                                    's', 0 },
+    { 0, "exec", 'e', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
+    { 'E', "no-exec", 'E', 0 },
+#    if defined ACUTEST_WIN__
+    { 't', "timer", 't', 0 },
+#    elif defined ACUTEST_HAS_POSIX_TIMER__
+    { 't', "timer", 't', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
+#    endif
+    { 0, "no-summary", 'S', 0 }, { 0, "tap", 'T', 0 }, { 'l', "list", 'l', 0 },
+    { 'v', "verbose", 'v', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
+    { 'q', "quiet", 'q', 0 },
+    { 0, "color", 'c', TEST_CMDLINE_OPTFLAG_OPTIONALARG__ },
+    { 0, "no-color", 'C', 0 }, { 'h', "help", 'h', 0 },
+    { 0, "worker", 'w', TEST_CMDLINE_OPTFLAG_REQUIREDARG__ }, /* internal */
+    { 'x', "xml-output", 'x', TEST_CMDLINE_OPTFLAG_REQUIREDARG__ },
+    { 0, NULL, 0, 0 } };
 
 static int
-test_cmdline_callback__(int id, const char* arg)
+test_cmdline_callback__(int id, const char *arg)
 {
-    switch(id) {
-        case 's':
-            test_skip_mode__ = 1;
-            break;
+    switch (id) {
+    case 's':
+        test_skip_mode__ = 1;
+        break;
 
-        case 'e':
-            if(arg == NULL || strcmp(arg, "always") == 0) {
-                test_no_exec__ = 0;
-            } else if(strcmp(arg, "never") == 0) {
-                test_no_exec__ = 1;
-            } else if(strcmp(arg, "auto") == 0) {
-                /*noop*/
-            } else {
-                fprintf(stderr, "%s: Unrecognized argument '%s' for option --exec.\n", test_argv0__, arg);
-                fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0__);
-                exit(2);
-            }
-            break;
-
-        case 'E':
+    case 'e':
+        if (arg == NULL || strcmp(arg, "always") == 0) {
+            test_no_exec__ = 0;
+        } else if (strcmp(arg, "never") == 0) {
             test_no_exec__ = 1;
-            break;
+        } else if (strcmp(arg, "auto") == 0) {
+            /*noop*/
+        } else {
+            fprintf(stderr,
+                "%s: Unrecognized argument '%s' for option --exec.\n",
+                test_argv0__, arg);
+            fprintf(stderr, "Try '%s --help' for more information.\n",
+                test_argv0__);
+            exit(2);
+        }
+        break;
 
-        case 't':
-#if defined ACUTEST_WIN__  ||  defined ACUTEST_HAS_POSIX_TIMER__
-            if(arg == NULL || strcmp(arg, "real") == 0) {
-                test_timer__ = 1;
-    #ifndef ACUTEST_WIN__
-            } else if(strcmp(arg, "cpu") == 0) {
-                test_timer__ = 2;
-    #endif
-            } else {
-                fprintf(stderr, "%s: Unrecognized argument '%s' for option --timer.\n", test_argv0__, arg);
-                fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0__);
-                exit(2);
-            }
-#endif
-            break;
+    case 'E':
+        test_no_exec__ = 1;
+        break;
 
-        case 'S':
-            test_no_summary__ = 1;
-            break;
+    case 't':
+#    if defined ACUTEST_WIN__ || defined ACUTEST_HAS_POSIX_TIMER__
+        if (arg == NULL || strcmp(arg, "real") == 0) {
+            test_timer__ = 1;
+#        ifndef ACUTEST_WIN__
+        } else if (strcmp(arg, "cpu") == 0) {
+            test_timer__ = 2;
+#        endif
+        } else {
+            fprintf(stderr,
+                "%s: Unrecognized argument '%s' for option --timer.\n",
+                test_argv0__, arg);
+            fprintf(stderr, "Try '%s --help' for more information.\n",
+                test_argv0__);
+            exit(2);
+        }
+#    endif
+        break;
 
-        case 'T':
-            test_tap__ = 1;
-            break;
+    case 'S':
+        test_no_summary__ = 1;
+        break;
 
-        case 'l':
-            test_list_names__();
-            exit(0);
+    case 'T':
+        test_tap__ = 1;
+        break;
 
-        case 'v':
-            test_verbose_level__ = (arg != NULL ? atoi(arg) : test_verbose_level__+1);
-            break;
+    case 'l':
+        test_list_names__();
+        exit(0);
 
-        case 'q':
-            test_verbose_level__ = 0;
-            break;
+    case 'v':
+        test_verbose_level__
+            = (arg != NULL ? atoi(arg) : test_verbose_level__ + 1);
+        break;
 
-        case 'c':
-            if(arg == NULL || strcmp(arg, "always") == 0) {
-                test_colorize__ = 1;
-            } else if(strcmp(arg, "never") == 0) {
-                test_colorize__ = 0;
-            } else if(strcmp(arg, "auto") == 0) {
-                /*noop*/
-            } else {
-                fprintf(stderr, "%s: Unrecognized argument '%s' for option --color.\n", test_argv0__, arg);
-                fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0__);
-                exit(2);
-            }
-            break;
+    case 'q':
+        test_verbose_level__ = 0;
+        break;
 
-        case 'C':
+    case 'c':
+        if (arg == NULL || strcmp(arg, "always") == 0) {
+            test_colorize__ = 1;
+        } else if (strcmp(arg, "never") == 0) {
             test_colorize__ = 0;
-            break;
-
-        case 'h':
-            test_help__();
-            exit(0);
-
-        case 'w':
-            test_worker__ = 1;
-            test_worker_index__ = atoi(arg);
-            break;
-        case 'x':
-            test_xml_output__ = fopen(arg, "w");
-            if (!test_xml_output__) {
-                fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
-                exit(2);
-            }
-            break;
-
-        case 0:
-            if(test_lookup__(arg) == 0) {
-                fprintf(stderr, "%s: Unrecognized unit test '%s'\n", test_argv0__, arg);
-                fprintf(stderr, "Try '%s --list' for list of unit tests.\n", test_argv0__);
-                exit(2);
-            }
-            break;
-
-        case TEST_CMDLINE_OPTID_UNKNOWN__:
-            fprintf(stderr, "Unrecognized command line option '%s'.\n", arg);
-            fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0__);
+        } else if (strcmp(arg, "auto") == 0) {
+            /*noop*/
+        } else {
+            fprintf(stderr,
+                "%s: Unrecognized argument '%s' for option --color.\n",
+                test_argv0__, arg);
+            fprintf(stderr, "Try '%s --help' for more information.\n",
+                test_argv0__);
             exit(2);
+        }
+        break;
 
-        case TEST_CMDLINE_OPTID_MISSINGARG__:
-            fprintf(stderr, "The command line option '%s' requires an argument.\n", arg);
-            fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0__);
-            exit(2);
+    case 'C':
+        test_colorize__ = 0;
+        break;
 
-        case TEST_CMDLINE_OPTID_BOGUSARG__:
-            fprintf(stderr, "The command line option '%s' does not expect an argument.\n", arg);
-            fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0__);
+    case 'h':
+        test_help__();
+        exit(0);
+
+    case 'w':
+        test_worker__ = 1;
+        test_worker_index__ = atoi(arg);
+        break;
+    case 'x':
+        test_xml_output__ = fopen(arg, "w");
+        if (!test_xml_output__) {
+            fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
             exit(2);
+        }
+        break;
+
+    case 0:
+        if (test_lookup__(arg) == 0) {
+            fprintf(
+                stderr, "%s: Unrecognized unit test '%s'\n", test_argv0__, arg);
+            fprintf(stderr, "Try '%s --list' for list of unit tests.\n",
+                test_argv0__);
+            exit(2);
+        }
+        break;
+
+    case TEST_CMDLINE_OPTID_UNKNOWN__:
+        fprintf(stderr, "Unrecognized command line option '%s'.\n", arg);
+        fprintf(
+            stderr, "Try '%s --help' for more information.\n", test_argv0__);
+        exit(2);
+
+    case TEST_CMDLINE_OPTID_MISSINGARG__:
+        fprintf(stderr, "The command line option '%s' requires an argument.\n",
+            arg);
+        fprintf(
+            stderr, "Try '%s --help' for more information.\n", test_argv0__);
+        exit(2);
+
+    case TEST_CMDLINE_OPTID_BOGUSARG__:
+        fprintf(stderr,
+            "The command line option '%s' does not expect an argument.\n", arg);
+        fprintf(
+            stderr, "Try '%s --help' for more information.\n", test_argv0__);
+        exit(2);
     }
 
     return 0;
 }
 
-
-#ifdef ACUTEST_LINUX__
+#    ifdef ACUTEST_LINUX__
 static int
 test_is_tracer_present__(void)
 {
-    char buf[256+32+1];
+    char buf[256 + 32 + 1];
     int tracer_present = 0;
     int fd;
     ssize_t n_read;
 
     fd = open("/proc/self/status", O_RDONLY);
-    if(fd == -1)
+    if (fd == -1)
         return 0;
 
-    n_read = read(fd, buf, sizeof(buf)-1);
-    while(n_read > 0) {
+    n_read = read(fd, buf, sizeof(buf) - 1);
+    while (n_read > 0) {
         static const char pattern[] = "TracerPid:";
-        const char* field;
+        const char *field;
 
         buf[n_read] = '\0';
         field = strstr(buf, pattern);
-        if(field != NULL  &&  field < buf + sizeof(buf) - 32) {
-            pid_t tracer_pid = (pid_t) atoi(field + sizeof(pattern) - 1);
+        if (field != NULL && field < buf + sizeof(buf) - 32) {
+            pid_t tracer_pid = (pid_t)atoi(field + sizeof(pattern) - 1);
             tracer_present = (tracer_pid != 0);
             break;
         }
 
-        if(n_read == sizeof(buf)-1) {
-            memmove(buf, buf + sizeof(buf)-1 - 32, 32);
-            n_read = read(fd, buf+32, sizeof(buf)-1-32);
-            if(n_read > 0)
+        if (n_read == sizeof(buf) - 1) {
+            memmove(buf, buf + sizeof(buf) - 1 - 32, 32);
+            n_read = read(fd, buf + 32, sizeof(buf) - 1 - 32);
+            if (n_read > 0)
                 n_read += 32;
         }
     }
@@ -1517,137 +1610,150 @@ test_is_tracer_present__(void)
     close(fd);
     return tracer_present;
 }
-#endif
+#    endif
 
 int
-main(int argc, char** argv)
+main(int argc, char **argv)
 {
     int i;
     test_argv0__ = argv[0];
 
-#if defined ACUTEST_UNIX__
+#    if defined ACUTEST_UNIX__
     test_colorize__ = isatty(STDOUT_FILENO);
-#elif defined ACUTEST_WIN__
- #if defined __BORLANDC__
+#    elif defined ACUTEST_WIN__
+#        if defined __BORLANDC__
     test_colorize__ = isatty(_fileno(stdout));
- #else
+#        else
     test_colorize__ = _isatty(_fileno(stdout));
- #endif
-#else
+#        endif
+#    else
     test_colorize__ = 0;
-#endif
+#    endif
 
     test_timer_init__();
 
     /* Count all test units */
     test_list_size__ = 0;
-    for(i = 0; test_list__[i].func != NULL; i++)
+    for (i = 0; test_list__[i].func != NULL; i++)
         test_list_size__++;
 
-    test_details__ = (struct test_detail__*)calloc(test_list_size__, sizeof(struct test_detail__));
-    if(test_details__ == NULL) {
+    test_details__ = (struct test_detail__ *)calloc(
+        test_list_size__, sizeof(struct test_detail__));
+    if (test_details__ == NULL) {
         fprintf(stderr, "Out of memory.\n");
         exit(2);
     }
 
     /* Parse options */
-    test_cmdline_read__(test_cmdline_options__, argc, argv, test_cmdline_callback__);
+    test_cmdline_read__(
+        test_cmdline_options__, argc, argv, test_cmdline_callback__);
 
-#if defined(ACUTEST_WIN__)
+#    if defined(ACUTEST_WIN__)
     SetUnhandledExceptionFilter(test_seh_exception_filter__);
-#endif
+#    endif
 
     /* By default, we want to run all tests. */
-    if(test_count__ == 0) {
-        for(i = 0; test_list__[i].func != NULL; i++)
+    if (test_count__ == 0) {
+        for (i = 0; test_list__[i].func != NULL; i++)
             test_remember__(i);
     }
 
     /* Guess whether we want to run unit tests as child processes. */
-    if(test_no_exec__ < 0) {
+    if (test_no_exec__ < 0) {
         test_no_exec__ = 0;
 
-        if(test_count__ <= 1) {
+        if (test_count__ <= 1) {
             test_no_exec__ = 1;
         } else {
-#ifdef ACUTEST_WIN__
-            if(IsDebuggerPresent())
+#    ifdef ACUTEST_WIN__
+            if (IsDebuggerPresent())
                 test_no_exec__ = 1;
-#endif
-#ifdef ACUTEST_LINUX__
-            if(test_is_tracer_present__())
+#    endif
+#    ifdef ACUTEST_LINUX__
+            if (test_is_tracer_present__())
                 test_no_exec__ = 1;
-#endif
+#    endif
         }
     }
 
-    if(test_tap__) {
+    if (test_tap__) {
         /* TAP requires we know test result ("ok", "not ok") before we output
          * anything about the test, and this gets problematic for larger verbose
          * levels. */
-        if(test_verbose_level__ > 2)
+        if (test_verbose_level__ > 2)
             test_verbose_level__ = 2;
 
         /* TAP harness should provide some summary. */
         test_no_summary__ = 1;
 
-        if(!test_worker__)
-            printf("1..%d\n", (int) test_count__);
+        if (!test_worker__)
+            printf("1..%d\n", (int)test_count__);
     }
 
     int index = test_worker_index__;
-    for(i = 0; test_list__[i].func != NULL; i++) {
+    for (i = 0; test_list__[i].func != NULL; i++) {
         int run = (test_details__[i].flags & TEST_FLAG_RUN__);
         if (test_skip_mode__) /* Run all tests except those listed. */
             run = !run;
-        if(run)
+        if (run)
             test_run__(&test_list__[i], index++, i);
     }
 
     /* Write a summary */
-    if(!test_no_summary__ && test_verbose_level__ >= 1) {
-        if(test_verbose_level__ >= 3) {
+    if (!test_no_summary__ && test_verbose_level__ >= 1) {
+        if (test_verbose_level__ >= 3) {
             test_print_in_color__(TEST_COLOR_DEFAULT_INTENSIVE__, "Summary:\n");
 
-            printf("  Count of all unit tests:     %4d\n", (int) test_list_size__);
-            printf("  Count of run unit tests:     %4d\n", test_stat_run_units__);
-            printf("  Count of failed unit tests:  %4d\n", test_stat_failed_units__);
-            printf("  Count of skipped unit tests: %4d\n", (int) test_list_size__ - test_stat_run_units__);
+            printf(
+                "  Count of all unit tests:     %4d\n", (int)test_list_size__);
+            printf(
+                "  Count of run unit tests:     %4d\n", test_stat_run_units__);
+            printf("  Count of failed unit tests:  %4d\n",
+                test_stat_failed_units__);
+            printf("  Count of skipped unit tests: %4d\n",
+                (int)test_list_size__ - test_stat_run_units__);
         }
 
-        if(test_stat_failed_units__ == 0) {
+        if (test_stat_failed_units__ == 0) {
             test_print_in_color__(TEST_COLOR_GREEN_INTENSIVE__, "SUCCESS:");
             printf(" All unit tests have passed.\n");
         } else {
             test_print_in_color__(TEST_COLOR_RED_INTENSIVE__, "FAILED:");
             printf(" %d of %d unit tests %s failed.\n",
-                    test_stat_failed_units__, test_stat_run_units__,
-                    (test_stat_failed_units__ == 1) ? "has" : "have");
+                test_stat_failed_units__, test_stat_run_units__,
+                (test_stat_failed_units__ == 1) ? "has" : "have");
         }
 
-        if(test_verbose_level__ >= 3)
+        if (test_verbose_level__ >= 3)
             printf("\n");
     }
 
     if (test_xml_output__) {
-#if defined ACUTEST_UNIX__
+#    if defined ACUTEST_UNIX__
         char *suite_name = basename(argv[0]);
-#elif defined ACUTEST_WIN__
+#    elif defined ACUTEST_WIN__
         char suite_name[_MAX_FNAME];
         _splitpath(argv[0], NULL, NULL, suite_name, NULL);
-#else
+#    else
         const char *suite_name = argv[0];
-#endif
-        fprintf(test_xml_output__, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        fprintf(test_xml_output__, "<testsuite name=\"%s\" tests=\"%d\" errors=\"%d\" failures=\"%d\" skip=\"%d\">\n",
-            suite_name, (int)test_list_size__, test_stat_failed_units__, test_stat_failed_units__,
+#    endif
+        fprintf(
+            test_xml_output__, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        fprintf(test_xml_output__,
+            "<testsuite name=\"%s\" tests=\"%d\" errors=\"%d\" failures=\"%d\" "
+            "skip=\"%d\">\n",
+            suite_name, (int)test_list_size__, test_stat_failed_units__,
+            test_stat_failed_units__,
             (int)test_list_size__ - test_stat_run_units__);
-        for(i = 0; test_list__[i].func != NULL; i++) {
+        for (i = 0; test_list__[i].func != NULL; i++) {
             struct test_detail__ *details = &test_details__[i];
-            fprintf(test_xml_output__, "  <testcase name=\"%s\" time=\"%.2f\">\n", test_list__[i].name, details->duration);
+            fprintf(test_xml_output__,
+                "  <testcase name=\"%s\" time=\"%.2f\">\n", test_list__[i].name,
+                details->duration);
             if (details->flags & TEST_FLAG_FAILURE__)
                 fprintf(test_xml_output__, "    <failure />\n");
-            if (!(details->flags & TEST_FLAG_FAILURE__) && !(details->flags & TEST_FLAG_SUCCESS__))
+            if (!(details->flags & TEST_FLAG_FAILURE__)
+                && !(details->flags & TEST_FLAG_SUCCESS__))
                 fprintf(test_xml_output__, "    <skipped />\n");
             fprintf(test_xml_output__, "  </testcase>\n");
         }
@@ -1655,17 +1761,15 @@ main(int argc, char** argv)
         fclose(test_xml_output__);
     }
 
-    free((void*) test_details__);
+    free((void *)test_details__);
 
     return (test_stat_failed_units__ == 0) ? 0 : 1;
 }
 
-
-#endif  /* #ifndef TEST_NO_MAIN */
+#endif /* #ifndef TEST_NO_MAIN */
 
 #ifdef __cplusplus
-    }  /* extern "C" */
+} /* extern "C" */
 #endif
 
-
-#endif  /* #ifndef ACUTEST_H__ */
+#endif /* #ifndef ACUTEST_H__ */

--- a/vendor/jsmn.h
+++ b/vendor/jsmn.h
@@ -31,9 +31,9 @@ extern "C" {
 #endif
 
 #ifdef JSMN_STATIC
-#define JSMN_API static
+#    define JSMN_API static
 #else
-#define JSMN_API extern
+#    define JSMN_API extern
 #endif
 
 /**
@@ -44,20 +44,20 @@ extern "C" {
  * 	o Other primitive: number, boolean (true/false) or null
  */
 typedef enum {
-  JSMN_UNDEFINED = 0,
-  JSMN_OBJECT = 1,
-  JSMN_ARRAY = 2,
-  JSMN_STRING = 3,
-  JSMN_PRIMITIVE = 4
+    JSMN_UNDEFINED = 0,
+    JSMN_OBJECT = 1,
+    JSMN_ARRAY = 2,
+    JSMN_STRING = 3,
+    JSMN_PRIMITIVE = 4
 } jsmntype_t;
 
 enum jsmnerr {
-  /* Not enough tokens were provided */
-  JSMN_ERROR_NOMEM = -1,
-  /* Invalid character inside JSON string */
-  JSMN_ERROR_INVAL = -2,
-  /* The string is not a full JSON packet, more bytes expected */
-  JSMN_ERROR_PART = -3
+    /* Not enough tokens were provided */
+    JSMN_ERROR_NOMEM = -1,
+    /* Invalid character inside JSON string */
+    JSMN_ERROR_INVAL = -2,
+    /* The string is not a full JSON packet, more bytes expected */
+    JSMN_ERROR_PART = -3
 };
 
 /**
@@ -67,12 +67,12 @@ enum jsmnerr {
  * end		end position in JSON data string
  */
 typedef struct {
-  jsmntype_t type;
-  int start;
-  int end;
-  int size;
+    jsmntype_t type;
+    int start;
+    int end;
+    int size;
 #ifdef JSMN_PARENT_LINKS
-  int parent;
+    int parent;
 #endif
 } jsmntok_t;
 
@@ -81,9 +81,9 @@ typedef struct {
  * the string being parsed now and current position in that string.
  */
 typedef struct {
-  unsigned int pos;     /* offset in the JSON string */
-  unsigned int toknext; /* next token to allocate */
-  int toksuper;         /* superior token node, e.g. parent object or array */
+    unsigned int pos; /* offset in the JSON string */
+    unsigned int toknext; /* next token to allocate */
+    int toksuper; /* superior token node, e.g. parent object or array */
 } jsmn_parser;
 
 /**
@@ -97,369 +97,384 @@ JSMN_API void jsmn_init(jsmn_parser *parser);
  * a single JSON object.
  */
 JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
-                        jsmntok_t *tokens, const unsigned int num_tokens);
+    jsmntok_t *tokens, const unsigned int num_tokens);
 
 #ifndef JSMN_HEADER
 /**
  * Allocates a fresh unused token from the token pool.
  */
-static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
-                                   const size_t num_tokens) {
-  jsmntok_t *tok;
-  if (parser->toknext >= num_tokens) {
-    return NULL;
-  }
-  tok = &tokens[parser->toknext++];
-  tok->start = tok->end = -1;
-  tok->size = 0;
-#ifdef JSMN_PARENT_LINKS
-  tok->parent = -1;
-#endif
-  return tok;
+static jsmntok_t *
+jsmn_alloc_token(
+    jsmn_parser *parser, jsmntok_t *tokens, const size_t num_tokens)
+{
+    jsmntok_t *tok;
+    if (parser->toknext >= num_tokens) {
+        return NULL;
+    }
+    tok = &tokens[parser->toknext++];
+    tok->start = tok->end = -1;
+    tok->size = 0;
+#    ifdef JSMN_PARENT_LINKS
+    tok->parent = -1;
+#    endif
+    return tok;
 }
 
 /**
  * Fills token type and boundaries.
  */
-static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
-                            const int start, const int end) {
-  token->type = type;
-  token->start = start;
-  token->end = end;
-  token->size = 0;
+static void
+jsmn_fill_token(
+    jsmntok_t *token, const jsmntype_t type, const int start, const int end)
+{
+    token->type = type;
+    token->start = start;
+    token->end = end;
+    token->size = 0;
 }
 
 /**
  * Fills next available token with JSON primitive.
  */
-static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
-                                const size_t len, jsmntok_t *tokens,
-                                const size_t num_tokens) {
-  jsmntok_t *token;
-  int start;
+static int
+jsmn_parse_primitive(jsmn_parser *parser, const char *js, const size_t len,
+    jsmntok_t *tokens, const size_t num_tokens)
+{
+    jsmntok_t *token;
+    int start;
 
-  start = parser->pos;
+    start = parser->pos;
 
-  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-    switch (js[parser->pos]) {
-#ifndef JSMN_STRICT
-    /* In strict mode primitive must be followed by "," or "}" or "]" */
-    case ':':
-#endif
-    case '\t':
-    case '\r':
-    case '\n':
-    case ' ':
-    case ',':
-    case ']':
-    case '}':
-      goto found;
-    default:
-                   /* to quiet a warning from gcc*/
-      break;
+    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+        switch (js[parser->pos]) {
+#    ifndef JSMN_STRICT
+        /* In strict mode primitive must be followed by "," or "}" or "]" */
+        case ':':
+#    endif
+        case '\t':
+        case '\r':
+        case '\n':
+        case ' ':
+        case ',':
+        case ']':
+        case '}':
+            goto found;
+        default:
+            /* to quiet a warning from gcc*/
+            break;
+        }
+        if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+        }
     }
-    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
-      parser->pos = start;
-      return JSMN_ERROR_INVAL;
-    }
-  }
-#ifdef JSMN_STRICT
-  /* In strict mode primitive must be followed by a comma/object/array */
-  parser->pos = start;
-  return JSMN_ERROR_PART;
-#endif
+#    ifdef JSMN_STRICT
+    /* In strict mode primitive must be followed by a comma/object/array */
+    parser->pos = start;
+    return JSMN_ERROR_PART;
+#    endif
 
 found:
-  if (tokens == NULL) {
+    if (tokens == NULL) {
+        parser->pos--;
+        return 0;
+    }
+    token = jsmn_alloc_token(parser, tokens, num_tokens);
+    if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+    }
+    jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#    ifdef JSMN_PARENT_LINKS
+    token->parent = parser->toksuper;
+#    endif
     parser->pos--;
     return 0;
-  }
-  token = jsmn_alloc_token(parser, tokens, num_tokens);
-  if (token == NULL) {
-    parser->pos = start;
-    return JSMN_ERROR_NOMEM;
-  }
-  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
-#ifdef JSMN_PARENT_LINKS
-  token->parent = parser->toksuper;
-#endif
-  parser->pos--;
-  return 0;
 }
 
 /**
  * Fills next token with JSON string.
  */
-static int jsmn_parse_string(jsmn_parser *parser, const char *js,
-                             const size_t len, jsmntok_t *tokens,
-                             const size_t num_tokens) {
-  jsmntok_t *token;
+static int
+jsmn_parse_string(jsmn_parser *parser, const char *js, const size_t len,
+    jsmntok_t *tokens, const size_t num_tokens)
+{
+    jsmntok_t *token;
 
-  int start = parser->pos;
+    int start = parser->pos;
 
-  parser->pos++;
+    parser->pos++;
 
-  /* Skip starting quote */
-  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-    char c = js[parser->pos];
+    /* Skip starting quote */
+    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+        char c = js[parser->pos];
 
-    /* Quote: end of string */
-    if (c == '\"') {
-      if (tokens == NULL) {
-        return 0;
-      }
-      token = jsmn_alloc_token(parser, tokens, num_tokens);
-      if (token == NULL) {
-        parser->pos = start;
-        return JSMN_ERROR_NOMEM;
-      }
-      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
-#ifdef JSMN_PARENT_LINKS
-      token->parent = parser->toksuper;
-#endif
-      return 0;
-    }
-
-    /* Backslash: Quoted symbol expected */
-    if (c == '\\' && parser->pos + 1 < len) {
-      int i;
-      parser->pos++;
-      switch (js[parser->pos]) {
-      /* Allowed escaped symbols */
-      case '\"':
-      case '/':
-      case '\\':
-      case 'b':
-      case 'f':
-      case 'r':
-      case 'n':
-      case 't':
-        break;
-      /* Allows escaped symbol \uXXXX */
-      case 'u':
-        parser->pos++;
-        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
-             i++) {
-          /* If it isn't a hex character we have an error */
-          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
-                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
-                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
-            parser->pos = start;
-            return JSMN_ERROR_INVAL;
-          }
-          parser->pos++;
+        /* Quote: end of string */
+        if (c == '\"') {
+            if (tokens == NULL) {
+                return 0;
+            }
+            token = jsmn_alloc_token(parser, tokens, num_tokens);
+            if (token == NULL) {
+                parser->pos = start;
+                return JSMN_ERROR_NOMEM;
+            }
+            jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+#    ifdef JSMN_PARENT_LINKS
+            token->parent = parser->toksuper;
+#    endif
+            return 0;
         }
-        parser->pos--;
-        break;
-      /* Unexpected symbol */
-      default:
-        parser->pos = start;
-        return JSMN_ERROR_INVAL;
-      }
+
+        /* Backslash: Quoted symbol expected */
+        if (c == '\\' && parser->pos + 1 < len) {
+            int i;
+            parser->pos++;
+            switch (js[parser->pos]) {
+            /* Allowed escaped symbols */
+            case '\"':
+            case '/':
+            case '\\':
+            case 'b':
+            case 'f':
+            case 'r':
+            case 'n':
+            case 't':
+                break;
+            /* Allows escaped symbol \uXXXX */
+            case 'u':
+                parser->pos++;
+                for (i = 0;
+                     i < 4 && parser->pos < len && js[parser->pos] != '\0';
+                     i++) {
+                    /* If it isn't a hex character we have an error */
+                    if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57)
+                            || /* 0-9 */
+                            (js[parser->pos] >= 65 && js[parser->pos] <= 70)
+                            || /* A-F */
+                            (js[parser->pos] >= 97
+                                && js[parser->pos] <= 102))) { /* a-f */
+                        parser->pos = start;
+                        return JSMN_ERROR_INVAL;
+                    }
+                    parser->pos++;
+                }
+                parser->pos--;
+                break;
+            /* Unexpected symbol */
+            default:
+                parser->pos = start;
+                return JSMN_ERROR_INVAL;
+            }
+        }
     }
-  }
-  parser->pos = start;
-  return JSMN_ERROR_PART;
+    parser->pos = start;
+    return JSMN_ERROR_PART;
 }
 
 /**
  * Parse JSON string and fill tokens.
  */
-JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
-                        jsmntok_t *tokens, const unsigned int num_tokens) {
-  int r;
-  int i;
-  jsmntok_t *token;
-  int count = parser->toknext;
+JSMN_API int
+jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+    jsmntok_t *tokens, const unsigned int num_tokens)
+{
+    int r;
+    int i;
+    jsmntok_t *token;
+    int count = parser->toknext;
 
-  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-    char c;
-    jsmntype_t type;
+    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+        char c;
+        jsmntype_t type;
 
-    c = js[parser->pos];
-    switch (c) {
-    case '{':
-    case '[':
-      count++;
-      if (tokens == NULL) {
-        break;
-      }
-      token = jsmn_alloc_token(parser, tokens, num_tokens);
-      if (token == NULL) {
-        return JSMN_ERROR_NOMEM;
-      }
-      if (parser->toksuper != -1) {
-        jsmntok_t *t = &tokens[parser->toksuper];
-#ifdef JSMN_STRICT
-        /* In strict mode an object or array can't become a key */
-        if (t->type == JSMN_OBJECT) {
-          return JSMN_ERROR_INVAL;
-        }
-#endif
-        t->size++;
-#ifdef JSMN_PARENT_LINKS
-        token->parent = parser->toksuper;
-#endif
-      }
-      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
-      token->start = parser->pos;
-      parser->toksuper = parser->toknext - 1;
-      break;
-    case '}':
-    case ']':
-      if (tokens == NULL) {
-        break;
-      }
-      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
-#ifdef JSMN_PARENT_LINKS
-      if (parser->toknext < 1) {
-        return JSMN_ERROR_INVAL;
-      }
-      token = &tokens[parser->toknext - 1];
-      for (;;) {
-        if (token->start != -1 && token->end == -1) {
-          if (token->type != type) {
-            return JSMN_ERROR_INVAL;
-          }
-          token->end = parser->pos + 1;
-          parser->toksuper = token->parent;
-          break;
-        }
-        if (token->parent == -1) {
-          if (token->type != type || parser->toksuper == -1) {
-            return JSMN_ERROR_INVAL;
-          }
-          break;
-        }
-        token = &tokens[token->parent];
-      }
-#else
-      for (i = parser->toknext - 1; i >= 0; i--) {
-        token = &tokens[i];
-        if (token->start != -1 && token->end == -1) {
-          if (token->type != type) {
-            return JSMN_ERROR_INVAL;
-          }
-          parser->toksuper = -1;
-          token->end = parser->pos + 1;
-          break;
-        }
-      }
-      /* Error if unmatched closing bracket */
-      if (i == -1) {
-        return JSMN_ERROR_INVAL;
-      }
-      for (; i >= 0; i--) {
-        token = &tokens[i];
-        if (token->start != -1 && token->end == -1) {
-          parser->toksuper = i;
-          break;
-        }
-      }
-#endif
-      break;
-    case '\"':
-      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
-      if (r < 0) {
-        return r;
-      }
-      count++;
-      if (parser->toksuper != -1 && tokens != NULL) {
-        tokens[parser->toksuper].size++;
-      }
-      break;
-    case '\t':
-    case '\r':
-    case '\n':
-    case ' ':
-      break;
-    case ':':
-      parser->toksuper = parser->toknext - 1;
-      break;
-    case ',':
-      if (tokens != NULL && parser->toksuper != -1 &&
-          tokens[parser->toksuper].type != JSMN_ARRAY &&
-          tokens[parser->toksuper].type != JSMN_OBJECT) {
-#ifdef JSMN_PARENT_LINKS
-        parser->toksuper = tokens[parser->toksuper].parent;
-#else
-        for (i = parser->toknext - 1; i >= 0; i--) {
-          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
-            if (tokens[i].start != -1 && tokens[i].end == -1) {
-              parser->toksuper = i;
-              break;
+        c = js[parser->pos];
+        switch (c) {
+        case '{':
+        case '[':
+            count++;
+            if (tokens == NULL) {
+                break;
             }
-          }
+            token = jsmn_alloc_token(parser, tokens, num_tokens);
+            if (token == NULL) {
+                return JSMN_ERROR_NOMEM;
+            }
+            if (parser->toksuper != -1) {
+                jsmntok_t *t = &tokens[parser->toksuper];
+#    ifdef JSMN_STRICT
+                /* In strict mode an object or array can't become a key */
+                if (t->type == JSMN_OBJECT) {
+                    return JSMN_ERROR_INVAL;
+                }
+#    endif
+                t->size++;
+#    ifdef JSMN_PARENT_LINKS
+                token->parent = parser->toksuper;
+#    endif
+            }
+            token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+            token->start = parser->pos;
+            parser->toksuper = parser->toknext - 1;
+            break;
+        case '}':
+        case ']':
+            if (tokens == NULL) {
+                break;
+            }
+            type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#    ifdef JSMN_PARENT_LINKS
+            if (parser->toknext < 1) {
+                return JSMN_ERROR_INVAL;
+            }
+            token = &tokens[parser->toknext - 1];
+            for (;;) {
+                if (token->start != -1 && token->end == -1) {
+                    if (token->type != type) {
+                        return JSMN_ERROR_INVAL;
+                    }
+                    token->end = parser->pos + 1;
+                    parser->toksuper = token->parent;
+                    break;
+                }
+                if (token->parent == -1) {
+                    if (token->type != type || parser->toksuper == -1) {
+                        return JSMN_ERROR_INVAL;
+                    }
+                    break;
+                }
+                token = &tokens[token->parent];
+            }
+#    else
+            for (i = parser->toknext - 1; i >= 0; i--) {
+                token = &tokens[i];
+                if (token->start != -1 && token->end == -1) {
+                    if (token->type != type) {
+                        return JSMN_ERROR_INVAL;
+                    }
+                    parser->toksuper = -1;
+                    token->end = parser->pos + 1;
+                    break;
+                }
+            }
+            /* Error if unmatched closing bracket */
+            if (i == -1) {
+                return JSMN_ERROR_INVAL;
+            }
+            for (; i >= 0; i--) {
+                token = &tokens[i];
+                if (token->start != -1 && token->end == -1) {
+                    parser->toksuper = i;
+                    break;
+                }
+            }
+#    endif
+            break;
+        case '\"':
+            r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+            if (r < 0) {
+                return r;
+            }
+            count++;
+            if (parser->toksuper != -1 && tokens != NULL) {
+                tokens[parser->toksuper].size++;
+            }
+            break;
+        case '\t':
+        case '\r':
+        case '\n':
+        case ' ':
+            break;
+        case ':':
+            parser->toksuper = parser->toknext - 1;
+            break;
+        case ',':
+            if (tokens != NULL && parser->toksuper != -1
+                && tokens[parser->toksuper].type != JSMN_ARRAY
+                && tokens[parser->toksuper].type != JSMN_OBJECT) {
+#    ifdef JSMN_PARENT_LINKS
+                parser->toksuper = tokens[parser->toksuper].parent;
+#    else
+                for (i = parser->toknext - 1; i >= 0; i--) {
+                    if (tokens[i].type == JSMN_ARRAY
+                        || tokens[i].type == JSMN_OBJECT) {
+                        if (tokens[i].start != -1 && tokens[i].end == -1) {
+                            parser->toksuper = i;
+                            break;
+                        }
+                    }
+                }
+#    endif
+            }
+            break;
+#    ifdef JSMN_STRICT
+        /* In strict mode primitives are: numbers and booleans */
+        case '-':
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+        case 't':
+        case 'f':
+        case 'n':
+            /* And they must not be keys of the object */
+            if (tokens != NULL && parser->toksuper != -1) {
+                const jsmntok_t *t = &tokens[parser->toksuper];
+                if (t->type == JSMN_OBJECT
+                    || (t->type == JSMN_STRING && t->size != 0)) {
+                    return JSMN_ERROR_INVAL;
+                }
+            }
+#    else
+        /* In non-strict mode every unquoted value is a primitive */
+        default:
+#    endif
+            r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+            if (r < 0) {
+                return r;
+            }
+            count++;
+            if (parser->toksuper != -1 && tokens != NULL) {
+                tokens[parser->toksuper].size++;
+            }
+            break;
+
+#    ifdef JSMN_STRICT
+        /* Unexpected char in strict mode */
+        default:
+            return JSMN_ERROR_INVAL;
+#    endif
         }
-#endif
-      }
-      break;
-#ifdef JSMN_STRICT
-    /* In strict mode primitives are: numbers and booleans */
-    case '-':
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-    case 't':
-    case 'f':
-    case 'n':
-      /* And they must not be keys of the object */
-      if (tokens != NULL && parser->toksuper != -1) {
-        const jsmntok_t *t = &tokens[parser->toksuper];
-        if (t->type == JSMN_OBJECT ||
-            (t->type == JSMN_STRING && t->size != 0)) {
-          return JSMN_ERROR_INVAL;
+    }
+
+    if (tokens != NULL) {
+        for (i = parser->toknext - 1; i >= 0; i--) {
+            /* Unmatched opened object or array */
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+                return JSMN_ERROR_PART;
+            }
         }
-      }
-#else
-    /* In non-strict mode every unquoted value is a primitive */
-    default:
-#endif
-      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
-      if (r < 0) {
-        return r;
-      }
-      count++;
-      if (parser->toksuper != -1 && tokens != NULL) {
-        tokens[parser->toksuper].size++;
-      }
-      break;
-
-#ifdef JSMN_STRICT
-    /* Unexpected char in strict mode */
-    default:
-      return JSMN_ERROR_INVAL;
-#endif
     }
-  }
 
-  if (tokens != NULL) {
-    for (i = parser->toknext - 1; i >= 0; i--) {
-      /* Unmatched opened object or array */
-      if (tokens[i].start != -1 && tokens[i].end == -1) {
-        return JSMN_ERROR_PART;
-      }
-    }
-  }
-
-  return count;
+    return count;
 }
 
 /**
  * Creates a new parser based over a given buffer with an array of tokens
  * available.
  */
-JSMN_API void jsmn_init(jsmn_parser *parser) {
-  parser->pos = 0;
-  parser->toknext = 0;
-  parser->toksuper = -1;
+JSMN_API void
+jsmn_init(jsmn_parser *parser)
+{
+    parser->pos = 0;
+    parser->toknext = 0;
+    parser->toksuper = -1;
 }
 
 #endif /* JSMN_HEADER */

--- a/vendor/mpack.c
+++ b/vendor/mpack.c
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015-2018 Nicholas Fraser
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- * 
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  */
 
 /*
@@ -34,9 +34,7 @@
 
 #include "mpack.h"
 
-
 /* mpack/mpack-platform.c.c */
-
 
 // We define MPACK_EMIT_INLINE_DEFS and include mpack.h to emit
 // standalone definitions of all (non-static) inline functions in MPack.
@@ -47,17 +45,16 @@
 /* #include "mpack-platform.h" */
 /* #include "mpack.h" */
 
-
 #if MPACK_DEBUG && MPACK_STDIO
-#include <stdarg.h>
+#    include <stdarg.h>
 #endif
-
-
 
 #if MPACK_DEBUG
 
-#if MPACK_STDIO
-void mpack_assert_fail_format(const char* format, ...) {
+#    if MPACK_STDIO
+void
+mpack_assert_fail_format(const char *format, ...)
+{
     char buffer[512];
     va_list args;
     va_start(args, format);
@@ -67,7 +64,9 @@ void mpack_assert_fail_format(const char* format, ...) {
     mpack_assert_fail_wrapper(buffer);
 }
 
-void mpack_break_hit_format(const char* format, ...) {
+void
+mpack_break_hit_format(const char *format, ...)
+{
     char buffer[512];
     va_list args;
     va_start(args, format);
@@ -76,52 +75,56 @@ void mpack_break_hit_format(const char* format, ...) {
     buffer[sizeof(buffer) - 1] = 0;
     mpack_break_hit(buffer);
 }
-#endif
+#    endif
 
-#if !MPACK_CUSTOM_ASSERT
-void mpack_assert_fail(const char* message) {
+#    if !MPACK_CUSTOM_ASSERT
+void
+mpack_assert_fail(const char *message)
+{
     MPACK_UNUSED(message);
 
-    #if MPACK_STDIO
+#        if MPACK_STDIO
     fprintf(stderr, "%s\n", message);
-    #endif
+#        endif
 }
-#endif
+#    endif
 
 // We split the assert failure from the wrapper so that a
 // custom assert function can return.
-void mpack_assert_fail_wrapper(const char* message) {
+void
+mpack_assert_fail_wrapper(const char *message)
+{
 
-    #ifdef MPACK_GCOV
+#    ifdef MPACK_GCOV
     // gcov marks even __builtin_unreachable() as an uncovered line. this
     // silences it.
     (mpack_assert_fail(message), __builtin_unreachable());
 
-    #else
+#    else
     mpack_assert_fail(message);
 
     // mpack_assert_fail() is not supposed to return. in case it does, we
     // abort.
 
-    #if !MPACK_NO_BUILTINS
-    #if defined(__GNUC__) || defined(__clang__)
+#        if !MPACK_NO_BUILTINS
+#            if defined(__GNUC__) || defined(__clang__)
     __builtin_trap();
-    #elif defined(WIN32)
+#            elif defined(WIN32)
     __debugbreak();
-    #endif
-    #endif
+#            endif
+#        endif
 
-    #if (defined(__GNUC__) || defined(__clang__)) && !MPACK_NO_BUILTINS
+#        if (defined(__GNUC__) || defined(__clang__)) && !MPACK_NO_BUILTINS
     __builtin_abort();
-    #elif MPACK_STDLIB
+#        elif MPACK_STDLIB
     abort();
-    #endif
+#        endif
 
     MPACK_UNREACHABLE;
-    #endif
+#    endif
 }
 
-#if !MPACK_CUSTOM_BREAK
+#    if !MPACK_CUSTOM_BREAK
 
 // If we have a custom assert handler, break wraps it by default.
 // This allows users of MPack to only implement mpack_assert_fail() without
@@ -131,55 +134,61 @@ void mpack_assert_fail_wrapper(const char* message) {
 // (which is needed by the unit test suite), but this is not offered in
 // mpack-config.h for simplicity.
 
-#if MPACK_CUSTOM_ASSERT
-void mpack_break_hit(const char* message) {
+#        if MPACK_CUSTOM_ASSERT
+void
+mpack_break_hit(const char *message)
+{
     mpack_assert_fail_wrapper(message);
 }
-#else
-void mpack_break_hit(const char* message) {
+#        else
+void
+mpack_break_hit(const char *message)
+{
     MPACK_UNUSED(message);
 
-    #if MPACK_STDIO
+#            if MPACK_STDIO
     fprintf(stderr, "%s\n", message);
-    #endif
+#            endif
 
-    #if defined(__GNUC__) || defined(__clang__) && !MPACK_NO_BUILTINS
+#            if defined(__GNUC__) || defined(__clang__) && !MPACK_NO_BUILTINS
     __builtin_trap();
-    #elif defined(WIN32) && !MPACK_NO_BUILTINS
+#            elif defined(WIN32) && !MPACK_NO_BUILTINS
     __debugbreak();
-    #elif MPACK_STDLIB
+#            elif MPACK_STDLIB
     abort();
-    #endif
+#            endif
 }
-#endif
+#        endif
+
+#    endif
 
 #endif
-
-#endif
-
-
 
 // The below are adapted from the C wikibook:
 //     https://en.wikibooks.org/wiki/C_Programming/Strings
 
 #ifndef mpack_memcmp
-int mpack_memcmp(const void* s1, const void* s2, size_t n) {
-     const unsigned char *us1 = (const unsigned char *) s1;
-     const unsigned char *us2 = (const unsigned char *) s2;
-     while (n-- != 0) {
-         if (*us1 != *us2)
-             return (*us1 < *us2) ? -1 : +1;
-         us1++;
-         us2++;
-     }
-     return 0;
+int
+mpack_memcmp(const void *s1, const void *s2, size_t n)
+{
+    const unsigned char *us1 = (const unsigned char *)s1;
+    const unsigned char *us2 = (const unsigned char *)s2;
+    while (n-- != 0) {
+        if (*us1 != *us2)
+            return (*us1 < *us2) ? -1 : +1;
+        us1++;
+        us2++;
+    }
+    return 0;
 }
 #endif
 
 #ifndef mpack_memcpy
-void* mpack_memcpy(void* MPACK_RESTRICT s1, const void* MPACK_RESTRICT s2, size_t n) {
-    char* MPACK_RESTRICT dst = (char *)s1;
-    const char* MPACK_RESTRICT src = (const char *)s2;
+void *
+mpack_memcpy(void *MPACK_RESTRICT s1, const void *MPACK_RESTRICT s2, size_t n)
+{
+    char *MPACK_RESTRICT dst = (char *)s1;
+    const char *MPACK_RESTRICT src = (const char *)s2;
     while (n-- != 0)
         *dst++ = *src++;
     return s1;
@@ -187,7 +196,9 @@ void* mpack_memcpy(void* MPACK_RESTRICT s1, const void* MPACK_RESTRICT s2, size_
 #endif
 
 #ifndef mpack_memmove
-void* mpack_memmove(void* s1, const void* s2, size_t n) {
+void *
+mpack_memmove(void *s1, const void *s2, size_t n)
+{
     char *p1 = (char *)s1;
     const char *p2 = (const char *)s2;
     if (p2 < p1 && p1 < p2 + n) {
@@ -203,7 +214,9 @@ void* mpack_memmove(void* s1, const void* s2, size_t n) {
 #endif
 
 #ifndef mpack_memset
-void* mpack_memset(void* s, int c, size_t n) {
+void *
+mpack_memset(void *s, int c, size_t n)
+{
     unsigned char *us = (unsigned char *)s;
     unsigned char uc = (unsigned char)c;
     while (n-- != 0)
@@ -213,25 +226,27 @@ void* mpack_memset(void* s, int c, size_t n) {
 #endif
 
 #ifndef mpack_strlen
-size_t mpack_strlen(const char* s) {
-    const char* p = s;
+size_t
+mpack_strlen(const char *s)
+{
+    const char *p = s;
     while (*p != '\0')
         p++;
     return (size_t)(p - s);
 }
 #endif
 
-
-
 #if defined(MPACK_MALLOC) && !defined(MPACK_REALLOC)
-void* mpack_realloc(void* old_ptr, size_t used_size, size_t new_size) {
+void *
+mpack_realloc(void *old_ptr, size_t used_size, size_t new_size)
+{
     if (new_size == 0) {
         if (old_ptr)
             MPACK_FREE(old_ptr);
         return NULL;
     }
 
-    void* new_ptr = MPACK_MALLOC(new_size);
+    void *new_ptr = MPACK_MALLOC(new_size);
     if (new_ptr == NULL)
         return NULL;
 
@@ -248,13 +263,17 @@ void* mpack_realloc(void* old_ptr, size_t used_size, size_t new_size) {
 /* #include "mpack-common.h" */
 
 #if MPACK_DEBUG && MPACK_STDIO
-#include <stdarg.h>
+#    include <stdarg.h>
 #endif
 
-const char* mpack_error_to_string(mpack_error_t error) {
-    #if MPACK_STRINGS
+const char *
+mpack_error_to_string(mpack_error_t error)
+{
+#if MPACK_STRINGS
     switch (error) {
-        #define MPACK_ERROR_STRING_CASE(e) case e: return #e
+#    define MPACK_ERROR_STRING_CASE(e)                                         \
+    case e:                                                                    \
+        return #e
         MPACK_ERROR_STRING_CASE(mpack_ok);
         MPACK_ERROR_STRING_CASE(mpack_error_io);
         MPACK_ERROR_STRING_CASE(mpack_error_invalid);
@@ -265,20 +284,24 @@ const char* mpack_error_to_string(mpack_error_t error) {
         MPACK_ERROR_STRING_CASE(mpack_error_bug);
         MPACK_ERROR_STRING_CASE(mpack_error_data);
         MPACK_ERROR_STRING_CASE(mpack_error_eof);
-        #undef MPACK_ERROR_STRING_CASE
+#    undef MPACK_ERROR_STRING_CASE
     }
     mpack_assert(0, "unrecognized error %i", (int)error);
     return "(unknown mpack_error_t)";
-    #else
+#else
     MPACK_UNUSED(error);
     return "";
-    #endif
+#endif
 }
 
-const char* mpack_type_to_string(mpack_type_t type) {
-    #if MPACK_STRINGS
+const char *
+mpack_type_to_string(mpack_type_t type)
+{
+#if MPACK_STRINGS
     switch (type) {
-        #define MPACK_TYPE_STRING_CASE(e) case e: return #e
+#    define MPACK_TYPE_STRING_CASE(e)                                          \
+    case e:                                                                    \
+        return #e
         MPACK_TYPE_STRING_CASE(mpack_type_missing);
         MPACK_TYPE_STRING_CASE(mpack_type_nil);
         MPACK_TYPE_STRING_CASE(mpack_type_bool);
@@ -290,20 +313,22 @@ const char* mpack_type_to_string(mpack_type_t type) {
         MPACK_TYPE_STRING_CASE(mpack_type_bin);
         MPACK_TYPE_STRING_CASE(mpack_type_array);
         MPACK_TYPE_STRING_CASE(mpack_type_map);
-        #if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
         MPACK_TYPE_STRING_CASE(mpack_type_ext);
-        #endif
-        #undef MPACK_TYPE_STRING_CASE
+#    endif
+#    undef MPACK_TYPE_STRING_CASE
     }
     mpack_assert(0, "unrecognized type %i", (int)type);
     return "(unknown mpack_type_t)";
-    #else
+#else
     MPACK_UNUSED(type);
     return "";
-    #endif
+#endif
 }
 
-int mpack_tag_cmp(mpack_tag_t left, mpack_tag_t right) {
+int
+mpack_tag_cmp(mpack_tag_t left, mpack_tag_t right)
+{
 
     // positive numbers may be stored as int; convert to uint
     if (left.type == mpack_type_int && left.v.i >= 0) {
@@ -319,60 +344,60 @@ int mpack_tag_cmp(mpack_tag_t left, mpack_tag_t right) {
         return ((int)left.type < (int)right.type) ? -1 : 1;
 
     switch (left.type) {
-        case mpack_type_missing: // fallthrough
-        case mpack_type_nil:
+    case mpack_type_missing: // fallthrough
+    case mpack_type_nil:
+        return 0;
+
+    case mpack_type_bool:
+        return (int)left.v.b - (int)right.v.b;
+
+    case mpack_type_int:
+        if (left.v.i == right.v.i)
             return 0;
+        return (left.v.i < right.v.i) ? -1 : 1;
 
-        case mpack_type_bool:
-            return (int)left.v.b - (int)right.v.b;
+    case mpack_type_uint:
+        if (left.v.u == right.v.u)
+            return 0;
+        return (left.v.u < right.v.u) ? -1 : 1;
 
-        case mpack_type_int:
-            if (left.v.i == right.v.i)
-                return 0;
-            return (left.v.i < right.v.i) ? -1 : 1;
+    case mpack_type_array:
+    case mpack_type_map:
+        if (left.v.n == right.v.n)
+            return 0;
+        return (left.v.n < right.v.n) ? -1 : 1;
 
-        case mpack_type_uint:
-            if (left.v.u == right.v.u)
-                return 0;
-            return (left.v.u < right.v.u) ? -1 : 1;
+    case mpack_type_str:
+    case mpack_type_bin:
+        if (left.v.l == right.v.l)
+            return 0;
+        return (left.v.l < right.v.l) ? -1 : 1;
 
-        case mpack_type_array:
-        case mpack_type_map:
-            if (left.v.n == right.v.n)
-                return 0;
-            return (left.v.n < right.v.n) ? -1 : 1;
-
-        case mpack_type_str:
-        case mpack_type_bin:
+#if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        if (left.exttype == right.exttype) {
             if (left.v.l == right.v.l)
                 return 0;
             return (left.v.l < right.v.l) ? -1 : 1;
+        }
+        return (int)left.exttype - (int)right.exttype;
+#endif
 
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            if (left.exttype == right.exttype) {
-                if (left.v.l == right.v.l)
-                    return 0;
-                return (left.v.l < right.v.l) ? -1 : 1;
-            }
-            return (int)left.exttype - (int)right.exttype;
-        #endif
-
-        // floats should not normally be compared for equality. we compare
-        // with memcmp() to silence compiler warnings, but this will return
-        // equal if both are NaNs with the same representation (though we may
-        // want this, for instance if you are for some bizarre reason using
-        // floats as map keys.) i'm not sure what the right thing to
-        // do is here. check for NaN first? always return false if the type
-        // is float? use operator== and pragmas to silence compiler warning?
-        // please send me your suggestions.
-        // note also that we don't convert floats to doubles, so when this is
-        // used for ordering purposes, all floats are ordered before all
-        // doubles.
-        case mpack_type_float:
-            return mpack_memcmp(&left.v.f, &right.v.f, sizeof(left.v.f));
-        case mpack_type_double:
-            return mpack_memcmp(&left.v.d, &right.v.d, sizeof(left.v.d));
+    // floats should not normally be compared for equality. we compare
+    // with memcmp() to silence compiler warnings, but this will return
+    // equal if both are NaNs with the same representation (though we may
+    // want this, for instance if you are for some bizarre reason using
+    // floats as map keys.) i'm not sure what the right thing to
+    // do is here. check for NaN first? always return false if the type
+    // is float? use operator== and pragmas to silence compiler warning?
+    // please send me your suggestions.
+    // note also that we don't convert floats to doubles, so when this is
+    // used for ordering purposes, all floats are ordered before all
+    // doubles.
+    case mpack_type_float:
+        return mpack_memcmp(&left.v.f, &right.v.f, sizeof(left.v.f));
+    case mpack_type_double:
+        return mpack_memcmp(&left.v.d, &right.v.d, sizeof(left.v.d));
     }
 
     mpack_assert(0, "unrecognized type %i", (int)left.type);
@@ -380,12 +405,16 @@ int mpack_tag_cmp(mpack_tag_t left, mpack_tag_t right) {
 }
 
 #if MPACK_DEBUG && MPACK_STDIO
-static char mpack_hex_char(uint8_t hex_value) {
-    return (hex_value < 10) ? (char)('0' + hex_value) : (char)('a' + (hex_value - 10));
+static char
+mpack_hex_char(uint8_t hex_value)
+{
+    return (hex_value < 10) ? (char)('0' + hex_value)
+                            : (char)('a' + (hex_value - 10));
 }
 
-static void mpack_tag_debug_complete_bin_ext(mpack_tag_t tag, size_t string_length, char* buffer, size_t buffer_size,
-        const char* prefix, size_t prefix_size)
+static void
+mpack_tag_debug_complete_bin_ext(mpack_tag_t tag, size_t string_length,
+    char *buffer, size_t buffer_size, const char *prefix, size_t prefix_size)
 {
     // If at any point in this function we run out of space in the buffer, we
     // bail out. The outer tag print wrapper will make sure we have a
@@ -409,7 +438,9 @@ static void mpack_tag_debug_complete_bin_ext(mpack_tag_t tag, size_t string_leng
     buffer_size -= 2;
 
     size_t hex_bytes = 0;
-    for (size_t i = 0; i < MPACK_PRINT_BYTE_COUNT && i < prefix_size && buffer_size > 2; ++i) {
+    for (size_t i = 0;
+         i < MPACK_PRINT_BYTE_COUNT && i < prefix_size && buffer_size > 2;
+         ++i) {
         uint8_t byte = (uint8_t)prefix[i];
         buffer[0] = mpack_hex_char((uint8_t)(byte >> 4));
         buffer[1] = mpack_hex_char((uint8_t)(byte & 0xfu));
@@ -419,137 +450,155 @@ static void mpack_tag_debug_complete_bin_ext(mpack_tag_t tag, size_t string_leng
     }
 
     if (buffer_size != 0)
-        mpack_snprintf(buffer, buffer_size, "%s>", (total > hex_bytes) ? "..." : "");
+        mpack_snprintf(
+            buffer, buffer_size, "%s>", (total > hex_bytes) ? "..." : "");
 }
 
-static void mpack_tag_debug_pseudo_json_bin(mpack_tag_t tag, char* buffer, size_t buffer_size,
-        const char* prefix, size_t prefix_size)
+static void
+mpack_tag_debug_pseudo_json_bin(mpack_tag_t tag, char *buffer,
+    size_t buffer_size, const char *prefix, size_t prefix_size)
 {
     mpack_assert(mpack_tag_type(&tag) == mpack_type_bin);
-    size_t length = (size_t)mpack_snprintf(buffer, buffer_size, "<binary data of length %u", tag.v.l);
-    mpack_tag_debug_complete_bin_ext(tag, length, buffer, buffer_size, prefix, prefix_size);
+    size_t length = (size_t)mpack_snprintf(
+        buffer, buffer_size, "<binary data of length %u", tag.v.l);
+    mpack_tag_debug_complete_bin_ext(
+        tag, length, buffer, buffer_size, prefix, prefix_size);
 }
 
-#if MPACK_EXTENSIONS
-static void mpack_tag_debug_pseudo_json_ext(mpack_tag_t tag, char* buffer, size_t buffer_size,
-        const char* prefix, size_t prefix_size)
+#    if MPACK_EXTENSIONS
+static void
+mpack_tag_debug_pseudo_json_ext(mpack_tag_t tag, char *buffer,
+    size_t buffer_size, const char *prefix, size_t prefix_size)
 {
     mpack_assert(mpack_tag_type(&tag) == mpack_type_ext);
-    size_t length = (size_t)mpack_snprintf(buffer, buffer_size, "<ext data of type %i and length %u",
-            mpack_tag_ext_exttype(&tag), mpack_tag_ext_length(&tag));
-    mpack_tag_debug_complete_bin_ext(tag, length, buffer, buffer_size, prefix, prefix_size);
+    size_t length = (size_t)mpack_snprintf(buffer, buffer_size,
+        "<ext data of type %i and length %u", mpack_tag_ext_exttype(&tag),
+        mpack_tag_ext_length(&tag));
+    mpack_tag_debug_complete_bin_ext(
+        tag, length, buffer, buffer_size, prefix, prefix_size);
 }
-#endif
+#    endif
 
-static void mpack_tag_debug_pseudo_json_impl(mpack_tag_t tag, char* buffer, size_t buffer_size,
-        const char* prefix, size_t prefix_size)
+static void
+mpack_tag_debug_pseudo_json_impl(mpack_tag_t tag, char *buffer,
+    size_t buffer_size, const char *prefix, size_t prefix_size)
 {
     switch (tag.type) {
-        case mpack_type_missing:
-            mpack_snprintf(buffer, buffer_size, "<missing!>");
-            return;
-        case mpack_type_nil:
-            mpack_snprintf(buffer, buffer_size, "null");
-            return;
-        case mpack_type_bool:
-            mpack_snprintf(buffer, buffer_size, tag.v.b ? "true" : "false");
-            return;
-        case mpack_type_int:
-            mpack_snprintf(buffer, buffer_size, "%" PRIi64, tag.v.i);
-            return;
-        case mpack_type_uint:
-            mpack_snprintf(buffer, buffer_size, "%" PRIu64, tag.v.u);
-            return;
-        case mpack_type_float:
-            mpack_snprintf(buffer, buffer_size, "%f", tag.v.f);
-            return;
-        case mpack_type_double:
-            mpack_snprintf(buffer, buffer_size, "%f", tag.v.d);
-            return;
+    case mpack_type_missing:
+        mpack_snprintf(buffer, buffer_size, "<missing!>");
+        return;
+    case mpack_type_nil:
+        mpack_snprintf(buffer, buffer_size, "null");
+        return;
+    case mpack_type_bool:
+        mpack_snprintf(buffer, buffer_size, tag.v.b ? "true" : "false");
+        return;
+    case mpack_type_int:
+        mpack_snprintf(buffer, buffer_size, "%" PRIi64, tag.v.i);
+        return;
+    case mpack_type_uint:
+        mpack_snprintf(buffer, buffer_size, "%" PRIu64, tag.v.u);
+        return;
+    case mpack_type_float:
+        mpack_snprintf(buffer, buffer_size, "%f", tag.v.f);
+        return;
+    case mpack_type_double:
+        mpack_snprintf(buffer, buffer_size, "%f", tag.v.d);
+        return;
 
-        case mpack_type_str:
-            mpack_snprintf(buffer, buffer_size, "<string of %u bytes>", tag.v.l);
-            return;
-        case mpack_type_bin:
-            mpack_tag_debug_pseudo_json_bin(tag, buffer, buffer_size, prefix, prefix_size);
-            return;
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            mpack_tag_debug_pseudo_json_ext(tag, buffer, buffer_size, prefix, prefix_size);
-            return;
-        #endif
+    case mpack_type_str:
+        mpack_snprintf(buffer, buffer_size, "<string of %u bytes>", tag.v.l);
+        return;
+    case mpack_type_bin:
+        mpack_tag_debug_pseudo_json_bin(
+            tag, buffer, buffer_size, prefix, prefix_size);
+        return;
+#    if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        mpack_tag_debug_pseudo_json_ext(
+            tag, buffer, buffer_size, prefix, prefix_size);
+        return;
+#    endif
 
-        case mpack_type_array:
-            mpack_snprintf(buffer, buffer_size, "<array of %u elements>", tag.v.n);
-            return;
-        case mpack_type_map:
-            mpack_snprintf(buffer, buffer_size, "<map of %u key-value pairs>", tag.v.n);
-            return;
+    case mpack_type_array:
+        mpack_snprintf(buffer, buffer_size, "<array of %u elements>", tag.v.n);
+        return;
+    case mpack_type_map:
+        mpack_snprintf(
+            buffer, buffer_size, "<map of %u key-value pairs>", tag.v.n);
+        return;
     }
 
     mpack_snprintf(buffer, buffer_size, "<unknown!>");
 }
 
-void mpack_tag_debug_pseudo_json(mpack_tag_t tag, char* buffer, size_t buffer_size,
-        const char* prefix, size_t prefix_size)
+void
+mpack_tag_debug_pseudo_json(mpack_tag_t tag, char *buffer, size_t buffer_size,
+    const char *prefix, size_t prefix_size)
 {
     mpack_assert(buffer_size > 0, "buffer size cannot be zero!");
     buffer[0] = 0;
 
-    mpack_tag_debug_pseudo_json_impl(tag, buffer, buffer_size, prefix, prefix_size);
+    mpack_tag_debug_pseudo_json_impl(
+        tag, buffer, buffer_size, prefix, prefix_size);
 
     // We always null-terminate the buffer manually just in case the snprintf()
     // function doesn't null-terminate when the string doesn't fit.
     buffer[buffer_size - 1] = 0;
 }
 
-static void mpack_tag_debug_describe_impl(mpack_tag_t tag, char* buffer, size_t buffer_size) {
+static void
+mpack_tag_debug_describe_impl(mpack_tag_t tag, char *buffer, size_t buffer_size)
+{
     switch (tag.type) {
-        case mpack_type_missing:
-            mpack_snprintf(buffer, buffer_size, "missing");
-            return;
-        case mpack_type_nil:
-            mpack_snprintf(buffer, buffer_size, "nil");
-            return;
-        case mpack_type_bool:
-            mpack_snprintf(buffer, buffer_size, tag.v.b ? "true" : "false");
-            return;
-        case mpack_type_int:
-            mpack_snprintf(buffer, buffer_size, "int %" PRIi64, tag.v.i);
-            return;
-        case mpack_type_uint:
-            mpack_snprintf(buffer, buffer_size, "uint %" PRIu64, tag.v.u);
-            return;
-        case mpack_type_float:
-            mpack_snprintf(buffer, buffer_size, "float %f", tag.v.f);
-            return;
-        case mpack_type_double:
-            mpack_snprintf(buffer, buffer_size, "double %f", tag.v.d);
-            return;
-        case mpack_type_str:
-            mpack_snprintf(buffer, buffer_size, "str of %u bytes", tag.v.l);
-            return;
-        case mpack_type_bin:
-            mpack_snprintf(buffer, buffer_size, "bin of %u bytes", tag.v.l);
-            return;
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            mpack_snprintf(buffer, buffer_size, "ext of type %i, %u bytes",
-                    mpack_tag_ext_exttype(&tag), mpack_tag_ext_length(&tag));
-            return;
-        #endif
-        case mpack_type_array:
-            mpack_snprintf(buffer, buffer_size, "array of %u elements", tag.v.n);
-            return;
-        case mpack_type_map:
-            mpack_snprintf(buffer, buffer_size, "map of %u key-value pairs", tag.v.n);
-            return;
+    case mpack_type_missing:
+        mpack_snprintf(buffer, buffer_size, "missing");
+        return;
+    case mpack_type_nil:
+        mpack_snprintf(buffer, buffer_size, "nil");
+        return;
+    case mpack_type_bool:
+        mpack_snprintf(buffer, buffer_size, tag.v.b ? "true" : "false");
+        return;
+    case mpack_type_int:
+        mpack_snprintf(buffer, buffer_size, "int %" PRIi64, tag.v.i);
+        return;
+    case mpack_type_uint:
+        mpack_snprintf(buffer, buffer_size, "uint %" PRIu64, tag.v.u);
+        return;
+    case mpack_type_float:
+        mpack_snprintf(buffer, buffer_size, "float %f", tag.v.f);
+        return;
+    case mpack_type_double:
+        mpack_snprintf(buffer, buffer_size, "double %f", tag.v.d);
+        return;
+    case mpack_type_str:
+        mpack_snprintf(buffer, buffer_size, "str of %u bytes", tag.v.l);
+        return;
+    case mpack_type_bin:
+        mpack_snprintf(buffer, buffer_size, "bin of %u bytes", tag.v.l);
+        return;
+#    if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        mpack_snprintf(buffer, buffer_size, "ext of type %i, %u bytes",
+            mpack_tag_ext_exttype(&tag), mpack_tag_ext_length(&tag));
+        return;
+#    endif
+    case mpack_type_array:
+        mpack_snprintf(buffer, buffer_size, "array of %u elements", tag.v.n);
+        return;
+    case mpack_type_map:
+        mpack_snprintf(
+            buffer, buffer_size, "map of %u key-value pairs", tag.v.n);
+        return;
     }
 
     mpack_snprintf(buffer, buffer_size, "unknown!");
 }
 
-void mpack_tag_debug_describe(mpack_tag_t tag, char* buffer, size_t buffer_size) {
+void
+mpack_tag_debug_describe(mpack_tag_t tag, char *buffer, size_t buffer_size)
+{
     mpack_assert(buffer_size > 0, "buffer size cannot be zero!");
     buffer[0] = 0;
 
@@ -561,33 +610,38 @@ void mpack_tag_debug_describe(mpack_tag_t tag, char* buffer, size_t buffer_size)
 }
 #endif
 
-
-
 #if MPACK_READ_TRACKING || MPACK_WRITE_TRACKING
 
-#ifndef MPACK_TRACKING_INITIAL_CAPACITY
+#    ifndef MPACK_TRACKING_INITIAL_CAPACITY
 // seems like a reasonable number. we grow by doubling, and it only
 // needs to be as long as the maximum depth of the message.
-#define MPACK_TRACKING_INITIAL_CAPACITY 8
-#endif
+#        define MPACK_TRACKING_INITIAL_CAPACITY 8
+#    endif
 
-mpack_error_t mpack_track_init(mpack_track_t* track) {
+mpack_error_t
+mpack_track_init(mpack_track_t *track)
+{
     track->count = 0;
     track->capacity = MPACK_TRACKING_INITIAL_CAPACITY;
-    track->elements = (mpack_track_element_t*)MPACK_MALLOC(sizeof(mpack_track_element_t) * track->capacity);
+    track->elements = (mpack_track_element_t *)MPACK_MALLOC(
+        sizeof(mpack_track_element_t) * track->capacity);
     if (track->elements == NULL)
         return mpack_error_memory;
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_grow(mpack_track_t* track) {
+mpack_error_t
+mpack_track_grow(mpack_track_t *track)
+{
     mpack_assert(track->elements, "null track elements!");
     mpack_assert(track->count == track->capacity, "incorrect growing?");
 
     size_t new_capacity = track->capacity * 2;
 
-    mpack_track_element_t* new_elements = (mpack_track_element_t*)mpack_realloc(track->elements,
-            sizeof(mpack_track_element_t) * track->count, sizeof(mpack_track_element_t) * new_capacity);
+    mpack_track_element_t *new_elements
+        = (mpack_track_element_t *)mpack_realloc(track->elements,
+            sizeof(mpack_track_element_t) * track->count,
+            sizeof(mpack_track_element_t) * new_capacity);
     if (new_elements == NULL)
         return mpack_error_memory;
 
@@ -596,9 +650,12 @@ mpack_error_t mpack_track_grow(mpack_track_t* track) {
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_push(mpack_track_t* track, mpack_type_t type, uint64_t count) {
+mpack_error_t
+mpack_track_push(mpack_track_t *track, mpack_type_t type, uint64_t count)
+{
     mpack_assert(track->elements, "null track elements!");
-    mpack_log("track pushing %s count %i\n", mpack_type_to_string(type), (int)count);
+    mpack_log(
+        "track pushing %s count %i\n", mpack_type_to_string(type), (int)count);
 
     // maps have twice the number of elements (key/value pairs)
     if (type == mpack_type_map)
@@ -618,27 +675,32 @@ mpack_error_t mpack_track_push(mpack_track_t* track, mpack_type_t type, uint64_t
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_pop(mpack_track_t* track, mpack_type_t type) {
+mpack_error_t
+mpack_track_pop(mpack_track_t *track, mpack_type_t type)
+{
     mpack_assert(track->elements, "null track elements!");
     mpack_log("track popping %s\n", mpack_type_to_string(type));
 
     if (track->count == 0) {
-        mpack_break("attempting to close a %s but nothing was opened!", mpack_type_to_string(type));
+        mpack_break("attempting to close a %s but nothing was opened!",
+            mpack_type_to_string(type));
         return mpack_error_bug;
     }
 
-    mpack_track_element_t* element = &track->elements[track->count - 1];
+    mpack_track_element_t *element = &track->elements[track->count - 1];
 
     if (element->type != type) {
         mpack_break("attempting to close a %s but the open element is a %s!",
-                mpack_type_to_string(type), mpack_type_to_string(element->type));
+            mpack_type_to_string(type), mpack_type_to_string(element->type));
         return mpack_error_bug;
     }
 
     if (element->left != 0) {
-        mpack_break("attempting to close a %s but there are %" PRIu64 " %s left",
-                mpack_type_to_string(type), element->left,
-                (type == mpack_type_map || type == mpack_type_array) ? "elements" : "bytes");
+        mpack_break("attempting to close a %s but there are %" PRIu64
+                    " %s left",
+            mpack_type_to_string(type), element->left,
+            (type == mpack_type_map || type == mpack_type_array) ? "elements"
+                                                                 : "bytes");
         return mpack_error_bug;
     }
 
@@ -646,58 +708,66 @@ mpack_error_t mpack_track_pop(mpack_track_t* track, mpack_type_t type) {
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_peek_element(mpack_track_t* track, bool read) {
+mpack_error_t
+mpack_track_peek_element(mpack_track_t *track, bool read)
+{
     MPACK_UNUSED(read);
     mpack_assert(track->elements, "null track elements!");
 
-    // if there are no open elements, that's fine, we can read/write elements at will
+    // if there are no open elements, that's fine, we can read/write elements at
+    // will
     if (track->count == 0)
         return mpack_ok;
 
-    mpack_track_element_t* element = &track->elements[track->count - 1];
+    mpack_track_element_t *element = &track->elements[track->count - 1];
 
     if (element->type != mpack_type_map && element->type != mpack_type_array) {
-        mpack_break("elements cannot be %s within an %s", read ? "read" : "written",
-                mpack_type_to_string(element->type));
+        mpack_break("elements cannot be %s within an %s",
+            read ? "read" : "written", mpack_type_to_string(element->type));
         return mpack_error_bug;
     }
 
     if (element->left == 0) {
         mpack_break("too many elements %s for %s", read ? "read" : "written",
-                mpack_type_to_string(element->type));
+            mpack_type_to_string(element->type));
         return mpack_error_bug;
     }
 
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_element(mpack_track_t* track, bool read) {
+mpack_error_t
+mpack_track_element(mpack_track_t *track, bool read)
+{
     mpack_error_t error = mpack_track_peek_element(track, read);
     if (track->count > 0 && error == mpack_ok)
         --track->elements[track->count - 1].left;
     return error;
 }
 
-mpack_error_t mpack_track_bytes(mpack_track_t* track, bool read, uint64_t count) {
+mpack_error_t
+mpack_track_bytes(mpack_track_t *track, bool read, uint64_t count)
+{
     MPACK_UNUSED(read);
     mpack_assert(track->elements, "null track elements!");
 
     if (track->count == 0) {
-        mpack_break("bytes cannot be %s with no open bin, str or ext", read ? "read" : "written");
+        mpack_break("bytes cannot be %s with no open bin, str or ext",
+            read ? "read" : "written");
         return mpack_error_bug;
     }
 
-    mpack_track_element_t* element = &track->elements[track->count - 1];
+    mpack_track_element_t *element = &track->elements[track->count - 1];
 
     if (element->type == mpack_type_map || element->type == mpack_type_array) {
-        mpack_break("bytes cannot be %s within an %s", read ? "read" : "written",
-                mpack_type_to_string(element->type));
+        mpack_break("bytes cannot be %s within an %s",
+            read ? "read" : "written", mpack_type_to_string(element->type));
         return mpack_error_bug;
     }
 
     if (element->left < count) {
         mpack_break("too many bytes %s for %s", read ? "read" : "written",
-                mpack_type_to_string(element->type));
+            mpack_type_to_string(element->type));
         return mpack_error_bug;
     }
 
@@ -705,35 +775,44 @@ mpack_error_t mpack_track_bytes(mpack_track_t* track, bool read, uint64_t count)
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_str_bytes_all(mpack_track_t* track, bool read, uint64_t count) {
+mpack_error_t
+mpack_track_str_bytes_all(mpack_track_t *track, bool read, uint64_t count)
+{
     mpack_error_t error = mpack_track_bytes(track, read, count);
     if (error != mpack_ok)
         return error;
 
-    mpack_track_element_t* element = &track->elements[track->count - 1];
+    mpack_track_element_t *element = &track->elements[track->count - 1];
 
     if (element->type != mpack_type_str) {
-        mpack_break("the open type must be a string, not a %s", mpack_type_to_string(element->type));
+        mpack_break("the open type must be a string, not a %s",
+            mpack_type_to_string(element->type));
         return mpack_error_bug;
     }
 
     if (element->left != 0) {
-        mpack_break("not all bytes were read; the wrong byte count was requested for a string read.");
+        mpack_break("not all bytes were read; the wrong byte count was "
+                    "requested for a string read.");
         return mpack_error_bug;
     }
 
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_check_empty(mpack_track_t* track) {
+mpack_error_t
+mpack_track_check_empty(mpack_track_t *track)
+{
     if (track->count != 0) {
-        mpack_break("unclosed %s", mpack_type_to_string(track->elements[0].type));
+        mpack_break(
+            "unclosed %s", mpack_type_to_string(track->elements[0].type));
         return mpack_error_bug;
     }
     return mpack_ok;
 }
 
-mpack_error_t mpack_track_destroy(mpack_track_t* track, bool cancel) {
+mpack_error_t
+mpack_track_destroy(mpack_track_t *track, bool cancel)
+{
     mpack_error_t error = cancel ? mpack_ok : mpack_track_check_empty(track);
     if (track->elements) {
         MPACK_FREE(track->elements);
@@ -743,14 +822,15 @@ mpack_error_t mpack_track_destroy(mpack_track_t* track, bool cancel) {
 }
 #endif
 
-
-
-static bool mpack_utf8_check_impl(const uint8_t* str, size_t count, bool allow_null) {
+static bool
+mpack_utf8_check_impl(const uint8_t *str, size_t count, bool allow_null)
+{
     while (count > 0) {
         uint8_t lead = str[0];
 
         // NUL
-        if (!allow_null && lead == '\0') // we don't allow NUL bytes in MPack C-strings
+        if (!allow_null
+            && lead == '\0') // we don't allow NUL bytes in MPack C-strings
             return false;
 
         // ASCII
@@ -758,7 +838,7 @@ static bool mpack_utf8_check_impl(const uint8_t* str, size_t count, bool allow_n
             ++str;
             --count;
 
-        // 2-byte sequence
+            // 2-byte sequence
         } else if ((lead & 0xE0) == 0xC0) {
             if (count < 2) // truncated sequence
                 return false;
@@ -770,13 +850,13 @@ static bool mpack_utf8_check_impl(const uint8_t* str, size_t count, bool allow_n
             str += 2;
             count -= 2;
 
-            uint32_t z = ((uint32_t)(lead & ~0xE0) << 6) |
-                          (uint32_t)(cont & ~0xC0);
+            uint32_t z
+                = ((uint32_t)(lead & ~0xE0) << 6) | (uint32_t)(cont & ~0xC0);
 
             if (z < 0x80) // overlong sequence
                 return false;
 
-        // 3-byte sequence
+            // 3-byte sequence
         } else if ((lead & 0xF0) == 0xE0) {
             if (count < 3) // truncated sequence
                 return false;
@@ -791,16 +871,15 @@ static bool mpack_utf8_check_impl(const uint8_t* str, size_t count, bool allow_n
             str += 3;
             count -= 3;
 
-            uint32_t z = ((uint32_t)(lead  & ~0xF0) << 12) |
-                         ((uint32_t)(cont1 & ~0xC0) <<  6) |
-                          (uint32_t)(cont2 & ~0xC0);
+            uint32_t z = ((uint32_t)(lead & ~0xF0) << 12)
+                | ((uint32_t)(cont1 & ~0xC0) << 6) | (uint32_t)(cont2 & ~0xC0);
 
             if (z < 0x800) // overlong sequence
                 return false;
             if (z >= 0xD800 && z <= 0xDFFF) // surrogate
                 return false;
 
-        // 4-byte sequence
+            // 4-byte sequence
         } else if ((lead & 0xF8) == 0xF0) {
             if (count < 4) // truncated sequence
                 return false;
@@ -818,10 +897,9 @@ static bool mpack_utf8_check_impl(const uint8_t* str, size_t count, bool allow_n
             str += 4;
             count -= 4;
 
-            uint32_t z = ((uint32_t)(lead  & ~0xF8) << 18) |
-                         ((uint32_t)(cont1 & ~0xC0) << 12) |
-                         ((uint32_t)(cont2 & ~0xC0) <<  6) |
-                          (uint32_t)(cont3 & ~0xC0);
+            uint32_t z = ((uint32_t)(lead & ~0xF8) << 18)
+                | ((uint32_t)(cont1 & ~0xC0) << 12)
+                | ((uint32_t)(cont2 & ~0xC0) << 6) | (uint32_t)(cont3 & ~0xC0);
 
             if (z < 0x10000) // overlong sequence
                 return false;
@@ -829,21 +907,28 @@ static bool mpack_utf8_check_impl(const uint8_t* str, size_t count, bool allow_n
                 return false;
 
         } else {
-            return false; // continuation byte without a lead, or lead for a 5-byte sequence or longer
+            return false; // continuation byte without a lead, or lead for a
+                          // 5-byte sequence or longer
         }
     }
     return true;
 }
 
-bool mpack_utf8_check(const char* str, size_t bytes) {
-    return mpack_utf8_check_impl((const uint8_t*)str, bytes, true);
+bool
+mpack_utf8_check(const char *str, size_t bytes)
+{
+    return mpack_utf8_check_impl((const uint8_t *)str, bytes, true);
 }
 
-bool mpack_utf8_check_no_null(const char* str, size_t bytes) {
-    return mpack_utf8_check_impl((const uint8_t*)str, bytes, false);
+bool
+mpack_utf8_check_no_null(const char *str, size_t bytes)
+{
+    return mpack_utf8_check_impl((const uint8_t *)str, bytes, false);
 }
 
-bool mpack_str_check_no_null(const char* str, size_t bytes) {
+bool
+mpack_str_check_no_null(const char *str, size_t bytes)
+{
     for (size_t i = 0; i < bytes; ++i)
         if (str[i] == '\0')
             return false;
@@ -851,7 +936,9 @@ bool mpack_str_check_no_null(const char* str, size_t bytes) {
 }
 
 #if MPACK_DEBUG && MPACK_STDIO
-void mpack_print_append(mpack_print_t* print, const char* data, size_t count) {
+void
+mpack_print_append(mpack_print_t *print, const char *data, size_t count)
+{
 
     // copy whatever fits into the buffer
     size_t copy = print->size - print->count;
@@ -878,18 +965,21 @@ void mpack_print_append(mpack_print_t* print, const char* data, size_t count) {
         mpack_memcpy(print->buffer, data, count);
         print->count = count;
     }
-
 }
 
-void mpack_print_flush(mpack_print_t* print) {
+void
+mpack_print_flush(mpack_print_t *print)
+{
     if (print->count > 0 && print->callback != NULL) {
         print->callback(print->context, print->buffer, print->count);
         print->count = 0;
     }
 }
 
-void mpack_print_file_callback(void* context, const char* data, size_t count) {
-    FILE* file = (FILE*)context;
+void
+mpack_print_file_callback(void *context, const char *data, size_t count)
+{
+    FILE *file = (FILE *)context;
     fwrite(data, 1, count, file);
 }
 #endif
@@ -902,37 +992,54 @@ void mpack_print_file_callback(void* context, const char* data, size_t count) {
 
 #if MPACK_WRITER
 
-#if MPACK_WRITE_TRACKING
-static void mpack_writer_flag_if_error(mpack_writer_t* writer, mpack_error_t error) {
+#    if MPACK_WRITE_TRACKING
+static void
+mpack_writer_flag_if_error(mpack_writer_t *writer, mpack_error_t error)
+{
     if (error != mpack_ok)
         mpack_writer_flag_error(writer, error);
 }
 
-void mpack_writer_track_push(mpack_writer_t* writer, mpack_type_t type, uint64_t count) {
+void
+mpack_writer_track_push(
+    mpack_writer_t *writer, mpack_type_t type, uint64_t count)
+{
     if (writer->error == mpack_ok)
-        mpack_writer_flag_if_error(writer, mpack_track_push(&writer->track, type, count));
+        mpack_writer_flag_if_error(
+            writer, mpack_track_push(&writer->track, type, count));
 }
 
-void mpack_writer_track_pop(mpack_writer_t* writer, mpack_type_t type) {
+void
+mpack_writer_track_pop(mpack_writer_t *writer, mpack_type_t type)
+{
     if (writer->error == mpack_ok)
-        mpack_writer_flag_if_error(writer, mpack_track_pop(&writer->track, type));
+        mpack_writer_flag_if_error(
+            writer, mpack_track_pop(&writer->track, type));
 }
 
-void mpack_writer_track_element(mpack_writer_t* writer) {
+void
+mpack_writer_track_element(mpack_writer_t *writer)
+{
     if (writer->error == mpack_ok)
-        mpack_writer_flag_if_error(writer, mpack_track_element(&writer->track, false));
+        mpack_writer_flag_if_error(
+            writer, mpack_track_element(&writer->track, false));
 }
 
-void mpack_writer_track_bytes(mpack_writer_t* writer, size_t count) {
+void
+mpack_writer_track_bytes(mpack_writer_t *writer, size_t count)
+{
     if (writer->error == mpack_ok)
-        mpack_writer_flag_if_error(writer, mpack_track_bytes(&writer->track, false, count));
+        mpack_writer_flag_if_error(
+            writer, mpack_track_bytes(&writer->track, false, count));
 }
-#endif
+#    endif
 
-static void mpack_writer_clear(mpack_writer_t* writer) {
-    #if MPACK_COMPATIBILITY
+static void
+mpack_writer_clear(mpack_writer_t *writer)
+{
+#    if MPACK_COMPATIBILITY
     writer->version = mpack_version_current;
-    #endif
+#    endif
     writer->flush = NULL;
     writer->error_fn = NULL;
     writer->teardown = NULL;
@@ -943,27 +1050,31 @@ static void mpack_writer_clear(mpack_writer_t* writer) {
     writer->end = NULL;
     writer->error = mpack_ok;
 
-    #if MPACK_WRITE_TRACKING
+#    if MPACK_WRITE_TRACKING
     mpack_memset(&writer->track, 0, sizeof(writer->track));
-    #endif
+#    endif
 }
 
-void mpack_writer_init(mpack_writer_t* writer, char* buffer, size_t size) {
+void
+mpack_writer_init(mpack_writer_t *writer, char *buffer, size_t size)
+{
     mpack_assert(buffer != NULL, "cannot initialize writer with empty buffer");
     mpack_writer_clear(writer);
     writer->buffer = buffer;
     writer->current = buffer;
     writer->end = writer->buffer + size;
 
-    #if MPACK_WRITE_TRACKING
+#    if MPACK_WRITE_TRACKING
     mpack_writer_flag_if_error(writer, mpack_track_init(&writer->track));
-    #endif
+#    endif
 
     mpack_log("===========================\n");
     mpack_log("initializing writer with buffer size %i\n", (int)size);
 }
 
-void mpack_writer_init_error(mpack_writer_t* writer, mpack_error_t error) {
+void
+mpack_writer_init_error(mpack_writer_t *writer, mpack_error_t error)
+{
     mpack_writer_clear(writer);
     writer->error = error;
 
@@ -971,15 +1082,21 @@ void mpack_writer_init_error(mpack_writer_t* writer, mpack_error_t error) {
     mpack_log("initializing writer in error state %i\n", (int)error);
 }
 
-void mpack_writer_set_flush(mpack_writer_t* writer, mpack_writer_flush_t flush) {
-    MPACK_STATIC_ASSERT(MPACK_WRITER_MINIMUM_BUFFER_SIZE >= MPACK_MAXIMUM_TAG_SIZE,
-            "minimum buffer size must fit any tag!");
-    MPACK_STATIC_ASSERT(31 + MPACK_TAG_SIZE_FIXSTR >= MPACK_WRITER_MINIMUM_BUFFER_SIZE,
-            "minimum buffer size must fit the largest possible fixstr!");
+void
+mpack_writer_set_flush(mpack_writer_t *writer, mpack_writer_flush_t flush)
+{
+    MPACK_STATIC_ASSERT(
+        MPACK_WRITER_MINIMUM_BUFFER_SIZE >= MPACK_MAXIMUM_TAG_SIZE,
+        "minimum buffer size must fit any tag!");
+    MPACK_STATIC_ASSERT(
+        31 + MPACK_TAG_SIZE_FIXSTR >= MPACK_WRITER_MINIMUM_BUFFER_SIZE,
+        "minimum buffer size must fit the largest possible fixstr!");
 
     if (mpack_writer_buffer_size(writer) < MPACK_WRITER_MINIMUM_BUFFER_SIZE) {
-        mpack_break("buffer size is %i, but minimum buffer size for flush is %i",
-                (int)mpack_writer_buffer_size(writer), MPACK_WRITER_MINIMUM_BUFFER_SIZE);
+        mpack_break(
+            "buffer size is %i, but minimum buffer size for flush is %i",
+            (int)mpack_writer_buffer_size(writer),
+            MPACK_WRITER_MINIMUM_BUFFER_SIZE);
         mpack_writer_flag_error(writer, mpack_error_bug);
         return;
     }
@@ -987,20 +1104,25 @@ void mpack_writer_set_flush(mpack_writer_t* writer, mpack_writer_flush_t flush) 
     writer->flush = flush;
 }
 
-#ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
 typedef struct mpack_growable_writer_t {
-    char** target_data;
-    size_t* target_size;
+    char **target_data;
+    size_t *target_size;
 } mpack_growable_writer_t;
 
-static char* mpack_writer_get_reserved(mpack_writer_t* writer) {
+static char *
+mpack_writer_get_reserved(mpack_writer_t *writer)
+{
     // This is in a separate function in order to avoid false strict aliasing
     // warnings. We aren't actually violating strict aliasing (the reserved
     // space is only ever dereferenced as an mpack_growable_writer_t.)
-    return (char*)writer->reserved;
+    return (char *)writer->reserved;
 }
 
-static void mpack_growable_writer_flush(mpack_writer_t* writer, const char* data, size_t count) {
+static void
+mpack_growable_writer_flush(
+    mpack_writer_t *writer, const char *data, size_t count)
+{
 
     // This is an intrusive flush function which modifies the writer's buffer
     // in response to a flush instead of emptying it in order to add more
@@ -1008,9 +1130,12 @@ static void mpack_growable_writer_flush(mpack_writer_t* writer, const char* data
     // into a growable one, improving performance.
     //
     // There are three ways flush can be called:
-    //   - flushing the buffer during writing (used is zero, count is all data, data is buffer)
-    //   - flushing extra data during writing (used is all flushed data, count is extra data, data is not buffer)
-    //   - flushing during teardown (used and count are both all flushed data, data is buffer)
+    //   - flushing the buffer during writing (used is zero, count is all data,
+    //   data is buffer)
+    //   - flushing extra data during writing (used is all flushed data, count
+    //   is extra data, data is not buffer)
+    //   - flushing during teardown (used and count are both all flushed data,
+    //   data is buffer)
     //
     // In the first two cases, we grow the buffer by at least double, enough
     // to ensure that new data will fit. We ignore the teardown flush.
@@ -1029,12 +1154,13 @@ static void mpack_growable_writer_flush(mpack_writer_t* writer, const char* data
     size_t used = mpack_writer_buffer_used(writer);
     size_t size = mpack_writer_buffer_size(writer);
 
-    mpack_log("flush size %i used %i data %p buffer %p\n",
-            (int)count, (int)used, data, writer->buffer);
+    mpack_log("flush size %i used %i data %p buffer %p\n", (int)count,
+        (int)used, data, writer->buffer);
 
     mpack_assert(data == writer->buffer || used + count > size,
-            "extra flush for %i but there is %i space left in the buffer! (%i/%i)",
-            (int)count, (int)mpack_writer_buffer_left(writer), (int)used, (int)size);
+        "extra flush for %i but there is %i space left in the buffer! (%i/%i)",
+        (int)count, (int)mpack_writer_buffer_left(writer), (int)used,
+        (int)size);
 
     // grow to fit the data
     // TODO: this really needs to correctly test for overflow
@@ -1042,10 +1168,11 @@ static void mpack_growable_writer_flush(mpack_writer_t* writer, const char* data
     while (new_size < used + count)
         new_size *= 2;
 
-    mpack_log("flush growing buffer size from %i to %i\n", (int)size, (int)new_size);
+    mpack_log(
+        "flush growing buffer size from %i to %i\n", (int)size, (int)new_size);
 
     // grow the buffer
-    char* new_buffer = (char*)mpack_realloc(writer->buffer, used, new_size);
+    char *new_buffer = (char *)mpack_realloc(writer->buffer, used, new_size);
     if (new_buffer == NULL) {
         mpack_writer_flag_error(writer, mpack_error_memory);
         return;
@@ -1060,17 +1187,22 @@ static void mpack_growable_writer_flush(mpack_writer_t* writer, const char* data
         writer->current += count;
     }
 
-    mpack_log("new buffer %p, used %i\n", new_buffer, (int)mpack_writer_buffer_used(writer));
+    mpack_log("new buffer %p, used %i\n", new_buffer,
+        (int)mpack_writer_buffer_used(writer));
 }
 
-static void mpack_growable_writer_teardown(mpack_writer_t* writer) {
-    mpack_growable_writer_t* growable_writer = (mpack_growable_writer_t*)mpack_writer_get_reserved(writer);
+static void
+mpack_growable_writer_teardown(mpack_writer_t *writer)
+{
+    mpack_growable_writer_t *growable_writer
+        = (mpack_growable_writer_t *)mpack_writer_get_reserved(writer);
 
     if (mpack_writer_error(writer) == mpack_ok) {
 
         // shrink the buffer to an appropriate size if the data is
         // much smaller than the buffer
-        if (mpack_writer_buffer_used(writer) < mpack_writer_buffer_size(writer) / 2) {
+        if (mpack_writer_buffer_used(writer)
+            < mpack_writer_buffer_size(writer) / 2) {
             size_t used = mpack_writer_buffer_used(writer);
 
             // We always return a non-null pointer that must be freed, even if
@@ -1078,7 +1210,7 @@ static void mpack_growable_writer_teardown(mpack_writer_t* writer) {
             // do this so we enforce it ourselves.
             size_t size = (used != 0) ? used : 1;
 
-            char* buffer = (char*)mpack_realloc(writer->buffer, used, size);
+            char *buffer = (char *)mpack_realloc(writer->buffer, used, size);
             if (!buffer) {
                 MPACK_FREE(writer->buffer);
                 mpack_writer_flag_error(writer, mpack_error_memory);
@@ -1100,22 +1232,29 @@ static void mpack_growable_writer_teardown(mpack_writer_t* writer) {
     writer->context = NULL;
 }
 
-void mpack_writer_init_growable(mpack_writer_t* writer, char** target_data, size_t* target_size) {
-    mpack_assert(target_data != NULL, "cannot initialize writer without a destination for the data");
-    mpack_assert(target_size != NULL, "cannot initialize writer without a destination for the size");
+void
+mpack_writer_init_growable(
+    mpack_writer_t *writer, char **target_data, size_t *target_size)
+{
+    mpack_assert(target_data != NULL,
+        "cannot initialize writer without a destination for the data");
+    mpack_assert(target_size != NULL,
+        "cannot initialize writer without a destination for the size");
 
     *target_data = NULL;
     *target_size = 0;
 
-    MPACK_STATIC_ASSERT(sizeof(mpack_growable_writer_t) <= sizeof(writer->reserved),
-            "not enough reserved space for growable writer!");
-    mpack_growable_writer_t* growable_writer = (mpack_growable_writer_t*)mpack_writer_get_reserved(writer);
+    MPACK_STATIC_ASSERT(
+        sizeof(mpack_growable_writer_t) <= sizeof(writer->reserved),
+        "not enough reserved space for growable writer!");
+    mpack_growable_writer_t *growable_writer
+        = (mpack_growable_writer_t *)mpack_writer_get_reserved(writer);
 
     growable_writer->target_data = target_data;
     growable_writer->target_size = target_size;
 
     size_t capacity = MPACK_BUFFER_SIZE;
-    char* buffer = (char*)MPACK_MALLOC(capacity);
+    char *buffer = (char *)MPACK_MALLOC(capacity);
     if (buffer == NULL) {
         mpack_writer_init_error(writer, mpack_error_memory);
         return;
@@ -1125,24 +1264,31 @@ void mpack_writer_init_growable(mpack_writer_t* writer, char** target_data, size
     mpack_writer_set_flush(writer, mpack_growable_writer_flush);
     mpack_writer_set_teardown(writer, mpack_growable_writer_teardown);
 }
-#endif
+#    endif
 
-#if MPACK_STDIO
-static void mpack_file_writer_flush(mpack_writer_t* writer, const char* buffer, size_t count) {
-    FILE* file = (FILE*)writer->context;
-    size_t written = fwrite((const void*)buffer, 1, count, file);
+#    if MPACK_STDIO
+static void
+mpack_file_writer_flush(
+    mpack_writer_t *writer, const char *buffer, size_t count)
+{
+    FILE *file = (FILE *)writer->context;
+    size_t written = fwrite((const void *)buffer, 1, count, file);
     if (written != count)
         mpack_writer_flag_error(writer, mpack_error_io);
 }
 
-static void mpack_file_writer_teardown(mpack_writer_t* writer) {
+static void
+mpack_file_writer_teardown(mpack_writer_t *writer)
+{
     MPACK_FREE(writer->buffer);
     writer->buffer = NULL;
     writer->context = NULL;
 }
 
-static void mpack_file_writer_teardown_close(mpack_writer_t* writer) {
-    FILE* file = (FILE*)writer->context;
+static void
+mpack_file_writer_teardown_close(mpack_writer_t *writer)
+{
+    FILE *file = (FILE *)writer->context;
 
     if (file) {
         int ret = fclose(file);
@@ -1153,11 +1299,14 @@ static void mpack_file_writer_teardown_close(mpack_writer_t* writer) {
     mpack_file_writer_teardown(writer);
 }
 
-void mpack_writer_init_stdfile(mpack_writer_t* writer, FILE* file, bool close_when_done) {
+void
+mpack_writer_init_stdfile(
+    mpack_writer_t *writer, FILE *file, bool close_when_done)
+{
     mpack_assert(file != NULL, "file is NULL");
 
     size_t capacity = MPACK_BUFFER_SIZE;
-    char* buffer = (char*)MPACK_MALLOC(capacity);
+    char *buffer = (char *)MPACK_MALLOC(capacity);
     if (buffer == NULL) {
         mpack_writer_init_error(writer, mpack_error_memory);
         if (close_when_done) {
@@ -1169,15 +1318,17 @@ void mpack_writer_init_stdfile(mpack_writer_t* writer, FILE* file, bool close_wh
     mpack_writer_init(writer, buffer, capacity);
     mpack_writer_set_context(writer, file);
     mpack_writer_set_flush(writer, mpack_file_writer_flush);
-    mpack_writer_set_teardown(writer, close_when_done ?
-            mpack_file_writer_teardown_close :
-            mpack_file_writer_teardown);
+    mpack_writer_set_teardown(writer,
+        close_when_done ? mpack_file_writer_teardown_close
+                        : mpack_file_writer_teardown);
 }
 
-void mpack_writer_init_filename(mpack_writer_t* writer, const char* filename) {
+void
+mpack_writer_init_filename(mpack_writer_t *writer, const char *filename)
+{
     mpack_assert(filename != NULL, "filename is NULL");
 
-    FILE* file = fopen(filename, "wb");
+    FILE *file = fopen(filename, "wb");
     if (file == NULL) {
         mpack_writer_init_error(writer, mpack_error_io);
         return;
@@ -1185,10 +1336,13 @@ void mpack_writer_init_filename(mpack_writer_t* writer, const char* filename) {
 
     mpack_writer_init_stdfile(writer, file, true);
 }
-#endif
+#    endif
 
-void mpack_writer_flag_error(mpack_writer_t* writer, mpack_error_t error) {
-    mpack_log("writer %p setting error %i: %s\n", writer, (int)error, mpack_error_to_string(error));
+void
+mpack_writer_flag_error(mpack_writer_t *writer, mpack_error_t error)
+{
+    mpack_log("writer %p setting error %i: %s\n", writer, (int)error,
+        mpack_error_to_string(error));
 
     if (writer->error == mpack_ok) {
         writer->error = error;
@@ -1197,7 +1351,9 @@ void mpack_writer_flag_error(mpack_writer_t* writer, mpack_error_t error) {
     }
 }
 
-MPACK_STATIC_INLINE void mpack_writer_flush_unchecked(mpack_writer_t* writer) {
+MPACK_STATIC_INLINE void
+mpack_writer_flush_unchecked(mpack_writer_t *writer)
+{
     // This is a bit ugly; we reset used before calling flush so that
     // a flush function can distinguish between flushing the buffer
     // versus flushing external data. see mpack_growable_writer_flush()
@@ -1206,18 +1362,21 @@ MPACK_STATIC_INLINE void mpack_writer_flush_unchecked(mpack_writer_t* writer) {
     writer->flush(writer, writer->buffer, used);
 }
 
-void mpack_writer_flush_message(mpack_writer_t* writer) {
+void
+mpack_writer_flush_message(mpack_writer_t *writer)
+{
     if (writer->error != mpack_ok)
         return;
 
-    #if MPACK_WRITE_TRACKING
+#    if MPACK_WRITE_TRACKING
     mpack_writer_flag_if_error(writer, mpack_track_check_empty(&writer->track));
     if (writer->error != mpack_ok)
         return;
-    #endif
+#    endif
 
     if (writer->flush == NULL) {
-        mpack_break("cannot call mpack_writer_flush_message() without a flush function!");
+        mpack_break("cannot call mpack_writer_flush_message() without a flush "
+                    "function!");
         mpack_writer_flag_error(writer, mpack_error_bug);
         return;
     }
@@ -1229,16 +1388,20 @@ void mpack_writer_flush_message(mpack_writer_t* writer) {
 // Ensures there are at least count bytes free in the buffer. This
 // will flag an error if the flush function fails to make enough
 // room in the buffer.
-MPACK_NOINLINE static bool mpack_writer_ensure(mpack_writer_t* writer, size_t count) {
+MPACK_NOINLINE static bool
+mpack_writer_ensure(mpack_writer_t *writer, size_t count)
+{
     mpack_assert(count != 0, "cannot ensure zero bytes!");
     mpack_assert(count <= MPACK_WRITER_MINIMUM_BUFFER_SIZE,
-            "cannot ensure %i bytes, this is more than the minimum buffer size %i!",
-            (int)count, (int)MPACK_WRITER_MINIMUM_BUFFER_SIZE);
+        "cannot ensure %i bytes, this is more than the minimum buffer size %i!",
+        (int)count, (int)MPACK_WRITER_MINIMUM_BUFFER_SIZE);
     mpack_assert(count > mpack_writer_buffer_left(writer),
-            "request to ensure %i bytes but there are already %i left in the buffer!",
-            (int)count, (int)mpack_writer_buffer_left(writer));
+        "request to ensure %i bytes but there are already %i left in the "
+        "buffer!",
+        (int)count, (int)mpack_writer_buffer_left(writer));
 
-    mpack_log("ensuring %i bytes, %i left\n", (int)count, (int)mpack_writer_buffer_left(writer));
+    mpack_log("ensuring %i bytes, %i left\n", (int)count,
+        (int)mpack_writer_buffer_left(writer));
 
     if (mpack_writer_error(writer) != mpack_ok)
         return false;
@@ -1263,17 +1426,20 @@ MPACK_NOINLINE static bool mpack_writer_ensure(mpack_writer_t* writer, size_t co
 // does not fit in the buffer (i.e. it straddles the edge of the
 // buffer.) If there is a flush function, it is guaranteed to be
 // called; otherwise mpack_error_too_big is raised.
-MPACK_NOINLINE static void mpack_write_native_straddle(mpack_writer_t* writer, const char* p, size_t count) {
-    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL", (int)count);
+MPACK_NOINLINE static void
+mpack_write_native_straddle(mpack_writer_t *writer, const char *p, size_t count)
+{
+    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL",
+        (int)count);
 
     if (mpack_writer_error(writer) != mpack_ok)
         return;
     mpack_log("big write for %i bytes from %p, %i space left in buffer\n",
-            (int)count, p, (int)mpack_writer_buffer_left(writer));
+        (int)count, p, (int)mpack_writer_buffer_left(writer));
     mpack_assert(count > mpack_writer_buffer_left(writer),
-            "big write requested for %i bytes, but there is %i available "
-            "space in buffer. should have called mpack_write_native() instead",
-            (int)count, (int)(mpack_writer_buffer_left(writer)));
+        "big write requested for %i bytes, but there is %i available "
+        "space in buffer. should have called mpack_write_native() instead",
+        (int)count, (int)(mpack_writer_buffer_left(writer)));
 
     // we'll need a flush function
     if (!writer->flush) {
@@ -1286,9 +1452,10 @@ MPACK_NOINLINE static void mpack_write_native_straddle(mpack_writer_t* writer, c
     if (mpack_writer_error(writer) != mpack_ok)
         return;
 
-    // note that an intrusive flush function (such as mpack_growable_writer_flush())
-    // may have changed size and/or reset used to a non-zero value. we treat both as
-    // though they may have changed, and there may still be data in the buffer.
+    // note that an intrusive flush function (such as
+    // mpack_growable_writer_flush()) may have changed size and/or reset used to
+    // a non-zero value. we treat both as though they may have changed, and
+    // there may still be data in the buffer.
 
     // flush the extra data directly if it doesn't fit in the buffer
     if (count > mpack_writer_buffer_left(writer)) {
@@ -1302,8 +1469,11 @@ MPACK_NOINLINE static void mpack_write_native_straddle(mpack_writer_t* writer, c
 }
 
 // Writes encoded bytes to the buffer, flushing if necessary.
-MPACK_STATIC_INLINE void mpack_write_native(mpack_writer_t* writer, const char* p, size_t count) {
-    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL", (int)count);
+MPACK_STATIC_INLINE void
+mpack_write_native(mpack_writer_t *writer, const char *p, size_t count)
+{
+    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL",
+        (int)count);
 
     if (mpack_writer_buffer_left(writer) < count) {
         mpack_write_native_straddle(writer, p, count);
@@ -1313,15 +1483,18 @@ MPACK_STATIC_INLINE void mpack_write_native(mpack_writer_t* writer, const char* 
     }
 }
 
-mpack_error_t mpack_writer_destroy(mpack_writer_t* writer) {
+mpack_error_t
+mpack_writer_destroy(mpack_writer_t *writer)
+{
 
-    // clean up tracking, asserting if we're not already in an error state
-    #if MPACK_WRITE_TRACKING
+// clean up tracking, asserting if we're not already in an error state
+#    if MPACK_WRITE_TRACKING
     mpack_track_destroy(&writer->track, writer->error != mpack_ok);
-    #endif
+#    endif
 
     // flush any outstanding data
-    if (mpack_writer_error(writer) == mpack_ok && mpack_writer_buffer_used(writer) != 0 && writer->flush != NULL) {
+    if (mpack_writer_error(writer) == mpack_ok
+        && mpack_writer_buffer_used(writer) != 0 && writer->flush != NULL) {
         writer->flush(writer, writer->buffer, mpack_writer_buffer_used(writer));
         writer->flush = NULL;
     }
@@ -1334,60 +1507,96 @@ mpack_error_t mpack_writer_destroy(mpack_writer_t* writer) {
     return writer->error;
 }
 
-void mpack_write_tag(mpack_writer_t* writer, mpack_tag_t value) {
+void
+mpack_write_tag(mpack_writer_t *writer, mpack_tag_t value)
+{
     switch (value.type) {
-        case mpack_type_missing:
-            mpack_break("cannot write a missing value!");
-            mpack_writer_flag_error(writer, mpack_error_bug);
-            return;
+    case mpack_type_missing:
+        mpack_break("cannot write a missing value!");
+        mpack_writer_flag_error(writer, mpack_error_bug);
+        return;
 
-        case mpack_type_nil:    mpack_write_nil   (writer);            return;
-        case mpack_type_bool:   mpack_write_bool  (writer, value.v.b); return;
-        case mpack_type_float:  mpack_write_float (writer, value.v.f); return;
-        case mpack_type_double: mpack_write_double(writer, value.v.d); return;
-        case mpack_type_int:    mpack_write_int   (writer, value.v.i); return;
-        case mpack_type_uint:   mpack_write_uint  (writer, value.v.u); return;
+    case mpack_type_nil:
+        mpack_write_nil(writer);
+        return;
+    case mpack_type_bool:
+        mpack_write_bool(writer, value.v.b);
+        return;
+    case mpack_type_float:
+        mpack_write_float(writer, value.v.f);
+        return;
+    case mpack_type_double:
+        mpack_write_double(writer, value.v.d);
+        return;
+    case mpack_type_int:
+        mpack_write_int(writer, value.v.i);
+        return;
+    case mpack_type_uint:
+        mpack_write_uint(writer, value.v.u);
+        return;
 
-        case mpack_type_str: mpack_start_str(writer, value.v.l); return;
-        case mpack_type_bin: mpack_start_bin(writer, value.v.l); return;
+    case mpack_type_str:
+        mpack_start_str(writer, value.v.l);
+        return;
+    case mpack_type_bin:
+        mpack_start_bin(writer, value.v.l);
+        return;
 
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            mpack_start_ext(writer, mpack_tag_ext_exttype(&value), mpack_tag_ext_length(&value));
-            return;
-        #endif
+#    if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        mpack_start_ext(writer, mpack_tag_ext_exttype(&value),
+            mpack_tag_ext_length(&value));
+        return;
+#    endif
 
-        case mpack_type_array: mpack_start_array(writer, value.v.n); return;
-        case mpack_type_map:   mpack_start_map(writer, value.v.n);   return;
+    case mpack_type_array:
+        mpack_start_array(writer, value.v.n);
+        return;
+    case mpack_type_map:
+        mpack_start_map(writer, value.v.n);
+        return;
     }
 
     mpack_break("unrecognized type %i", (int)value.type);
     mpack_writer_flag_error(writer, mpack_error_bug);
 }
 
-MPACK_STATIC_INLINE void mpack_write_byte_element(mpack_writer_t* writer, char value) {
+MPACK_STATIC_INLINE void
+mpack_write_byte_element(mpack_writer_t *writer, char value)
+{
     mpack_writer_track_element(writer);
-    if (MPACK_LIKELY(mpack_writer_buffer_left(writer) >= 1) || mpack_writer_ensure(writer, 1))
+    if (MPACK_LIKELY(mpack_writer_buffer_left(writer) >= 1)
+        || mpack_writer_ensure(writer, 1))
         *(writer->current++) = value;
 }
 
-void mpack_write_nil(mpack_writer_t* writer) {
+void
+mpack_write_nil(mpack_writer_t *writer)
+{
     mpack_write_byte_element(writer, (char)0xc0);
 }
 
-void mpack_write_bool(mpack_writer_t* writer, bool value) {
+void
+mpack_write_bool(mpack_writer_t *writer, bool value)
+{
     mpack_write_byte_element(writer, (char)(0xc2 | (value ? 1 : 0)));
 }
 
-void mpack_write_true(mpack_writer_t* writer) {
+void
+mpack_write_true(mpack_writer_t *writer)
+{
     mpack_write_byte_element(writer, (char)0xc3);
 }
 
-void mpack_write_false(mpack_writer_t* writer) {
+void
+mpack_write_false(mpack_writer_t *writer)
+{
     mpack_write_byte_element(writer, (char)0xc2);
 }
 
-void mpack_write_object_bytes(mpack_writer_t* writer, const char* data, size_t bytes) {
+void
+mpack_write_object_bytes(mpack_writer_t *writer, const char *data, size_t bytes)
+{
     mpack_writer_track_element(writer);
     mpack_write_native(writer, data, bytes);
 }
@@ -1396,121 +1605,163 @@ void mpack_write_object_bytes(mpack_writer_t* writer, const char* data, size_t b
  * Encode functions
  */
 
-MPACK_STATIC_INLINE void mpack_encode_fixuint(char* p, uint8_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixuint(char *p, uint8_t value)
+{
     mpack_assert(value <= 127);
     mpack_store_u8(p, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_u8(char* p, uint8_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_u8(char *p, uint8_t value)
+{
     mpack_assert(value > 127);
     mpack_store_u8(p, 0xcc);
     mpack_store_u8(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_u16(char* p, uint16_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_u16(char *p, uint16_t value)
+{
     mpack_assert(value > UINT8_MAX);
     mpack_store_u8(p, 0xcd);
     mpack_store_u16(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_u32(char* p, uint32_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_u32(char *p, uint32_t value)
+{
     mpack_assert(value > UINT16_MAX);
     mpack_store_u8(p, 0xce);
     mpack_store_u32(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_u64(char* p, uint64_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_u64(char *p, uint64_t value)
+{
     mpack_assert(value > UINT32_MAX);
     mpack_store_u8(p, 0xcf);
     mpack_store_u64(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixint(char* p, int8_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixint(char *p, int8_t value)
+{
     // this can encode positive or negative fixints
     mpack_assert(value >= -32);
     mpack_store_i8(p, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_i8(char* p, int8_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_i8(char *p, int8_t value)
+{
     mpack_assert(value < -32);
     mpack_store_u8(p, 0xd0);
     mpack_store_i8(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_i16(char* p, int16_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_i16(char *p, int16_t value)
+{
     mpack_assert(value < INT8_MIN);
     mpack_store_u8(p, 0xd1);
     mpack_store_i16(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_i32(char* p, int32_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_i32(char *p, int32_t value)
+{
     mpack_assert(value < INT16_MIN);
     mpack_store_u8(p, 0xd2);
     mpack_store_i32(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_i64(char* p, int64_t value) {
+MPACK_STATIC_INLINE void
+mpack_encode_i64(char *p, int64_t value)
+{
     mpack_assert(value < INT32_MIN);
     mpack_store_u8(p, 0xd3);
     mpack_store_i64(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_float(char* p, float value) {
+MPACK_STATIC_INLINE void
+mpack_encode_float(char *p, float value)
+{
     mpack_store_u8(p, 0xca);
     mpack_store_float(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_double(char* p, double value) {
+MPACK_STATIC_INLINE void
+mpack_encode_double(char *p, double value)
+{
     mpack_store_u8(p, 0xcb);
     mpack_store_double(p + 1, value);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixarray(char* p, uint8_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixarray(char *p, uint8_t count)
+{
     mpack_assert(count <= 15);
     mpack_store_u8(p, (uint8_t)(0x90 | count));
 }
 
-MPACK_STATIC_INLINE void mpack_encode_array16(char* p, uint16_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_array16(char *p, uint16_t count)
+{
     mpack_assert(count > 15);
     mpack_store_u8(p, 0xdc);
     mpack_store_u16(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_array32(char* p, uint32_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_array32(char *p, uint32_t count)
+{
     mpack_assert(count > UINT16_MAX);
     mpack_store_u8(p, 0xdd);
     mpack_store_u32(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixmap(char* p, uint8_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixmap(char *p, uint8_t count)
+{
     mpack_assert(count <= 15);
     mpack_store_u8(p, (uint8_t)(0x80 | count));
 }
 
-MPACK_STATIC_INLINE void mpack_encode_map16(char* p, uint16_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_map16(char *p, uint16_t count)
+{
     mpack_assert(count > 15);
     mpack_store_u8(p, 0xde);
     mpack_store_u16(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_map32(char* p, uint32_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_map32(char *p, uint32_t count)
+{
     mpack_assert(count > UINT16_MAX);
     mpack_store_u8(p, 0xdf);
     mpack_store_u32(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixstr(char* p, uint8_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixstr(char *p, uint8_t count)
+{
     mpack_assert(count <= 31);
     mpack_store_u8(p, (uint8_t)(0xa0 | count));
 }
 
-MPACK_STATIC_INLINE void mpack_encode_str8(char* p, uint8_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_str8(char *p, uint8_t count)
+{
     mpack_assert(count > 31);
     mpack_store_u8(p, 0xd9);
     mpack_store_u8(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_str16(char* p, uint16_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_str16(char *p, uint16_t count)
+{
     // we might be encoding a raw in compatibility mode, so we
     // allow count to be in the range [32, UINT8_MAX].
     mpack_assert(count > 31);
@@ -1518,97 +1769,126 @@ MPACK_STATIC_INLINE void mpack_encode_str16(char* p, uint16_t count) {
     mpack_store_u16(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_str32(char* p, uint32_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_str32(char *p, uint32_t count)
+{
     mpack_assert(count > UINT16_MAX);
     mpack_store_u8(p, 0xdb);
     mpack_store_u32(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_bin8(char* p, uint8_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_bin8(char *p, uint8_t count)
+{
     mpack_store_u8(p, 0xc4);
     mpack_store_u8(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_bin16(char* p, uint16_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_bin16(char *p, uint16_t count)
+{
     mpack_assert(count > UINT8_MAX);
     mpack_store_u8(p, 0xc5);
     mpack_store_u16(p + 1, count);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_bin32(char* p, uint32_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_bin32(char *p, uint32_t count)
+{
     mpack_assert(count > UINT16_MAX);
     mpack_store_u8(p, 0xc6);
     mpack_store_u32(p + 1, count);
 }
 
-#if MPACK_EXTENSIONS
-MPACK_STATIC_INLINE void mpack_encode_fixext1(char* p, int8_t exttype) {
+#    if MPACK_EXTENSIONS
+MPACK_STATIC_INLINE void
+mpack_encode_fixext1(char *p, int8_t exttype)
+{
     mpack_store_u8(p, 0xd4);
     mpack_store_i8(p + 1, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixext2(char* p, int8_t exttype) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixext2(char *p, int8_t exttype)
+{
     mpack_store_u8(p, 0xd5);
     mpack_store_i8(p + 1, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixext4(char* p, int8_t exttype) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixext4(char *p, int8_t exttype)
+{
     mpack_store_u8(p, 0xd6);
     mpack_store_i8(p + 1, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixext8(char* p, int8_t exttype) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixext8(char *p, int8_t exttype)
+{
     mpack_store_u8(p, 0xd7);
     mpack_store_i8(p + 1, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_fixext16(char* p, int8_t exttype) {
+MPACK_STATIC_INLINE void
+mpack_encode_fixext16(char *p, int8_t exttype)
+{
     mpack_store_u8(p, 0xd8);
     mpack_store_i8(p + 1, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_ext8(char* p, int8_t exttype, uint8_t count) {
-    mpack_assert(count != 1 && count != 2 && count != 4 && count != 8 && count != 16);
+MPACK_STATIC_INLINE void
+mpack_encode_ext8(char *p, int8_t exttype, uint8_t count)
+{
+    mpack_assert(
+        count != 1 && count != 2 && count != 4 && count != 8 && count != 16);
     mpack_store_u8(p, 0xc7);
     mpack_store_u8(p + 1, count);
     mpack_store_i8(p + 2, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_ext16(char* p, int8_t exttype, uint16_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_ext16(char *p, int8_t exttype, uint16_t count)
+{
     mpack_assert(count > UINT8_MAX);
     mpack_store_u8(p, 0xc8);
     mpack_store_u16(p + 1, count);
     mpack_store_i8(p + 3, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_ext32(char* p, int8_t exttype, uint32_t count) {
+MPACK_STATIC_INLINE void
+mpack_encode_ext32(char *p, int8_t exttype, uint32_t count)
+{
     mpack_assert(count > UINT16_MAX);
     mpack_store_u8(p, 0xc9);
     mpack_store_u32(p + 1, count);
     mpack_store_i8(p + 5, exttype);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_timestamp_4(char* p, uint32_t seconds) {
+MPACK_STATIC_INLINE void
+mpack_encode_timestamp_4(char *p, uint32_t seconds)
+{
     mpack_encode_fixext4(p, MPACK_EXTTYPE_TIMESTAMP);
     mpack_store_u32(p + MPACK_TAG_SIZE_FIXEXT4, seconds);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_timestamp_8(char* p, int64_t seconds, uint32_t nanoseconds) {
+MPACK_STATIC_INLINE void
+mpack_encode_timestamp_8(char *p, int64_t seconds, uint32_t nanoseconds)
+{
     mpack_assert(nanoseconds <= MPACK_TIMESTAMP_NANOSECONDS_MAX);
     mpack_encode_fixext8(p, MPACK_EXTTYPE_TIMESTAMP);
     uint64_t encoded = ((uint64_t)nanoseconds << 34) | (uint64_t)seconds;
     mpack_store_u64(p + MPACK_TAG_SIZE_FIXEXT8, encoded);
 }
 
-MPACK_STATIC_INLINE void mpack_encode_timestamp_12(char* p, int64_t seconds, uint32_t nanoseconds) {
+MPACK_STATIC_INLINE void
+mpack_encode_timestamp_12(char *p, int64_t seconds, uint32_t nanoseconds)
+{
     mpack_assert(nanoseconds <= MPACK_TIMESTAMP_NANOSECONDS_MAX);
     mpack_encode_ext8(p, MPACK_EXTTYPE_TIMESTAMP, 12);
     mpack_store_u32(p + MPACK_TAG_SIZE_EXT8, nanoseconds);
     mpack_store_i64(p + MPACK_TAG_SIZE_EXT8 + 4, seconds);
 }
-#endif
-
-
+#    endif
 
 /*
  * Write functions
@@ -1617,192 +1897,244 @@ MPACK_STATIC_INLINE void mpack_encode_timestamp_12(char* p, int64_t seconds, uin
 // This is a macro wrapper to the encode functions to encode
 // directly into the buffer. If mpack_writer_ensure() fails
 // it will flag an error so we don't have to do anything.
-#define MPACK_WRITE_ENCODED(encode_fn, size, ...) do {                                                 \
-    if (MPACK_LIKELY(mpack_writer_buffer_left(writer) >= size) || mpack_writer_ensure(writer, size)) { \
-        MPACK_EXPAND(encode_fn(writer->current, __VA_ARGS__));                                         \
-        writer->current += size;                                                                       \
-    }                                                                                                  \
-} while (0)
+#    define MPACK_WRITE_ENCODED(encode_fn, size, ...)                          \
+        do {                                                                   \
+            if (MPACK_LIKELY(mpack_writer_buffer_left(writer) >= size)         \
+                || mpack_writer_ensure(writer, size)) {                        \
+                MPACK_EXPAND(encode_fn(writer->current, __VA_ARGS__));         \
+                writer->current += size;                                       \
+            }                                                                  \
+        } while (0)
 
-void mpack_write_u8(mpack_writer_t* writer, uint8_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_u8(mpack_writer_t *writer, uint8_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_write_u64(writer, value);
-    #else
+#    else
     mpack_writer_track_element(writer);
     if (value <= 127) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, value);
     }
-    #endif
+#    endif
 }
 
-void mpack_write_u16(mpack_writer_t* writer, uint16_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_u16(mpack_writer_t *writer, uint16_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_write_u64(writer, value);
-    #else
+#    else
     mpack_writer_track_element(writer);
     if (value <= 127) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, (uint8_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, (uint8_t)value);
     } else if (value <= UINT8_MAX) {
         MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_u16, MPACK_TAG_SIZE_U16, value);
     }
-    #endif
+#    endif
 }
 
-void mpack_write_u32(mpack_writer_t* writer, uint32_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_u32(mpack_writer_t *writer, uint32_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_write_u64(writer, value);
-    #else
+#    else
     mpack_writer_track_element(writer);
     if (value <= 127) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, (uint8_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, (uint8_t)value);
     } else if (value <= UINT8_MAX) {
         MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
     } else if (value <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_u32, MPACK_TAG_SIZE_U32, value);
     }
-    #endif
+#    endif
 }
 
-void mpack_write_u64(mpack_writer_t* writer, uint64_t value) {
+void
+mpack_write_u64(mpack_writer_t *writer, uint64_t value)
+{
     mpack_writer_track_element(writer);
 
     if (value <= 127) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, (uint8_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixuint, MPACK_TAG_SIZE_FIXUINT, (uint8_t)value);
     } else if (value <= UINT8_MAX) {
         MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
     } else if (value <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
     } else if (value <= UINT32_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_u32, MPACK_TAG_SIZE_U32, (uint32_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_u32, MPACK_TAG_SIZE_U32, (uint32_t)value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_u64, MPACK_TAG_SIZE_U64, value);
     }
 }
 
-void mpack_write_i8(mpack_writer_t* writer, int8_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_i8(mpack_writer_t *writer, int8_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_write_i64(writer, value);
-    #else
+#    else
     mpack_writer_track_element(writer);
     if (value >= -32) {
         // we encode positive and negative fixints together
-        MPACK_WRITE_ENCODED(mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_i8, MPACK_TAG_SIZE_I8, (int8_t)value);
     }
-    #endif
+#    endif
 }
 
-void mpack_write_i16(mpack_writer_t* writer, int16_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_i16(mpack_writer_t *writer, int16_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_write_i64(writer, value);
-    #else
+#    else
     mpack_writer_track_element(writer);
     if (value >= -32) {
         if (value <= 127) {
             // we encode positive and negative fixints together
-            MPACK_WRITE_ENCODED(mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
         } else if (value <= UINT8_MAX) {
-            MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
         } else {
-            MPACK_WRITE_ENCODED(mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
         }
     } else if (value >= INT8_MIN) {
         MPACK_WRITE_ENCODED(mpack_encode_i8, MPACK_TAG_SIZE_I8, (int8_t)value);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_i16, MPACK_TAG_SIZE_I16, (int16_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_i16, MPACK_TAG_SIZE_I16, (int16_t)value);
     }
-    #endif
+#    endif
 }
 
-void mpack_write_i32(mpack_writer_t* writer, int32_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_i32(mpack_writer_t *writer, int32_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_write_i64(writer, value);
-    #else
+#    else
     mpack_writer_track_element(writer);
     if (value >= -32) {
         if (value <= 127) {
             // we encode positive and negative fixints together
-            MPACK_WRITE_ENCODED(mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
         } else if (value <= UINT8_MAX) {
-            MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
         } else if (value <= UINT16_MAX) {
-            MPACK_WRITE_ENCODED(mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
         } else {
-            MPACK_WRITE_ENCODED(mpack_encode_u32, MPACK_TAG_SIZE_U32, (uint32_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u32, MPACK_TAG_SIZE_U32, (uint32_t)value);
         }
     } else if (value >= INT8_MIN) {
         MPACK_WRITE_ENCODED(mpack_encode_i8, MPACK_TAG_SIZE_I8, (int8_t)value);
     } else if (value >= INT16_MIN) {
-        MPACK_WRITE_ENCODED(mpack_encode_i16, MPACK_TAG_SIZE_I16, (int16_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_i16, MPACK_TAG_SIZE_I16, (int16_t)value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_i32, MPACK_TAG_SIZE_I32, value);
     }
-    #endif
+#    endif
 }
 
-void mpack_write_i64(mpack_writer_t* writer, int64_t value) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+void
+mpack_write_i64(mpack_writer_t *writer, int64_t value)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     if (value > 127) {
         // for non-fix positive ints we call the u64 writer to save space
         mpack_write_u64(writer, (uint64_t)value);
         return;
     }
-    #endif
+#    endif
 
     mpack_writer_track_element(writer);
     if (value >= -32) {
-        #if MPACK_OPTIMIZE_FOR_SIZE
-        MPACK_WRITE_ENCODED(mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
-        #else
+#    if MPACK_OPTIMIZE_FOR_SIZE
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
+#    else
         if (value <= 127) {
-            MPACK_WRITE_ENCODED(mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_fixint, MPACK_TAG_SIZE_FIXINT, (int8_t)value);
         } else if (value <= UINT8_MAX) {
-            MPACK_WRITE_ENCODED(mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u8, MPACK_TAG_SIZE_U8, (uint8_t)value);
         } else if (value <= UINT16_MAX) {
-            MPACK_WRITE_ENCODED(mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u16, MPACK_TAG_SIZE_U16, (uint16_t)value);
         } else if (value <= UINT32_MAX) {
-            MPACK_WRITE_ENCODED(mpack_encode_u32, MPACK_TAG_SIZE_U32, (uint32_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u32, MPACK_TAG_SIZE_U32, (uint32_t)value);
         } else {
-            MPACK_WRITE_ENCODED(mpack_encode_u64, MPACK_TAG_SIZE_U64, (uint64_t)value);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_u64, MPACK_TAG_SIZE_U64, (uint64_t)value);
         }
-        #endif
+#    endif
     } else if (value >= INT8_MIN) {
         MPACK_WRITE_ENCODED(mpack_encode_i8, MPACK_TAG_SIZE_I8, (int8_t)value);
     } else if (value >= INT16_MIN) {
-        MPACK_WRITE_ENCODED(mpack_encode_i16, MPACK_TAG_SIZE_I16, (int16_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_i16, MPACK_TAG_SIZE_I16, (int16_t)value);
     } else if (value >= INT32_MIN) {
-        MPACK_WRITE_ENCODED(mpack_encode_i32, MPACK_TAG_SIZE_I32, (int32_t)value);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_i32, MPACK_TAG_SIZE_I32, (int32_t)value);
     } else {
         MPACK_WRITE_ENCODED(mpack_encode_i64, MPACK_TAG_SIZE_I64, value);
     }
 }
 
-void mpack_write_float(mpack_writer_t* writer, float value) {
+void
+mpack_write_float(mpack_writer_t *writer, float value)
+{
     mpack_writer_track_element(writer);
     MPACK_WRITE_ENCODED(mpack_encode_float, MPACK_TAG_SIZE_FLOAT, value);
 }
 
-void mpack_write_double(mpack_writer_t* writer, double value) {
+void
+mpack_write_double(mpack_writer_t *writer, double value)
+{
     mpack_writer_track_element(writer);
     MPACK_WRITE_ENCODED(mpack_encode_double, MPACK_TAG_SIZE_DOUBLE, value);
 }
 
-#if MPACK_EXTENSIONS
-void mpack_write_timestamp(mpack_writer_t* writer, int64_t seconds, uint32_t nanoseconds) {
-    #if MPACK_COMPATIBILITY
+#    if MPACK_EXTENSIONS
+void
+mpack_write_timestamp(
+    mpack_writer_t *writer, int64_t seconds, uint32_t nanoseconds)
+{
+#        if MPACK_COMPATIBILITY
     if (writer->version <= mpack_version_v4) {
-        mpack_break("Timestamps require spec version v5 or later. This writer is in v%i mode.", (int)writer->version);
+        mpack_break("Timestamps require spec version v5 or later. This writer "
+                    "is in v%i mode.",
+            (int)writer->version);
         mpack_writer_flag_error(writer, mpack_error_bug);
         return;
     }
-    #endif
+#        endif
 
     if (nanoseconds > MPACK_TIMESTAMP_NANOSECONDS_MAX) {
         mpack_break("timestamp nanoseconds out of bounds: %u", nanoseconds);
@@ -1813,64 +2145,85 @@ void mpack_write_timestamp(mpack_writer_t* writer, int64_t seconds, uint32_t nan
     mpack_writer_track_element(writer);
 
     if (seconds < 0 || seconds >= (INT64_C(1) << 34)) {
-        MPACK_WRITE_ENCODED(mpack_encode_timestamp_12, MPACK_EXT_SIZE_TIMESTAMP12, seconds, nanoseconds);
+        MPACK_WRITE_ENCODED(mpack_encode_timestamp_12,
+            MPACK_EXT_SIZE_TIMESTAMP12, seconds, nanoseconds);
     } else if (seconds > UINT32_MAX || nanoseconds > 0) {
-        MPACK_WRITE_ENCODED(mpack_encode_timestamp_8, MPACK_EXT_SIZE_TIMESTAMP8, seconds, nanoseconds);
+        MPACK_WRITE_ENCODED(mpack_encode_timestamp_8, MPACK_EXT_SIZE_TIMESTAMP8,
+            seconds, nanoseconds);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_timestamp_4, MPACK_EXT_SIZE_TIMESTAMP4, (uint32_t)seconds);
+        MPACK_WRITE_ENCODED(mpack_encode_timestamp_4, MPACK_EXT_SIZE_TIMESTAMP4,
+            (uint32_t)seconds);
     }
 }
-#endif
+#    endif
 
-void mpack_start_array(mpack_writer_t* writer, uint32_t count) {
+void
+mpack_start_array(mpack_writer_t *writer, uint32_t count)
+{
     mpack_writer_track_element(writer);
 
     if (count <= 15) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixarray, MPACK_TAG_SIZE_FIXARRAY, (uint8_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixarray, MPACK_TAG_SIZE_FIXARRAY, (uint8_t)count);
     } else if (count <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_array16, MPACK_TAG_SIZE_ARRAY16, (uint16_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_array16, MPACK_TAG_SIZE_ARRAY16, (uint16_t)count);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_array32, MPACK_TAG_SIZE_ARRAY32, (uint32_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_array32, MPACK_TAG_SIZE_ARRAY32, (uint32_t)count);
     }
 
     mpack_writer_track_push(writer, mpack_type_array, count);
 }
 
-void mpack_start_map(mpack_writer_t* writer, uint32_t count) {
+void
+mpack_start_map(mpack_writer_t *writer, uint32_t count)
+{
     mpack_writer_track_element(writer);
 
     if (count <= 15) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixmap, MPACK_TAG_SIZE_FIXMAP, (uint8_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixmap, MPACK_TAG_SIZE_FIXMAP, (uint8_t)count);
     } else if (count <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_map16, MPACK_TAG_SIZE_MAP16, (uint16_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_map16, MPACK_TAG_SIZE_MAP16, (uint16_t)count);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_map32, MPACK_TAG_SIZE_MAP32, (uint32_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_map32, MPACK_TAG_SIZE_MAP32, (uint32_t)count);
     }
 
     mpack_writer_track_push(writer, mpack_type_map, count);
 }
 
-static void mpack_start_str_notrack(mpack_writer_t* writer, uint32_t count) {
+static void
+mpack_start_str_notrack(mpack_writer_t *writer, uint32_t count)
+{
     if (count <= 31) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixstr, MPACK_TAG_SIZE_FIXSTR, (uint8_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixstr, MPACK_TAG_SIZE_FIXSTR, (uint8_t)count);
 
-    // str8 is only supported in v5 or later.
+        // str8 is only supported in v5 or later.
     } else if (count <= UINT8_MAX
-            #if MPACK_COMPATIBILITY
-            && writer->version >= mpack_version_v5
-            #endif
-            ) {
-        MPACK_WRITE_ENCODED(mpack_encode_str8, MPACK_TAG_SIZE_STR8, (uint8_t)count);
+#    if MPACK_COMPATIBILITY
+        && writer->version >= mpack_version_v5
+#    endif
+    ) {
+        MPACK_WRITE_ENCODED(
+            mpack_encode_str8, MPACK_TAG_SIZE_STR8, (uint8_t)count);
 
     } else if (count <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_str16, MPACK_TAG_SIZE_STR16, (uint16_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_str16, MPACK_TAG_SIZE_STR16, (uint16_t)count);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_str32, MPACK_TAG_SIZE_STR32, (uint32_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_str32, MPACK_TAG_SIZE_STR32, (uint32_t)count);
     }
 }
 
-static void mpack_start_bin_notrack(mpack_writer_t* writer, uint32_t count) {
-    #if MPACK_COMPATIBILITY
+static void
+mpack_start_bin_notrack(mpack_writer_t *writer, uint32_t count)
+{
+#    if MPACK_COMPATIBILITY
     // In the v4 spec, there was only the raw type for any kind of
     // variable-length data. In v4 mode, we support the bin functions,
     // but we produce an old-style raw.
@@ -1878,77 +2231,97 @@ static void mpack_start_bin_notrack(mpack_writer_t* writer, uint32_t count) {
         mpack_start_str_notrack(writer, count);
         return;
     }
-    #endif
+#    endif
 
     if (count <= UINT8_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_bin8, MPACK_TAG_SIZE_BIN8, (uint8_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_bin8, MPACK_TAG_SIZE_BIN8, (uint8_t)count);
     } else if (count <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_bin16, MPACK_TAG_SIZE_BIN16, (uint16_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_bin16, MPACK_TAG_SIZE_BIN16, (uint16_t)count);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_bin32, MPACK_TAG_SIZE_BIN32, (uint32_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_bin32, MPACK_TAG_SIZE_BIN32, (uint32_t)count);
     }
 }
 
-void mpack_start_str(mpack_writer_t* writer, uint32_t count) {
+void
+mpack_start_str(mpack_writer_t *writer, uint32_t count)
+{
     mpack_writer_track_element(writer);
     mpack_start_str_notrack(writer, count);
     mpack_writer_track_push(writer, mpack_type_str, count);
 }
 
-void mpack_start_bin(mpack_writer_t* writer, uint32_t count) {
+void
+mpack_start_bin(mpack_writer_t *writer, uint32_t count)
+{
     mpack_writer_track_element(writer);
     mpack_start_bin_notrack(writer, count);
     mpack_writer_track_push(writer, mpack_type_bin, count);
 }
 
-#if MPACK_EXTENSIONS
-void mpack_start_ext(mpack_writer_t* writer, int8_t exttype, uint32_t count) {
-    #if MPACK_COMPATIBILITY
+#    if MPACK_EXTENSIONS
+void
+mpack_start_ext(mpack_writer_t *writer, int8_t exttype, uint32_t count)
+{
+#        if MPACK_COMPATIBILITY
     if (writer->version <= mpack_version_v4) {
-        mpack_break("Ext types require spec version v5 or later. This writer is in v%i mode.", (int)writer->version);
+        mpack_break("Ext types require spec version v5 or later. This writer "
+                    "is in v%i mode.",
+            (int)writer->version);
         mpack_writer_flag_error(writer, mpack_error_bug);
         return;
     }
-    #endif
+#        endif
 
     mpack_writer_track_element(writer);
 
     if (count == 1) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixext1, MPACK_TAG_SIZE_FIXEXT1, exttype);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixext1, MPACK_TAG_SIZE_FIXEXT1, exttype);
     } else if (count == 2) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixext2, MPACK_TAG_SIZE_FIXEXT2, exttype);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixext2, MPACK_TAG_SIZE_FIXEXT2, exttype);
     } else if (count == 4) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixext4, MPACK_TAG_SIZE_FIXEXT4, exttype);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixext4, MPACK_TAG_SIZE_FIXEXT4, exttype);
     } else if (count == 8) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixext8, MPACK_TAG_SIZE_FIXEXT8, exttype);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixext8, MPACK_TAG_SIZE_FIXEXT8, exttype);
     } else if (count == 16) {
-        MPACK_WRITE_ENCODED(mpack_encode_fixext16, MPACK_TAG_SIZE_FIXEXT16, exttype);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_fixext16, MPACK_TAG_SIZE_FIXEXT16, exttype);
     } else if (count <= UINT8_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_ext8, MPACK_TAG_SIZE_EXT8, exttype, (uint8_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_ext8, MPACK_TAG_SIZE_EXT8, exttype, (uint8_t)count);
     } else if (count <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_ext16, MPACK_TAG_SIZE_EXT16, exttype, (uint16_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_ext16, MPACK_TAG_SIZE_EXT16, exttype, (uint16_t)count);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_ext32, MPACK_TAG_SIZE_EXT32, exttype, (uint32_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_ext32, MPACK_TAG_SIZE_EXT32, exttype, (uint32_t)count);
     }
 
     mpack_writer_track_push(writer, mpack_type_ext, count);
 }
-#endif
-
-
+#    endif
 
 /*
  * Compound helpers and other functions
  */
 
-void mpack_write_str(mpack_writer_t* writer, const char* data, uint32_t count) {
-    mpack_assert(data != NULL, "data for string of length %i is NULL", (int)count);
+void
+mpack_write_str(mpack_writer_t *writer, const char *data, uint32_t count)
+{
+    mpack_assert(
+        data != NULL, "data for string of length %i is NULL", (int)count);
 
-    #if MPACK_OPTIMIZE_FOR_SIZE
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_writer_track_element(writer);
     mpack_start_str_notrack(writer, count);
     mpack_write_native(writer, data, count);
-    #else
+#    else
 
     mpack_writer_track_element(writer);
 
@@ -1956,8 +2329,9 @@ void mpack_write_str(mpack_writer_t* writer, const char* data, uint32_t count) {
         // The minimum buffer size when using a flush function is guaranteed to
         // fit the largest possible fixstr.
         size_t size = count + MPACK_TAG_SIZE_FIXSTR;
-        if (MPACK_LIKELY(mpack_writer_buffer_left(writer) >= size) || mpack_writer_ensure(writer, size)) {
-            char* MPACK_RESTRICT p = writer->current;
+        if (MPACK_LIKELY(mpack_writer_buffer_left(writer) >= size)
+            || mpack_writer_ensure(writer, size)) {
+            char *MPACK_RESTRICT p = writer->current;
             mpack_encode_fixstr(p, (uint8_t)count);
             mpack_memcpy(p + MPACK_TAG_SIZE_FIXSTR, data, count);
             writer->current += count + MPACK_TAG_SIZE_FIXSTR;
@@ -1966,17 +2340,18 @@ void mpack_write_str(mpack_writer_t* writer, const char* data, uint32_t count) {
     }
 
     if (count <= UINT8_MAX
-            #if MPACK_COMPATIBILITY
-            && writer->version >= mpack_version_v5
-            #endif
-            ) {
+#        if MPACK_COMPATIBILITY
+        && writer->version >= mpack_version_v5
+#        endif
+    ) {
         if (count + MPACK_TAG_SIZE_STR8 <= mpack_writer_buffer_left(writer)) {
-            char* MPACK_RESTRICT p = writer->current;
+            char *MPACK_RESTRICT p = writer->current;
             mpack_encode_str8(p, (uint8_t)count);
             mpack_memcpy(p + MPACK_TAG_SIZE_STR8, data, count);
             writer->current += count + MPACK_TAG_SIZE_STR8;
         } else {
-            MPACK_WRITE_ENCODED(mpack_encode_str8, MPACK_TAG_SIZE_STR8, (uint8_t)count);
+            MPACK_WRITE_ENCODED(
+                mpack_encode_str8, MPACK_TAG_SIZE_STR8, (uint8_t)count);
             mpack_write_native(writer, data, count);
         }
         return;
@@ -1986,39 +2361,53 @@ void mpack_write_str(mpack_writer_t* writer, const char* data, uint32_t count) {
     // size, so we don't bother with a combined space check in order to
     // minimize code size.
     if (count <= UINT16_MAX) {
-        MPACK_WRITE_ENCODED(mpack_encode_str16, MPACK_TAG_SIZE_STR16, (uint16_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_str16, MPACK_TAG_SIZE_STR16, (uint16_t)count);
         mpack_write_native(writer, data, count);
     } else {
-        MPACK_WRITE_ENCODED(mpack_encode_str32, MPACK_TAG_SIZE_STR32, (uint32_t)count);
+        MPACK_WRITE_ENCODED(
+            mpack_encode_str32, MPACK_TAG_SIZE_STR32, (uint32_t)count);
         mpack_write_native(writer, data, count);
     }
 
-    #endif
+#    endif
 }
 
-void mpack_write_bin(mpack_writer_t* writer, const char* data, uint32_t count) {
-    mpack_assert(data != NULL, "data pointer for bin of %i bytes is NULL", (int)count);
+void
+mpack_write_bin(mpack_writer_t *writer, const char *data, uint32_t count)
+{
+    mpack_assert(
+        data != NULL, "data pointer for bin of %i bytes is NULL", (int)count);
     mpack_start_bin(writer, count);
     mpack_write_bytes(writer, data, count);
     mpack_finish_bin(writer);
 }
 
-#if MPACK_EXTENSIONS
-void mpack_write_ext(mpack_writer_t* writer, int8_t exttype, const char* data, uint32_t count) {
-    mpack_assert(data != NULL, "data pointer for ext of type %i and %i bytes is NULL", exttype, (int)count);
+#    if MPACK_EXTENSIONS
+void
+mpack_write_ext(
+    mpack_writer_t *writer, int8_t exttype, const char *data, uint32_t count)
+{
+    mpack_assert(data != NULL,
+        "data pointer for ext of type %i and %i bytes is NULL", exttype,
+        (int)count);
     mpack_start_ext(writer, exttype, count);
     mpack_write_bytes(writer, data, count);
     mpack_finish_ext(writer);
 }
-#endif
+#    endif
 
-void mpack_write_bytes(mpack_writer_t* writer, const char* data, size_t count) {
+void
+mpack_write_bytes(mpack_writer_t *writer, const char *data, size_t count)
+{
     mpack_assert(data != NULL, "data pointer for %i bytes is NULL", (int)count);
     mpack_writer_track_bytes(writer, count);
     mpack_write_native(writer, data, count);
 }
 
-void mpack_write_cstr(mpack_writer_t* writer, const char* cstr) {
+void
+mpack_write_cstr(mpack_writer_t *writer, const char *cstr)
+{
     mpack_assert(cstr != NULL, "cstr pointer is NULL");
     size_t length = mpack_strlen(cstr);
     if (length > UINT32_MAX)
@@ -2026,15 +2415,20 @@ void mpack_write_cstr(mpack_writer_t* writer, const char* cstr) {
     mpack_write_str(writer, cstr, (uint32_t)length);
 }
 
-void mpack_write_cstr_or_nil(mpack_writer_t* writer, const char* cstr) {
+void
+mpack_write_cstr_or_nil(mpack_writer_t *writer, const char *cstr)
+{
     if (cstr)
         mpack_write_cstr(writer, cstr);
     else
         mpack_write_nil(writer);
 }
 
-void mpack_write_utf8(mpack_writer_t* writer, const char* str, uint32_t length) {
-    mpack_assert(str != NULL, "data for string of length %i is NULL", (int)length);
+void
+mpack_write_utf8(mpack_writer_t *writer, const char *str, uint32_t length)
+{
+    mpack_assert(
+        str != NULL, "data for string of length %i is NULL", (int)length);
     if (!mpack_utf8_check(str, length)) {
         mpack_writer_flag_error(writer, mpack_error_invalid);
         return;
@@ -2042,7 +2436,9 @@ void mpack_write_utf8(mpack_writer_t* writer, const char* str, uint32_t length) 
     mpack_write_str(writer, str, length);
 }
 
-void mpack_write_utf8_cstr(mpack_writer_t* writer, const char* cstr) {
+void
+mpack_write_utf8_cstr(mpack_writer_t *writer, const char *cstr)
+{
     mpack_assert(cstr != NULL, "cstr pointer is NULL");
     size_t length = mpack_strlen(cstr);
     if (length > UINT32_MAX) {
@@ -2052,7 +2448,9 @@ void mpack_write_utf8_cstr(mpack_writer_t* writer, const char* cstr) {
     mpack_write_utf8(writer, cstr, (uint32_t)length);
 }
 
-void mpack_write_utf8_cstr_or_nil(mpack_writer_t* writer, const char* cstr) {
+void
+mpack_write_utf8_cstr_or_nil(mpack_writer_t *writer, const char *cstr)
+{
     if (cstr)
         mpack_write_utf8_cstr(writer, cstr);
     else
@@ -2060,7 +2458,6 @@ void mpack_write_utf8_cstr_or_nil(mpack_writer_t* writer, const char* cstr) {
 }
 
 #endif
-
 
 /* mpack/mpack-reader.c.c */
 
@@ -2070,9 +2467,12 @@ void mpack_write_utf8_cstr_or_nil(mpack_writer_t* writer, const char* cstr) {
 
 #if MPACK_READER
 
-static void mpack_reader_skip_using_fill(mpack_reader_t* reader, size_t count);
+static void mpack_reader_skip_using_fill(mpack_reader_t *reader, size_t count);
 
-void mpack_reader_init(mpack_reader_t* reader, char* buffer, size_t size, size_t count) {
+void
+mpack_reader_init(
+    mpack_reader_t *reader, char *buffer, size_t size, size_t count)
+{
     mpack_assert(buffer != NULL, "buffer is NULL");
 
     mpack_memset(reader, 0, sizeof(*reader));
@@ -2081,15 +2481,17 @@ void mpack_reader_init(mpack_reader_t* reader, char* buffer, size_t size, size_t
     reader->data = buffer;
     reader->end = buffer + count;
 
-    #if MPACK_READ_TRACKING
+#    if MPACK_READ_TRACKING
     mpack_reader_flag_if_error(reader, mpack_track_init(&reader->track));
-    #endif
+#    endif
 
     mpack_log("===========================\n");
     mpack_log("initializing reader with buffer size %i\n", (int)size);
 }
 
-void mpack_reader_init_error(mpack_reader_t* reader, mpack_error_t error) {
+void
+mpack_reader_init_error(mpack_reader_t *reader, mpack_error_t error)
+{
     mpack_memset(reader, 0, sizeof(*reader));
     reader->error = error;
 
@@ -2097,24 +2499,29 @@ void mpack_reader_init_error(mpack_reader_t* reader, mpack_error_t error) {
     mpack_log("initializing reader error state %i\n", (int)error);
 }
 
-void mpack_reader_init_data(mpack_reader_t* reader, const char* data, size_t count) {
+void
+mpack_reader_init_data(mpack_reader_t *reader, const char *data, size_t count)
+{
     mpack_assert(data != NULL, "data is NULL");
 
     mpack_memset(reader, 0, sizeof(*reader));
     reader->data = data;
     reader->end = data + count;
 
-    #if MPACK_READ_TRACKING
+#    if MPACK_READ_TRACKING
     mpack_reader_flag_if_error(reader, mpack_track_init(&reader->track));
-    #endif
+#    endif
 
     mpack_log("===========================\n");
     mpack_log("initializing reader with data size %i\n", (int)count);
 }
 
-void mpack_reader_set_fill(mpack_reader_t* reader, mpack_reader_fill_t fill) {
-    MPACK_STATIC_ASSERT(MPACK_READER_MINIMUM_BUFFER_SIZE >= MPACK_MAXIMUM_TAG_SIZE,
-            "minimum buffer size must fit any tag!");
+void
+mpack_reader_set_fill(mpack_reader_t *reader, mpack_reader_fill_t fill)
+{
+    MPACK_STATIC_ASSERT(
+        MPACK_READER_MINIMUM_BUFFER_SIZE >= MPACK_MAXIMUM_TAG_SIZE,
+        "minimum buffer size must fit any tag!");
 
     if (reader->size == 0) {
         mpack_break("cannot use fill function without a writeable buffer!");
@@ -2124,7 +2531,7 @@ void mpack_reader_set_fill(mpack_reader_t* reader, mpack_reader_fill_t fill) {
 
     if (reader->size < MPACK_READER_MINIMUM_BUFFER_SIZE) {
         mpack_break("buffer size is %i, but minimum buffer size for fill is %i",
-                (int)reader->size, MPACK_READER_MINIMUM_BUFFER_SIZE);
+            (int)reader->size, MPACK_READER_MINIMUM_BUFFER_SIZE);
         mpack_reader_flag_error(reader, mpack_error_bug);
         return;
     }
@@ -2132,24 +2539,31 @@ void mpack_reader_set_fill(mpack_reader_t* reader, mpack_reader_fill_t fill) {
     reader->fill = fill;
 }
 
-void mpack_reader_set_skip(mpack_reader_t* reader, mpack_reader_skip_t skip) {
-    mpack_assert(reader->size != 0, "cannot use skip function without a writeable buffer!");
+void
+mpack_reader_set_skip(mpack_reader_t *reader, mpack_reader_skip_t skip)
+{
+    mpack_assert(reader->size != 0,
+        "cannot use skip function without a writeable buffer!");
     reader->skip = skip;
 }
 
-#if MPACK_STDIO
-static size_t mpack_file_reader_fill(mpack_reader_t* reader, char* buffer, size_t count) {
+#    if MPACK_STDIO
+static size_t
+mpack_file_reader_fill(mpack_reader_t *reader, char *buffer, size_t count)
+{
     if (feof((FILE *)reader->context)) {
-       mpack_reader_flag_error(reader, mpack_error_eof);
-       return 0;
+        mpack_reader_flag_error(reader, mpack_error_eof);
+        return 0;
     }
-    return fread((void*)buffer, 1, count, (FILE*)reader->context);
+    return fread((void *)buffer, 1, count, (FILE *)reader->context);
 }
 
-static void mpack_file_reader_skip(mpack_reader_t* reader, size_t count) {
+static void
+mpack_file_reader_skip(mpack_reader_t *reader, size_t count)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return;
-    FILE* file = (FILE*)reader->context;
+    FILE *file = (FILE *)reader->context;
 
     // We call ftell() to test whether the stream is seekable
     // without causing a file error.
@@ -2168,7 +2582,9 @@ static void mpack_file_reader_skip(mpack_reader_t* reader, size_t count) {
     mpack_reader_skip_using_fill(reader, count);
 }
 
-static void mpack_file_reader_teardown(mpack_reader_t* reader) {
+static void
+mpack_file_reader_teardown(mpack_reader_t *reader)
+{
     MPACK_FREE(reader->buffer);
     reader->buffer = NULL;
     reader->context = NULL;
@@ -2178,8 +2594,10 @@ static void mpack_file_reader_teardown(mpack_reader_t* reader) {
     reader->teardown = NULL;
 }
 
-static void mpack_file_reader_teardown_close(mpack_reader_t* reader) {
-    FILE* file = (FILE*)reader->context;
+static void
+mpack_file_reader_teardown_close(mpack_reader_t *reader)
+{
+    FILE *file = (FILE *)reader->context;
 
     if (file) {
         int ret = fclose(file);
@@ -2190,11 +2608,14 @@ static void mpack_file_reader_teardown_close(mpack_reader_t* reader) {
     mpack_file_reader_teardown(reader);
 }
 
-void mpack_reader_init_stdfile(mpack_reader_t* reader, FILE* file, bool close_when_done) {
+void
+mpack_reader_init_stdfile(
+    mpack_reader_t *reader, FILE *file, bool close_when_done)
+{
     mpack_assert(file != NULL, "file is NULL");
 
     size_t capacity = MPACK_BUFFER_SIZE;
-    char* buffer = (char*)MPACK_MALLOC(capacity);
+    char *buffer = (char *)MPACK_MALLOC(capacity);
     if (buffer == NULL) {
         mpack_reader_init_error(reader, mpack_error_memory);
         if (close_when_done) {
@@ -2207,15 +2628,17 @@ void mpack_reader_init_stdfile(mpack_reader_t* reader, FILE* file, bool close_wh
     mpack_reader_set_context(reader, file);
     mpack_reader_set_fill(reader, mpack_file_reader_fill);
     mpack_reader_set_skip(reader, mpack_file_reader_skip);
-    mpack_reader_set_teardown(reader, close_when_done ?
-            mpack_file_reader_teardown_close :
-            mpack_file_reader_teardown);
+    mpack_reader_set_teardown(reader,
+        close_when_done ? mpack_file_reader_teardown_close
+                        : mpack_file_reader_teardown);
 }
 
-void mpack_reader_init_filename(mpack_reader_t* reader, const char* filename) {
+void
+mpack_reader_init_filename(mpack_reader_t *reader, const char *filename)
+{
     mpack_assert(filename != NULL, "filename is NULL");
 
-    FILE* file = fopen(filename, "rb");
+    FILE *file = fopen(filename, "rb");
     if (file == NULL) {
         mpack_reader_init_error(reader, mpack_error_io);
         return;
@@ -2223,14 +2646,18 @@ void mpack_reader_init_filename(mpack_reader_t* reader, const char* filename) {
 
     mpack_reader_init_stdfile(reader, file, true);
 }
-#endif
+#    endif
 
-mpack_error_t mpack_reader_destroy(mpack_reader_t* reader) {
+mpack_error_t
+mpack_reader_destroy(mpack_reader_t *reader)
+{
 
-    // clean up tracking, asserting if we're not already in an error state
-    #if MPACK_READ_TRACKING
-    mpack_reader_flag_if_error(reader, mpack_track_destroy(&reader->track, mpack_reader_error(reader) != mpack_ok));
-    #endif
+// clean up tracking, asserting if we're not already in an error state
+#    if MPACK_READ_TRACKING
+    mpack_reader_flag_if_error(reader,
+        mpack_track_destroy(
+            &reader->track, mpack_reader_error(reader) != mpack_ok));
+#    endif
 
     if (reader->teardown)
         reader->teardown(reader);
@@ -2239,22 +2666,29 @@ mpack_error_t mpack_reader_destroy(mpack_reader_t* reader) {
     return reader->error;
 }
 
-size_t mpack_reader_remaining(mpack_reader_t* reader, const char** data) {
+size_t
+mpack_reader_remaining(mpack_reader_t *reader, const char **data)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return 0;
 
-    #if MPACK_READ_TRACKING
-    if (mpack_reader_flag_if_error(reader, mpack_track_check_empty(&reader->track)) != mpack_ok)
+#    if MPACK_READ_TRACKING
+    if (mpack_reader_flag_if_error(
+            reader, mpack_track_check_empty(&reader->track))
+        != mpack_ok)
         return 0;
-    #endif
+#    endif
 
     if (data)
         *data = reader->data;
     return (size_t)(reader->end - reader->data);
 }
 
-void mpack_reader_flag_error(mpack_reader_t* reader, mpack_error_t error) {
-    mpack_log("reader %p setting error %i: %s\n", reader, (int)error, mpack_error_to_string(error));
+void
+mpack_reader_flag_error(mpack_reader_t *reader, mpack_error_t error)
+{
+    mpack_log("reader %p setting error %i: %s\n", reader, (int)error,
+        mpack_error_to_string(error));
 
     if (reader->error == mpack_ok) {
         reader->error = error;
@@ -2266,11 +2700,16 @@ void mpack_reader_flag_error(mpack_reader_t* reader, mpack_error_t error) {
 
 // Loops on the fill function, reading between the minimum and
 // maximum number of bytes and flagging an error if it fails.
-MPACK_NOINLINE static size_t mpack_fill_range(mpack_reader_t* reader, char* p, size_t min_bytes, size_t max_bytes) {
-    mpack_assert(reader->fill != NULL, "mpack_fill_range() called with no fill function?");
+MPACK_NOINLINE static size_t
+mpack_fill_range(
+    mpack_reader_t *reader, char *p, size_t min_bytes, size_t max_bytes)
+{
+    mpack_assert(reader->fill != NULL,
+        "mpack_fill_range() called with no fill function?");
     mpack_assert(min_bytes > 0, "cannot fill zero bytes!");
-    mpack_assert(max_bytes >= min_bytes, "min_bytes %i cannot be larger than max_bytes %i!",
-            (int)min_bytes, (int)max_bytes);
+    mpack_assert(max_bytes >= min_bytes,
+        "min_bytes %i cannot be larger than max_bytes %i!", (int)min_bytes,
+        (int)max_bytes);
 
     size_t count = 0;
     while (count < min_bytes) {
@@ -2290,14 +2729,17 @@ MPACK_NOINLINE static size_t mpack_fill_range(mpack_reader_t* reader, char* p, s
     return count;
 }
 
-MPACK_NOINLINE bool mpack_reader_ensure_straddle(mpack_reader_t* reader, size_t count) {
+MPACK_NOINLINE bool
+mpack_reader_ensure_straddle(mpack_reader_t *reader, size_t count)
+{
     mpack_assert(count != 0, "cannot ensure zero bytes!");
-    mpack_assert(reader->error == mpack_ok, "reader cannot be in an error state!");
+    mpack_assert(
+        reader->error == mpack_ok, "reader cannot be in an error state!");
 
     mpack_assert(count > (size_t)(reader->end - reader->data),
-            "straddling ensure requested for %i bytes, but there are %i bytes "
-            "left in buffer. call mpack_reader_ensure() instead",
-            (int)count, (int)(reader->end - reader->data));
+        "straddling ensure requested for %i bytes, but there are %i bytes "
+        "left in buffer. call mpack_reader_ensure() instead",
+        (int)count, (int)(reader->end - reader->data));
 
     // we'll need a fill function to get more data. if there's no
     // fill function, the buffer should contain an entire MessagePack
@@ -2324,8 +2766,8 @@ MPACK_NOINLINE bool mpack_reader_ensure_straddle(mpack_reader_t* reader, size_t 
 
     // read at least the necessary number of bytes, accepting up to the
     // buffer size
-    size_t read = mpack_fill_range(reader, reader->buffer + left,
-            count - left, reader->size - left);
+    size_t read = mpack_fill_range(
+        reader, reader->buffer + left, count - left, reader->size - left);
     if (mpack_reader_error(reader) != mpack_ok)
         return false;
     reader->end += read;
@@ -2334,8 +2776,11 @@ MPACK_NOINLINE bool mpack_reader_ensure_straddle(mpack_reader_t* reader, size_t 
 
 // Reads count bytes into p. Used when there are not enough bytes
 // left in the buffer to satisfy a read.
-MPACK_NOINLINE void mpack_read_native_straddle(mpack_reader_t* reader, char* p, size_t count) {
-    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL", (int)count);
+MPACK_NOINLINE void
+mpack_read_native_straddle(mpack_reader_t *reader, char *p, size_t count)
+{
+    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL",
+        (int)count);
 
     if (mpack_reader_error(reader) != mpack_ok) {
         mpack_memset(p, 0, count);
@@ -2343,14 +2788,15 @@ MPACK_NOINLINE void mpack_read_native_straddle(mpack_reader_t* reader, char* p, 
     }
 
     size_t left = (size_t)(reader->end - reader->data);
-    mpack_log("big read for %i bytes into %p, %i left in buffer, buffer size %i\n",
-            (int)count, p, (int)left, (int)reader->size);
+    mpack_log(
+        "big read for %i bytes into %p, %i left in buffer, buffer size %i\n",
+        (int)count, p, (int)left, (int)reader->size);
 
     if (count <= left) {
         mpack_assert(0,
-                "big read requested for %i bytes, but there are %i bytes "
-                "left in buffer. call mpack_read_native() instead",
-                (int)count, (int)left);
+            "big read requested for %i bytes, but there are %i bytes "
+            "left in buffer. call mpack_read_native() instead",
+            (int)count, (int)left);
         mpack_reader_flag_error(reader, mpack_error_bug);
         mpack_memset(p, 0, count);
         return;
@@ -2390,21 +2836,24 @@ MPACK_NOINLINE void mpack_read_native_straddle(mpack_reader_t* reader, char* p, 
     // buffer size, we'll try to fill the buffer as much as possible
     // and copy the needed data out.
     if (count <= reader->size / MPACK_READER_SMALL_FRACTION_DENOMINATOR) {
-        size_t read = mpack_fill_range(reader, reader->buffer, count, reader->size);
+        size_t read
+            = mpack_fill_range(reader, reader->buffer, count, reader->size);
         if (mpack_reader_error(reader) != mpack_ok)
             return;
         mpack_memcpy(p, reader->buffer, count);
         reader->data = reader->buffer + count;
         reader->end = reader->buffer + read;
 
-    // otherwise we read the remaining data directly into the target.
+        // otherwise we read the remaining data directly into the target.
     } else {
         mpack_log("reading %i additional bytes\n", (int)count);
         mpack_fill_range(reader, p, count, count);
     }
 }
 
-MPACK_NOINLINE static void mpack_skip_bytes_straddle(mpack_reader_t* reader, size_t count) {
+MPACK_NOINLINE static void
+mpack_skip_bytes_straddle(mpack_reader_t *reader, size_t count)
+{
 
     // we'll need at least a fill function to skip more data. if there's
     // no fill function, the buffer should contain an entire MessagePack
@@ -2435,7 +2884,9 @@ MPACK_NOINLINE static void mpack_skip_bytes_straddle(mpack_reader_t* reader, siz
     mpack_reader_skip_using_fill(reader, count);
 }
 
-void mpack_skip_bytes(mpack_reader_t* reader, size_t count) {
+void
+mpack_skip_bytes(mpack_reader_t *reader, size_t count)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return;
     mpack_log("skip requested for %i bytes\n", (int)count);
@@ -2452,16 +2903,22 @@ void mpack_skip_bytes(mpack_reader_t* reader, size_t count) {
     mpack_skip_bytes_straddle(reader, count);
 }
 
-MPACK_NOINLINE static void mpack_reader_skip_using_fill(mpack_reader_t* reader, size_t count) {
+MPACK_NOINLINE static void
+mpack_reader_skip_using_fill(mpack_reader_t *reader, size_t count)
+{
     mpack_assert(reader->fill != NULL, "missing fill function!");
-    mpack_assert(reader->data == reader->end, "there are bytes left in the buffer!");
-    mpack_assert(reader->error == mpack_ok, "should not have called this in an error state (%i)", reader->error);
+    mpack_assert(
+        reader->data == reader->end, "there are bytes left in the buffer!");
+    mpack_assert(reader->error == mpack_ok,
+        "should not have called this in an error state (%i)", reader->error);
     mpack_log("skip using fill for %i bytes\n", (int)count);
 
     // fill and discard multiples of the buffer size
     while (count > reader->size) {
-        mpack_log("filling and discarding buffer of %i bytes\n", (int)reader->size);
-        if (mpack_fill_range(reader, reader->buffer, reader->size, reader->size) < reader->size) {
+        mpack_log(
+            "filling and discarding buffer of %i bytes\n", (int)reader->size);
+        if (mpack_fill_range(reader, reader->buffer, reader->size, reader->size)
+            < reader->size) {
             mpack_reader_flag_error(reader, mpack_error_io);
             return;
         }
@@ -2476,28 +2933,42 @@ MPACK_NOINLINE static void mpack_reader_skip_using_fill(mpack_reader_t* reader, 
         return;
     }
     reader->end = reader->data + read;
-    mpack_log("filled %i bytes into buffer; discarding %i bytes\n", (int)read, (int)count);
+    mpack_log("filled %i bytes into buffer; discarding %i bytes\n", (int)read,
+        (int)count);
     reader->data += count;
 }
 
-void mpack_read_bytes(mpack_reader_t* reader, char* p, size_t count) {
-    mpack_assert(p != NULL, "destination for read of %i bytes is NULL", (int)count);
+void
+mpack_read_bytes(mpack_reader_t *reader, char *p, size_t count)
+{
+    mpack_assert(
+        p != NULL, "destination for read of %i bytes is NULL", (int)count);
     mpack_reader_track_bytes(reader, count);
     mpack_read_native(reader, p, count);
 }
 
-void mpack_read_utf8(mpack_reader_t* reader, char* p, size_t byte_count) {
-    mpack_assert(p != NULL, "destination for read of %i bytes is NULL", (int)byte_count);
+void
+mpack_read_utf8(mpack_reader_t *reader, char *p, size_t byte_count)
+{
+    mpack_assert(
+        p != NULL, "destination for read of %i bytes is NULL", (int)byte_count);
     mpack_reader_track_str_bytes_all(reader, byte_count);
     mpack_read_native(reader, p, byte_count);
 
-    if (mpack_reader_error(reader) == mpack_ok && !mpack_utf8_check(p, byte_count))
+    if (mpack_reader_error(reader) == mpack_ok
+        && !mpack_utf8_check(p, byte_count))
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-static void mpack_read_cstr_unchecked(mpack_reader_t* reader, char* buf, size_t buffer_size, size_t byte_count) {
-    mpack_assert(buf != NULL, "destination for read of %i bytes is NULL", (int)byte_count);
-    mpack_assert(buffer_size >= 1, "buffer size is zero; you must have room for at least a null-terminator");
+static void
+mpack_read_cstr_unchecked(
+    mpack_reader_t *reader, char *buf, size_t buffer_size, size_t byte_count)
+{
+    mpack_assert(buf != NULL, "destination for read of %i bytes is NULL",
+        (int)byte_count);
+    mpack_assert(buffer_size >= 1,
+        "buffer size is zero; you must have room for at least a "
+        "null-terminator");
 
     if (mpack_reader_error(reader)) {
         buf[0] = 0;
@@ -2515,39 +2986,54 @@ static void mpack_read_cstr_unchecked(mpack_reader_t* reader, char* buf, size_t 
     buf[byte_count] = 0;
 }
 
-void mpack_read_cstr(mpack_reader_t* reader, char* buf, size_t buffer_size, size_t byte_count) {
+void
+mpack_read_cstr(
+    mpack_reader_t *reader, char *buf, size_t buffer_size, size_t byte_count)
+{
     mpack_read_cstr_unchecked(reader, buf, buffer_size, byte_count);
 
     // check for null bytes
-    if (mpack_reader_error(reader) == mpack_ok && !mpack_str_check_no_null(buf, byte_count)) {
+    if (mpack_reader_error(reader) == mpack_ok
+        && !mpack_str_check_no_null(buf, byte_count)) {
         buf[0] = 0;
         mpack_reader_flag_error(reader, mpack_error_type);
     }
 }
 
-void mpack_read_utf8_cstr(mpack_reader_t* reader, char* buf, size_t buffer_size, size_t byte_count) {
+void
+mpack_read_utf8_cstr(
+    mpack_reader_t *reader, char *buf, size_t buffer_size, size_t byte_count)
+{
     mpack_read_cstr_unchecked(reader, buf, buffer_size, byte_count);
 
     // check encoding
-    if (mpack_reader_error(reader) == mpack_ok && !mpack_utf8_check_no_null(buf, byte_count)) {
+    if (mpack_reader_error(reader) == mpack_ok
+        && !mpack_utf8_check_no_null(buf, byte_count)) {
         buf[0] = 0;
         mpack_reader_flag_error(reader, mpack_error_type);
     }
 }
 
-#ifdef MPACK_MALLOC
-// Reads native bytes with error callback disabled. This allows MPack reader functions
-// to hold an allocated buffer and read native data into it without leaking it in
-// case of a non-local jump (longjmp, throw) out of an error handler.
-static void mpack_read_native_noerrorfn(mpack_reader_t* reader, char* p, size_t count) {
-    mpack_assert(reader->error == mpack_ok, "cannot call if an error is already flagged!");
+#    ifdef MPACK_MALLOC
+// Reads native bytes with error callback disabled. This allows MPack reader
+// functions to hold an allocated buffer and read native data into it without
+// leaking it in case of a non-local jump (longjmp, throw) out of an error
+// handler.
+static void
+mpack_read_native_noerrorfn(mpack_reader_t *reader, char *p, size_t count)
+{
+    mpack_assert(reader->error == mpack_ok,
+        "cannot call if an error is already flagged!");
     mpack_reader_error_t error_fn = reader->error_fn;
     reader->error_fn = NULL;
     mpack_read_native(reader, p, count);
     reader->error_fn = error_fn;
 }
 
-char* mpack_read_bytes_alloc_impl(mpack_reader_t* reader, size_t count, bool null_terminated) {
+char *
+mpack_read_bytes_alloc_impl(
+    mpack_reader_t *reader, size_t count, bool null_terminated)
+{
 
     // track the bytes first in case it jumps
     mpack_reader_track_bytes(reader, count);
@@ -2559,7 +3045,8 @@ char* mpack_read_bytes_alloc_impl(mpack_reader_t* reader, size_t count, bool nul
         return NULL;
 
     // allocate data
-    char* data = (char*)MPACK_MALLOC(count + (null_terminated ? 1 : 0)); // TODO: can this overflow?
+    char *data = (char *)MPACK_MALLOC(
+        count + (null_terminated ? 1 : 0)); // TODO: can this overflow?
     if (data == NULL) {
         mpack_reader_flag_error(reader, mpack_error_memory);
         return NULL;
@@ -2580,17 +3067,19 @@ char* mpack_read_bytes_alloc_impl(mpack_reader_t* reader, size_t count, bool nul
         data[count] = '\0';
     return data;
 }
-#endif
+#    endif
 
 // read inplace without tracking (since there are different
 // tracking modes for different inplace readers)
-static const char* mpack_read_bytes_inplace_notrack(mpack_reader_t* reader, size_t count) {
+static const char *
+mpack_read_bytes_inplace_notrack(mpack_reader_t *reader, size_t count)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return NULL;
 
     // if we have enough bytes already in the buffer, we can return it directly.
     if ((size_t)(reader->end - reader->data) >= count) {
-        const char* bytes = reader->data;
+        const char *bytes = reader->data;
         reader->data += count;
         return bytes;
     }
@@ -2598,21 +3087,26 @@ static const char* mpack_read_bytes_inplace_notrack(mpack_reader_t* reader, size
     if (!mpack_reader_ensure(reader, count))
         return NULL;
 
-    const char* bytes = reader->data;
+    const char *bytes = reader->data;
     reader->data += count;
     return bytes;
 }
 
-const char* mpack_read_bytes_inplace(mpack_reader_t* reader, size_t count) {
+const char *
+mpack_read_bytes_inplace(mpack_reader_t *reader, size_t count)
+{
     mpack_reader_track_bytes(reader, count);
     return mpack_read_bytes_inplace_notrack(reader, count);
 }
 
-const char* mpack_read_utf8_inplace(mpack_reader_t* reader, size_t count) {
+const char *
+mpack_read_utf8_inplace(mpack_reader_t *reader, size_t count)
+{
     mpack_reader_track_str_bytes_all(reader, count);
-    const char* str = mpack_read_bytes_inplace_notrack(reader, count);
+    const char *str = mpack_read_bytes_inplace_notrack(reader, count);
 
-    if (mpack_reader_error(reader) == mpack_ok && !mpack_utf8_check(str, count)) {
+    if (mpack_reader_error(reader) == mpack_ok
+        && !mpack_utf8_check(str, count)) {
         mpack_reader_flag_error(reader, mpack_error_type);
         return NULL;
     }
@@ -2620,8 +3114,11 @@ const char* mpack_read_utf8_inplace(mpack_reader_t* reader, size_t count) {
     return str;
 }
 
-static size_t mpack_parse_tag(mpack_reader_t* reader, mpack_tag_t* tag) {
-    mpack_assert(reader->error == mpack_ok, "reader cannot be in an error state!");
+static size_t
+mpack_parse_tag(mpack_reader_t *reader, mpack_tag_t *tag)
+{
+    mpack_assert(
+        reader->error == mpack_ok, "reader cannot be in an error state!");
 
     if (!mpack_reader_ensure(reader, 1))
         return 0;
@@ -2634,337 +3131,546 @@ static size_t mpack_parse_tag(mpack_reader_t* reader, mpack_tag_t* tag) {
     // in size-optimized builds, we switch on the top four bits first to
     // handle most infix types with a smaller jump table to save space.
 
-    #if MPACK_OPTIMIZE_FOR_SIZE
+#    if MPACK_OPTIMIZE_FOR_SIZE
     switch (type >> 4) {
 
-        // positive fixnum
-        case 0x0: case 0x1: case 0x2: case 0x3:
-        case 0x4: case 0x5: case 0x6: case 0x7:
-            *tag = mpack_tag_make_uint(type);
-            return 1;
+    // positive fixnum
+    case 0x0:
+    case 0x1:
+    case 0x2:
+    case 0x3:
+    case 0x4:
+    case 0x5:
+    case 0x6:
+    case 0x7:
+        *tag = mpack_tag_make_uint(type);
+        return 1;
 
-        // negative fixnum
-        case 0xe: case 0xf:
-            *tag = mpack_tag_make_int((int8_t)type);
-            return 1;
+    // negative fixnum
+    case 0xe:
+    case 0xf:
+        *tag = mpack_tag_make_int((int8_t)type);
+        return 1;
 
-        // fixmap
-        case 0x8:
-            *tag = mpack_tag_make_map(type & ~0xf0u);
-            return 1;
+    // fixmap
+    case 0x8:
+        *tag = mpack_tag_make_map(type & ~0xf0u);
+        return 1;
 
-        // fixarray
-        case 0x9:
-            *tag = mpack_tag_make_array(type & ~0xf0u);
-            return 1;
+    // fixarray
+    case 0x9:
+        *tag = mpack_tag_make_array(type & ~0xf0u);
+        return 1;
 
-        // fixstr
-        case 0xa: case 0xb:
-            *tag = mpack_tag_make_str(type & ~0xe0u);
-            return 1;
+    // fixstr
+    case 0xa:
+    case 0xb:
+        *tag = mpack_tag_make_str(type & ~0xe0u);
+        return 1;
 
-        // not one of the common infix types
-        default:
-            break;
-
+    // not one of the common infix types
+    default:
+        break;
     }
-    #endif
+#    endif
 
     // handle individual type tags
     switch (type) {
 
-        #if !MPACK_OPTIMIZE_FOR_SIZE
-        // positive fixnum
-        case 0x00: case 0x01: case 0x02: case 0x03: case 0x04: case 0x05: case 0x06: case 0x07:
-        case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
-        case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17:
-        case 0x18: case 0x19: case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e: case 0x1f:
-        case 0x20: case 0x21: case 0x22: case 0x23: case 0x24: case 0x25: case 0x26: case 0x27:
-        case 0x28: case 0x29: case 0x2a: case 0x2b: case 0x2c: case 0x2d: case 0x2e: case 0x2f:
-        case 0x30: case 0x31: case 0x32: case 0x33: case 0x34: case 0x35: case 0x36: case 0x37:
-        case 0x38: case 0x39: case 0x3a: case 0x3b: case 0x3c: case 0x3d: case 0x3e: case 0x3f:
-        case 0x40: case 0x41: case 0x42: case 0x43: case 0x44: case 0x45: case 0x46: case 0x47:
-        case 0x48: case 0x49: case 0x4a: case 0x4b: case 0x4c: case 0x4d: case 0x4e: case 0x4f:
-        case 0x50: case 0x51: case 0x52: case 0x53: case 0x54: case 0x55: case 0x56: case 0x57:
-        case 0x58: case 0x59: case 0x5a: case 0x5b: case 0x5c: case 0x5d: case 0x5e: case 0x5f:
-        case 0x60: case 0x61: case 0x62: case 0x63: case 0x64: case 0x65: case 0x66: case 0x67:
-        case 0x68: case 0x69: case 0x6a: case 0x6b: case 0x6c: case 0x6d: case 0x6e: case 0x6f:
-        case 0x70: case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
-        case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7e: case 0x7f:
-            *tag = mpack_tag_make_uint(type);
-            return 1;
+#    if !MPACK_OPTIMIZE_FOR_SIZE
+    // positive fixnum
+    case 0x00:
+    case 0x01:
+    case 0x02:
+    case 0x03:
+    case 0x04:
+    case 0x05:
+    case 0x06:
+    case 0x07:
+    case 0x08:
+    case 0x09:
+    case 0x0a:
+    case 0x0b:
+    case 0x0c:
+    case 0x0d:
+    case 0x0e:
+    case 0x0f:
+    case 0x10:
+    case 0x11:
+    case 0x12:
+    case 0x13:
+    case 0x14:
+    case 0x15:
+    case 0x16:
+    case 0x17:
+    case 0x18:
+    case 0x19:
+    case 0x1a:
+    case 0x1b:
+    case 0x1c:
+    case 0x1d:
+    case 0x1e:
+    case 0x1f:
+    case 0x20:
+    case 0x21:
+    case 0x22:
+    case 0x23:
+    case 0x24:
+    case 0x25:
+    case 0x26:
+    case 0x27:
+    case 0x28:
+    case 0x29:
+    case 0x2a:
+    case 0x2b:
+    case 0x2c:
+    case 0x2d:
+    case 0x2e:
+    case 0x2f:
+    case 0x30:
+    case 0x31:
+    case 0x32:
+    case 0x33:
+    case 0x34:
+    case 0x35:
+    case 0x36:
+    case 0x37:
+    case 0x38:
+    case 0x39:
+    case 0x3a:
+    case 0x3b:
+    case 0x3c:
+    case 0x3d:
+    case 0x3e:
+    case 0x3f:
+    case 0x40:
+    case 0x41:
+    case 0x42:
+    case 0x43:
+    case 0x44:
+    case 0x45:
+    case 0x46:
+    case 0x47:
+    case 0x48:
+    case 0x49:
+    case 0x4a:
+    case 0x4b:
+    case 0x4c:
+    case 0x4d:
+    case 0x4e:
+    case 0x4f:
+    case 0x50:
+    case 0x51:
+    case 0x52:
+    case 0x53:
+    case 0x54:
+    case 0x55:
+    case 0x56:
+    case 0x57:
+    case 0x58:
+    case 0x59:
+    case 0x5a:
+    case 0x5b:
+    case 0x5c:
+    case 0x5d:
+    case 0x5e:
+    case 0x5f:
+    case 0x60:
+    case 0x61:
+    case 0x62:
+    case 0x63:
+    case 0x64:
+    case 0x65:
+    case 0x66:
+    case 0x67:
+    case 0x68:
+    case 0x69:
+    case 0x6a:
+    case 0x6b:
+    case 0x6c:
+    case 0x6d:
+    case 0x6e:
+    case 0x6f:
+    case 0x70:
+    case 0x71:
+    case 0x72:
+    case 0x73:
+    case 0x74:
+    case 0x75:
+    case 0x76:
+    case 0x77:
+    case 0x78:
+    case 0x79:
+    case 0x7a:
+    case 0x7b:
+    case 0x7c:
+    case 0x7d:
+    case 0x7e:
+    case 0x7f:
+        *tag = mpack_tag_make_uint(type);
+        return 1;
 
-        // negative fixnum
-        case 0xe0: case 0xe1: case 0xe2: case 0xe3: case 0xe4: case 0xe5: case 0xe6: case 0xe7:
-        case 0xe8: case 0xe9: case 0xea: case 0xeb: case 0xec: case 0xed: case 0xee: case 0xef:
-        case 0xf0: case 0xf1: case 0xf2: case 0xf3: case 0xf4: case 0xf5: case 0xf6: case 0xf7:
-        case 0xf8: case 0xf9: case 0xfa: case 0xfb: case 0xfc: case 0xfd: case 0xfe: case 0xff:
-            *tag = mpack_tag_make_int((int8_t)type);
-            return 1;
+    // negative fixnum
+    case 0xe0:
+    case 0xe1:
+    case 0xe2:
+    case 0xe3:
+    case 0xe4:
+    case 0xe5:
+    case 0xe6:
+    case 0xe7:
+    case 0xe8:
+    case 0xe9:
+    case 0xea:
+    case 0xeb:
+    case 0xec:
+    case 0xed:
+    case 0xee:
+    case 0xef:
+    case 0xf0:
+    case 0xf1:
+    case 0xf2:
+    case 0xf3:
+    case 0xf4:
+    case 0xf5:
+    case 0xf6:
+    case 0xf7:
+    case 0xf8:
+    case 0xf9:
+    case 0xfa:
+    case 0xfb:
+    case 0xfc:
+    case 0xfd:
+    case 0xfe:
+    case 0xff:
+        *tag = mpack_tag_make_int((int8_t)type);
+        return 1;
 
-        // fixmap
-        case 0x80: case 0x81: case 0x82: case 0x83: case 0x84: case 0x85: case 0x86: case 0x87:
-        case 0x88: case 0x89: case 0x8a: case 0x8b: case 0x8c: case 0x8d: case 0x8e: case 0x8f:
-            *tag = mpack_tag_make_map(type & ~0xf0u);
-            return 1;
+    // fixmap
+    case 0x80:
+    case 0x81:
+    case 0x82:
+    case 0x83:
+    case 0x84:
+    case 0x85:
+    case 0x86:
+    case 0x87:
+    case 0x88:
+    case 0x89:
+    case 0x8a:
+    case 0x8b:
+    case 0x8c:
+    case 0x8d:
+    case 0x8e:
+    case 0x8f:
+        *tag = mpack_tag_make_map(type & ~0xf0u);
+        return 1;
 
-        // fixarray
-        case 0x90: case 0x91: case 0x92: case 0x93: case 0x94: case 0x95: case 0x96: case 0x97:
-        case 0x98: case 0x99: case 0x9a: case 0x9b: case 0x9c: case 0x9d: case 0x9e: case 0x9f:
-            *tag = mpack_tag_make_array(type & ~0xf0u);
-            return 1;
+    // fixarray
+    case 0x90:
+    case 0x91:
+    case 0x92:
+    case 0x93:
+    case 0x94:
+    case 0x95:
+    case 0x96:
+    case 0x97:
+    case 0x98:
+    case 0x99:
+    case 0x9a:
+    case 0x9b:
+    case 0x9c:
+    case 0x9d:
+    case 0x9e:
+    case 0x9f:
+        *tag = mpack_tag_make_array(type & ~0xf0u);
+        return 1;
 
-        // fixstr
-        case 0xa0: case 0xa1: case 0xa2: case 0xa3: case 0xa4: case 0xa5: case 0xa6: case 0xa7:
-        case 0xa8: case 0xa9: case 0xaa: case 0xab: case 0xac: case 0xad: case 0xae: case 0xaf:
-        case 0xb0: case 0xb1: case 0xb2: case 0xb3: case 0xb4: case 0xb5: case 0xb6: case 0xb7:
-        case 0xb8: case 0xb9: case 0xba: case 0xbb: case 0xbc: case 0xbd: case 0xbe: case 0xbf:
-            *tag = mpack_tag_make_str(type & ~0xe0u);
-            return 1;
-        #endif
+    // fixstr
+    case 0xa0:
+    case 0xa1:
+    case 0xa2:
+    case 0xa3:
+    case 0xa4:
+    case 0xa5:
+    case 0xa6:
+    case 0xa7:
+    case 0xa8:
+    case 0xa9:
+    case 0xaa:
+    case 0xab:
+    case 0xac:
+    case 0xad:
+    case 0xae:
+    case 0xaf:
+    case 0xb0:
+    case 0xb1:
+    case 0xb2:
+    case 0xb3:
+    case 0xb4:
+    case 0xb5:
+    case 0xb6:
+    case 0xb7:
+    case 0xb8:
+    case 0xb9:
+    case 0xba:
+    case 0xbb:
+    case 0xbc:
+    case 0xbd:
+    case 0xbe:
+    case 0xbf:
+        *tag = mpack_tag_make_str(type & ~0xe0u);
+        return 1;
+#    endif
 
-        // nil
-        case 0xc0:
-            *tag = mpack_tag_make_nil();
-            return 1;
+    // nil
+    case 0xc0:
+        *tag = mpack_tag_make_nil();
+        return 1;
 
-        // bool
-        case 0xc2: case 0xc3:
-            *tag = mpack_tag_make_bool((bool)(type & 1));
-            return 1;
+    // bool
+    case 0xc2:
+    case 0xc3:
+        *tag = mpack_tag_make_bool((bool)(type & 1));
+        return 1;
 
-        // bin8
-        case 0xc4:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_BIN8))
-                return 0;
-            *tag = mpack_tag_make_bin(mpack_load_u8(reader->data + 1));
-            return MPACK_TAG_SIZE_BIN8;
-
-        // bin16
-        case 0xc5:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_BIN16))
-                return 0;
-            *tag = mpack_tag_make_bin(mpack_load_u16(reader->data + 1));
-            return MPACK_TAG_SIZE_BIN16;
-
-        // bin32
-        case 0xc6:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_BIN32))
-                return 0;
-            *tag = mpack_tag_make_bin(mpack_load_u32(reader->data + 1));
-            return MPACK_TAG_SIZE_BIN32;
-
-        #if MPACK_EXTENSIONS
-        // ext8
-        case 0xc7:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_EXT8))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 2), mpack_load_u8(reader->data + 1));
-            return MPACK_TAG_SIZE_EXT8;
-
-        // ext16
-        case 0xc8:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_EXT16))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 3), mpack_load_u16(reader->data + 1));
-            return MPACK_TAG_SIZE_EXT16;
-
-        // ext32
-        case 0xc9:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_EXT32))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 5), mpack_load_u32(reader->data + 1));
-            return MPACK_TAG_SIZE_EXT32;
-        #endif
-
-        // float
-        case 0xca:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FLOAT))
-                return 0;
-            *tag = mpack_tag_make_float(mpack_load_float(reader->data + 1));
-            return MPACK_TAG_SIZE_FLOAT;
-
-        // double
-        case 0xcb:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_DOUBLE))
-                return 0;
-            *tag = mpack_tag_make_double(mpack_load_double(reader->data + 1));
-            return MPACK_TAG_SIZE_DOUBLE;
-
-        // uint8
-        case 0xcc:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U8))
-                return 0;
-            *tag = mpack_tag_make_uint(mpack_load_u8(reader->data + 1));
-            return MPACK_TAG_SIZE_U8;
-
-        // uint16
-        case 0xcd:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U16))
-                return 0;
-            *tag = mpack_tag_make_uint(mpack_load_u16(reader->data + 1));
-            return MPACK_TAG_SIZE_U16;
-
-        // uint32
-        case 0xce:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U32))
-                return 0;
-            *tag = mpack_tag_make_uint(mpack_load_u32(reader->data + 1));
-            return MPACK_TAG_SIZE_U32;
-
-        // uint64
-        case 0xcf:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U64))
-                return 0;
-            *tag = mpack_tag_make_uint(mpack_load_u64(reader->data + 1));
-            return MPACK_TAG_SIZE_U64;
-
-        // int8
-        case 0xd0:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I8))
-                return 0;
-            *tag = mpack_tag_make_int(mpack_load_i8(reader->data + 1));
-            return MPACK_TAG_SIZE_I8;
-
-        // int16
-        case 0xd1:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I16))
-                return 0;
-            *tag = mpack_tag_make_int(mpack_load_i16(reader->data + 1));
-            return MPACK_TAG_SIZE_I16;
-
-        // int32
-        case 0xd2:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I32))
-                return 0;
-            *tag = mpack_tag_make_int(mpack_load_i32(reader->data + 1));
-            return MPACK_TAG_SIZE_I32;
-
-        // int64
-        case 0xd3:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I64))
-                return 0;
-            *tag = mpack_tag_make_int(mpack_load_i64(reader->data + 1));
-            return MPACK_TAG_SIZE_I64;
-
-        #if MPACK_EXTENSIONS
-        // fixext1
-        case 0xd4:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT1))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 1);
-            return MPACK_TAG_SIZE_FIXEXT1;
-
-        // fixext2
-        case 0xd5:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT2))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 2);
-            return MPACK_TAG_SIZE_FIXEXT2;
-
-        // fixext4
-        case 0xd6:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT4))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 4);
-            return 2;
-
-        // fixext8
-        case 0xd7:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT8))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 8);
-            return MPACK_TAG_SIZE_FIXEXT8;
-
-        // fixext16
-        case 0xd8:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT16))
-                return 0;
-            *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 16);
-            return MPACK_TAG_SIZE_FIXEXT16;
-        #endif
-
-        // str8
-        case 0xd9:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_STR8))
-                return 0;
-            *tag = mpack_tag_make_str(mpack_load_u8(reader->data + 1));
-            return MPACK_TAG_SIZE_STR8;
-
-        // str16
-        case 0xda:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_STR16))
-                return 0;
-            *tag = mpack_tag_make_str(mpack_load_u16(reader->data + 1));
-            return MPACK_TAG_SIZE_STR16;
-
-        // str32
-        case 0xdb:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_STR32))
-                return 0;
-            *tag = mpack_tag_make_str(mpack_load_u32(reader->data + 1));
-            return MPACK_TAG_SIZE_STR32;
-
-        // array16
-        case 0xdc:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_ARRAY16))
-                return 0;
-            *tag = mpack_tag_make_array(mpack_load_u16(reader->data + 1));
-            return MPACK_TAG_SIZE_ARRAY16;
-
-        // array32
-        case 0xdd:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_ARRAY32))
-                return 0;
-            *tag = mpack_tag_make_array(mpack_load_u32(reader->data + 1));
-            return MPACK_TAG_SIZE_ARRAY32;
-
-        // map16
-        case 0xde:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_MAP16))
-                return 0;
-            *tag = mpack_tag_make_map(mpack_load_u16(reader->data + 1));
-            return MPACK_TAG_SIZE_MAP16;
-
-        // map32
-        case 0xdf:
-            if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_MAP32))
-                return 0;
-            *tag = mpack_tag_make_map(mpack_load_u32(reader->data + 1));
-            return MPACK_TAG_SIZE_MAP32;
-
-        // reserved
-        case 0xc1:
-            mpack_reader_flag_error(reader, mpack_error_invalid);
+    // bin8
+    case 0xc4:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_BIN8))
             return 0;
+        *tag = mpack_tag_make_bin(mpack_load_u8(reader->data + 1));
+        return MPACK_TAG_SIZE_BIN8;
 
-        #if !MPACK_EXTENSIONS
-        // ext
-        case 0xc7: // fallthrough
-        case 0xc8: // fallthrough
-        case 0xc9: // fallthrough
-        // fixext
-        case 0xd4: // fallthrough
-        case 0xd5: // fallthrough
-        case 0xd6: // fallthrough
-        case 0xd7: // fallthrough
-        case 0xd8:
-            mpack_reader_flag_error(reader, mpack_error_unsupported);
+    // bin16
+    case 0xc5:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_BIN16))
             return 0;
-        #endif
+        *tag = mpack_tag_make_bin(mpack_load_u16(reader->data + 1));
+        return MPACK_TAG_SIZE_BIN16;
 
-        #if MPACK_OPTIMIZE_FOR_SIZE
-        // any other bytes should have been handled by the infix switch
-        default:
-            break;
-        #endif
+    // bin32
+    case 0xc6:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_BIN32))
+            return 0;
+        *tag = mpack_tag_make_bin(mpack_load_u32(reader->data + 1));
+        return MPACK_TAG_SIZE_BIN32;
+
+#    if MPACK_EXTENSIONS
+    // ext8
+    case 0xc7:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_EXT8))
+            return 0;
+        *tag = mpack_tag_make_ext(
+            mpack_load_i8(reader->data + 2), mpack_load_u8(reader->data + 1));
+        return MPACK_TAG_SIZE_EXT8;
+
+    // ext16
+    case 0xc8:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_EXT16))
+            return 0;
+        *tag = mpack_tag_make_ext(
+            mpack_load_i8(reader->data + 3), mpack_load_u16(reader->data + 1));
+        return MPACK_TAG_SIZE_EXT16;
+
+    // ext32
+    case 0xc9:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_EXT32))
+            return 0;
+        *tag = mpack_tag_make_ext(
+            mpack_load_i8(reader->data + 5), mpack_load_u32(reader->data + 1));
+        return MPACK_TAG_SIZE_EXT32;
+#    endif
+
+    // float
+    case 0xca:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FLOAT))
+            return 0;
+        *tag = mpack_tag_make_float(mpack_load_float(reader->data + 1));
+        return MPACK_TAG_SIZE_FLOAT;
+
+    // double
+    case 0xcb:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_DOUBLE))
+            return 0;
+        *tag = mpack_tag_make_double(mpack_load_double(reader->data + 1));
+        return MPACK_TAG_SIZE_DOUBLE;
+
+    // uint8
+    case 0xcc:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U8))
+            return 0;
+        *tag = mpack_tag_make_uint(mpack_load_u8(reader->data + 1));
+        return MPACK_TAG_SIZE_U8;
+
+    // uint16
+    case 0xcd:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U16))
+            return 0;
+        *tag = mpack_tag_make_uint(mpack_load_u16(reader->data + 1));
+        return MPACK_TAG_SIZE_U16;
+
+    // uint32
+    case 0xce:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U32))
+            return 0;
+        *tag = mpack_tag_make_uint(mpack_load_u32(reader->data + 1));
+        return MPACK_TAG_SIZE_U32;
+
+    // uint64
+    case 0xcf:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_U64))
+            return 0;
+        *tag = mpack_tag_make_uint(mpack_load_u64(reader->data + 1));
+        return MPACK_TAG_SIZE_U64;
+
+    // int8
+    case 0xd0:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I8))
+            return 0;
+        *tag = mpack_tag_make_int(mpack_load_i8(reader->data + 1));
+        return MPACK_TAG_SIZE_I8;
+
+    // int16
+    case 0xd1:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I16))
+            return 0;
+        *tag = mpack_tag_make_int(mpack_load_i16(reader->data + 1));
+        return MPACK_TAG_SIZE_I16;
+
+    // int32
+    case 0xd2:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I32))
+            return 0;
+        *tag = mpack_tag_make_int(mpack_load_i32(reader->data + 1));
+        return MPACK_TAG_SIZE_I32;
+
+    // int64
+    case 0xd3:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_I64))
+            return 0;
+        *tag = mpack_tag_make_int(mpack_load_i64(reader->data + 1));
+        return MPACK_TAG_SIZE_I64;
+
+#    if MPACK_EXTENSIONS
+    // fixext1
+    case 0xd4:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT1))
+            return 0;
+        *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 1);
+        return MPACK_TAG_SIZE_FIXEXT1;
+
+    // fixext2
+    case 0xd5:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT2))
+            return 0;
+        *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 2);
+        return MPACK_TAG_SIZE_FIXEXT2;
+
+    // fixext4
+    case 0xd6:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT4))
+            return 0;
+        *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 4);
+        return 2;
+
+    // fixext8
+    case 0xd7:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT8))
+            return 0;
+        *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 8);
+        return MPACK_TAG_SIZE_FIXEXT8;
+
+    // fixext16
+    case 0xd8:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_FIXEXT16))
+            return 0;
+        *tag = mpack_tag_make_ext(mpack_load_i8(reader->data + 1), 16);
+        return MPACK_TAG_SIZE_FIXEXT16;
+#    endif
+
+    // str8
+    case 0xd9:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_STR8))
+            return 0;
+        *tag = mpack_tag_make_str(mpack_load_u8(reader->data + 1));
+        return MPACK_TAG_SIZE_STR8;
+
+    // str16
+    case 0xda:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_STR16))
+            return 0;
+        *tag = mpack_tag_make_str(mpack_load_u16(reader->data + 1));
+        return MPACK_TAG_SIZE_STR16;
+
+    // str32
+    case 0xdb:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_STR32))
+            return 0;
+        *tag = mpack_tag_make_str(mpack_load_u32(reader->data + 1));
+        return MPACK_TAG_SIZE_STR32;
+
+    // array16
+    case 0xdc:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_ARRAY16))
+            return 0;
+        *tag = mpack_tag_make_array(mpack_load_u16(reader->data + 1));
+        return MPACK_TAG_SIZE_ARRAY16;
+
+    // array32
+    case 0xdd:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_ARRAY32))
+            return 0;
+        *tag = mpack_tag_make_array(mpack_load_u32(reader->data + 1));
+        return MPACK_TAG_SIZE_ARRAY32;
+
+    // map16
+    case 0xde:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_MAP16))
+            return 0;
+        *tag = mpack_tag_make_map(mpack_load_u16(reader->data + 1));
+        return MPACK_TAG_SIZE_MAP16;
+
+    // map32
+    case 0xdf:
+        if (!mpack_reader_ensure(reader, MPACK_TAG_SIZE_MAP32))
+            return 0;
+        *tag = mpack_tag_make_map(mpack_load_u32(reader->data + 1));
+        return MPACK_TAG_SIZE_MAP32;
+
+    // reserved
+    case 0xc1:
+        mpack_reader_flag_error(reader, mpack_error_invalid);
+        return 0;
+
+#    if !MPACK_EXTENSIONS
+    // ext
+    case 0xc7: // fallthrough
+    case 0xc8: // fallthrough
+    case 0xc9: // fallthrough
+    // fixext
+    case 0xd4: // fallthrough
+    case 0xd5: // fallthrough
+    case 0xd6: // fallthrough
+    case 0xd7: // fallthrough
+    case 0xd8:
+        mpack_reader_flag_error(reader, mpack_error_unsupported);
+        return 0;
+#    endif
+
+#    if MPACK_OPTIMIZE_FOR_SIZE
+    // any other bytes should have been handled by the infix switch
+    default:
+        break;
+#    endif
     }
 
     mpack_assert(0, "unreachable");
     return 0;
 }
 
-mpack_tag_t mpack_read_tag(mpack_reader_t* reader) {
+mpack_tag_t
+mpack_read_tag(mpack_reader_t *reader)
+{
     mpack_log("reading tag\n");
 
     // make sure we can read a tag
@@ -2978,36 +3684,38 @@ mpack_tag_t mpack_read_tag(mpack_reader_t* reader) {
     if (count == 0)
         return mpack_tag_nil();
 
-    #if MPACK_READ_TRACKING
+#    if MPACK_READ_TRACKING
     mpack_error_t track_error = mpack_ok;
 
     switch (tag.type) {
-        case mpack_type_map:
-        case mpack_type_array:
-            track_error = mpack_track_push(&reader->track, tag.type, tag.v.n);
-            break;
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-        #endif
-        case mpack_type_str:
-        case mpack_type_bin:
-            track_error = mpack_track_push(&reader->track, tag.type, tag.v.l);
-            break;
-        default:
-            break;
+    case mpack_type_map:
+    case mpack_type_array:
+        track_error = mpack_track_push(&reader->track, tag.type, tag.v.n);
+        break;
+#        if MPACK_EXTENSIONS
+    case mpack_type_ext:
+#        endif
+    case mpack_type_str:
+    case mpack_type_bin:
+        track_error = mpack_track_push(&reader->track, tag.type, tag.v.l);
+        break;
+    default:
+        break;
     }
 
     if (track_error != mpack_ok) {
         mpack_reader_flag_error(reader, track_error);
         return mpack_tag_nil();
     }
-    #endif
+#    endif
 
     reader->data += count;
     return tag;
 }
 
-mpack_tag_t mpack_peek_tag(mpack_reader_t* reader) {
+mpack_tag_t
+mpack_peek_tag(mpack_reader_t *reader)
+{
     mpack_log("peeking tag\n");
 
     // make sure we can peek a tag
@@ -3022,52 +3730,56 @@ mpack_tag_t mpack_peek_tag(mpack_reader_t* reader) {
     return tag;
 }
 
-void mpack_discard(mpack_reader_t* reader) {
+void
+mpack_discard(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (mpack_reader_error(reader))
         return;
     switch (var.type) {
-        case mpack_type_str:
-            mpack_skip_bytes(reader, var.v.l);
-            mpack_done_str(reader);
-            break;
-        case mpack_type_bin:
-            mpack_skip_bytes(reader, var.v.l);
-            mpack_done_bin(reader);
-            break;
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            mpack_skip_bytes(reader, var.v.l);
-            mpack_done_ext(reader);
-            break;
-        #endif
-        case mpack_type_array: {
-            for (; var.v.n > 0; --var.v.n) {
-                mpack_discard(reader);
-                if (mpack_reader_error(reader))
-                    break;
-            }
-            mpack_done_array(reader);
-            break;
+    case mpack_type_str:
+        mpack_skip_bytes(reader, var.v.l);
+        mpack_done_str(reader);
+        break;
+    case mpack_type_bin:
+        mpack_skip_bytes(reader, var.v.l);
+        mpack_done_bin(reader);
+        break;
+#    if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        mpack_skip_bytes(reader, var.v.l);
+        mpack_done_ext(reader);
+        break;
+#    endif
+    case mpack_type_array: {
+        for (; var.v.n > 0; --var.v.n) {
+            mpack_discard(reader);
+            if (mpack_reader_error(reader))
+                break;
         }
-        case mpack_type_map: {
-            for (; var.v.n > 0; --var.v.n) {
-                mpack_discard(reader);
-                mpack_discard(reader);
-                if (mpack_reader_error(reader))
-                    break;
-            }
-            mpack_done_map(reader);
-            break;
+        mpack_done_array(reader);
+        break;
+    }
+    case mpack_type_map: {
+        for (; var.v.n > 0; --var.v.n) {
+            mpack_discard(reader);
+            mpack_discard(reader);
+            if (mpack_reader_error(reader))
+                break;
         }
-        default:
-            break;
+        mpack_done_map(reader);
+        break;
+    }
+    default:
+        break;
     }
 }
 
-#if MPACK_EXTENSIONS
-mpack_timestamp_t mpack_read_timestamp(mpack_reader_t* reader, size_t size) {
-    mpack_timestamp_t timestamp = {0, 0};
+#    if MPACK_EXTENSIONS
+mpack_timestamp_t
+mpack_read_timestamp(mpack_reader_t *reader, size_t size)
+{
+    mpack_timestamp_t timestamp = { 0, 0 };
 
     if (size != 4 && size != 8 && size != 12) {
         mpack_reader_flag_error(reader, mpack_error_invalid);
@@ -3081,46 +3793,52 @@ mpack_timestamp_t mpack_read_timestamp(mpack_reader_t* reader, size_t size) {
         return timestamp;
 
     switch (size) {
-        case 4:
-            timestamp.seconds = (int64_t)(uint64_t)mpack_load_u32(buf);
-            break;
+    case 4:
+        timestamp.seconds = (int64_t)(uint64_t)mpack_load_u32(buf);
+        break;
 
-        case 8: {
-            uint64_t packed = mpack_load_u64(buf);
-            timestamp.seconds = (int64_t)(packed & ((UINT64_C(1) << 34) - 1));
-            timestamp.nanoseconds = (uint32_t)(packed >> 34);
-            break;
-        }
+    case 8: {
+        uint64_t packed = mpack_load_u64(buf);
+        timestamp.seconds = (int64_t)(packed & ((UINT64_C(1) << 34) - 1));
+        timestamp.nanoseconds = (uint32_t)(packed >> 34);
+        break;
+    }
 
-        case 12:
-            timestamp.nanoseconds = mpack_load_u32(buf);
-            timestamp.seconds = mpack_load_i64(buf + 4);
-            break;
+    case 12:
+        timestamp.nanoseconds = mpack_load_u32(buf);
+        timestamp.seconds = mpack_load_i64(buf + 4);
+        break;
 
-        default:
-            mpack_assert(false, "unreachable");
-            break;
+    default:
+        mpack_assert(false, "unreachable");
+        break;
     }
 
     if (timestamp.nanoseconds > MPACK_TIMESTAMP_NANOSECONDS_MAX) {
         mpack_reader_flag_error(reader, mpack_error_invalid);
-        mpack_timestamp_t zero = {0, 0};
+        mpack_timestamp_t zero = { 0, 0 };
         return zero;
     }
 
     return timestamp;
 }
-#endif
+#    endif
 
-#if MPACK_READ_TRACKING
-void mpack_done_type(mpack_reader_t* reader, mpack_type_t type) {
+#    if MPACK_READ_TRACKING
+void
+mpack_done_type(mpack_reader_t *reader, mpack_type_t type)
+{
     if (mpack_reader_error(reader) == mpack_ok)
-        mpack_reader_flag_if_error(reader, mpack_track_pop(&reader->track, type));
+        mpack_reader_flag_if_error(
+            reader, mpack_track_pop(&reader->track, type));
 }
-#endif
+#    endif
 
-#if MPACK_DEBUG && MPACK_STDIO
-static size_t mpack_print_read_prefix(mpack_reader_t* reader, size_t length, char* buffer, size_t buffer_size) {
+#    if MPACK_DEBUG && MPACK_STDIO
+static size_t
+mpack_print_read_prefix(
+    mpack_reader_t *reader, size_t length, char *buffer, size_t buffer_size)
+{
     if (length == 0)
         return 0;
 
@@ -3133,7 +3851,9 @@ static size_t mpack_print_read_prefix(mpack_reader_t* reader, size_t length, cha
     return read;
 }
 
-static void mpack_print_element(mpack_reader_t* reader, mpack_print_t* print, size_t depth) {
+static void
+mpack_print_element(mpack_reader_t *reader, mpack_print_t *print, size_t depth)
+{
     mpack_tag_t val = mpack_read_tag(reader);
     if (mpack_reader_error(reader) != mpack_ok)
         return;
@@ -3143,81 +3863,91 @@ static void mpack_print_element(mpack_reader_t* reader, mpack_print_t* print, si
     size_t count = 0;
 
     switch (val.type) {
-        case mpack_type_str:
-            mpack_print_append_cstr(print, "\"");
-            for (size_t i = 0; i < val.v.l; ++i) {
-                char c;
-                mpack_read_bytes(reader, &c, 1);
-                if (mpack_reader_error(reader) != mpack_ok)
-                    return;
-                switch (c) {
-                    case '\n': mpack_print_append_cstr(print, "\\n"); break;
-                    case '\\': mpack_print_append_cstr(print, "\\\\"); break;
-                    case '"': mpack_print_append_cstr(print, "\\\""); break;
-                    default: mpack_print_append(print, &c, 1); break;
-                }
+    case mpack_type_str:
+        mpack_print_append_cstr(print, "\"");
+        for (size_t i = 0; i < val.v.l; ++i) {
+            char c;
+            mpack_read_bytes(reader, &c, 1);
+            if (mpack_reader_error(reader) != mpack_ok)
+                return;
+            switch (c) {
+            case '\n':
+                mpack_print_append_cstr(print, "\\n");
+                break;
+            case '\\':
+                mpack_print_append_cstr(print, "\\\\");
+                break;
+            case '"':
+                mpack_print_append_cstr(print, "\\\"");
+                break;
+            default:
+                mpack_print_append(print, &c, 1);
+                break;
             }
-            mpack_print_append_cstr(print, "\"");
-            mpack_done_str(reader);
-            return;
+        }
+        mpack_print_append_cstr(print, "\"");
+        mpack_done_str(reader);
+        return;
 
-        case mpack_type_array:
-            mpack_print_append_cstr(print, "[\n");
-            for (size_t i = 0; i < val.v.n; ++i) {
-                for (size_t j = 0; j < depth + 1; ++j)
-                    mpack_print_append_cstr(print, "    ");
-                mpack_print_element(reader, print, depth + 1);
-                if (mpack_reader_error(reader) != mpack_ok)
-                    return;
-                if (i != val.v.n - 1)
-                    mpack_print_append_cstr(print, ",");
-                mpack_print_append_cstr(print, "\n");
-            }
-            for (size_t i = 0; i < depth; ++i)
+    case mpack_type_array:
+        mpack_print_append_cstr(print, "[\n");
+        for (size_t i = 0; i < val.v.n; ++i) {
+            for (size_t j = 0; j < depth + 1; ++j)
                 mpack_print_append_cstr(print, "    ");
-            mpack_print_append_cstr(print, "]");
-            mpack_done_array(reader);
-            return;
+            mpack_print_element(reader, print, depth + 1);
+            if (mpack_reader_error(reader) != mpack_ok)
+                return;
+            if (i != val.v.n - 1)
+                mpack_print_append_cstr(print, ",");
+            mpack_print_append_cstr(print, "\n");
+        }
+        for (size_t i = 0; i < depth; ++i)
+            mpack_print_append_cstr(print, "    ");
+        mpack_print_append_cstr(print, "]");
+        mpack_done_array(reader);
+        return;
 
-        case mpack_type_map:
-            mpack_print_append_cstr(print, "{\n");
-            for (size_t i = 0; i < val.v.n; ++i) {
-                for (size_t j = 0; j < depth + 1; ++j)
-                    mpack_print_append_cstr(print, "    ");
-                mpack_print_element(reader, print, depth + 1);
-                if (mpack_reader_error(reader) != mpack_ok)
-                    return;
-                mpack_print_append_cstr(print, ": ");
-                mpack_print_element(reader, print, depth + 1);
-                if (mpack_reader_error(reader) != mpack_ok)
-                    return;
-                if (i != val.v.n - 1)
-                    mpack_print_append_cstr(print, ",");
-                mpack_print_append_cstr(print, "\n");
-            }
-            for (size_t i = 0; i < depth; ++i)
+    case mpack_type_map:
+        mpack_print_append_cstr(print, "{\n");
+        for (size_t i = 0; i < val.v.n; ++i) {
+            for (size_t j = 0; j < depth + 1; ++j)
                 mpack_print_append_cstr(print, "    ");
-            mpack_print_append_cstr(print, "}");
-            mpack_done_map(reader);
-            return;
+            mpack_print_element(reader, print, depth + 1);
+            if (mpack_reader_error(reader) != mpack_ok)
+                return;
+            mpack_print_append_cstr(print, ": ");
+            mpack_print_element(reader, print, depth + 1);
+            if (mpack_reader_error(reader) != mpack_ok)
+                return;
+            if (i != val.v.n - 1)
+                mpack_print_append_cstr(print, ",");
+            mpack_print_append_cstr(print, "\n");
+        }
+        for (size_t i = 0; i < depth; ++i)
+            mpack_print_append_cstr(print, "    ");
+        mpack_print_append_cstr(print, "}");
+        mpack_done_map(reader);
+        return;
 
         // The above cases return so as not to print a pseudo-json value. The
         // below cases break and print pseudo-json.
 
-        case mpack_type_bin:
-            count = mpack_print_read_prefix(reader, mpack_tag_bin_length(&val), buffer, sizeof(buffer));
-            mpack_done_bin(reader);
-            break;
+    case mpack_type_bin:
+        count = mpack_print_read_prefix(
+            reader, mpack_tag_bin_length(&val), buffer, sizeof(buffer));
+        mpack_done_bin(reader);
+        break;
 
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            count = mpack_print_read_prefix(reader, mpack_tag_ext_length(&val), buffer, sizeof(buffer));
-            mpack_done_ext(reader);
-            break;
-        #endif
+#        if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        count = mpack_print_read_prefix(
+            reader, mpack_tag_ext_length(&val), buffer, sizeof(buffer));
+        mpack_done_ext(reader);
+        break;
+#        endif
 
-        default:
-            break;
+    default:
+        break;
     }
 
     char buf[256];
@@ -3225,7 +3955,10 @@ static void mpack_print_element(mpack_reader_t* reader, mpack_print_t* print, si
     mpack_print_append_cstr(print, buf);
 }
 
-static void mpack_print_and_destroy(mpack_reader_t* reader, mpack_print_t* print, size_t depth) {
+static void
+mpack_print_and_destroy(
+    mpack_reader_t *reader, mpack_print_t *print, size_t depth)
+{
     for (size_t i = 0; i < depth; ++i)
         mpack_print_append_cstr(print, "    ");
     mpack_print_element(reader, print, depth);
@@ -3234,23 +3967,31 @@ static void mpack_print_and_destroy(mpack_reader_t* reader, mpack_print_t* print
 
     char buf[256];
     if (mpack_reader_destroy(reader) != mpack_ok) {
-        mpack_snprintf(buf, sizeof(buf), "\n<mpack parsing error %s>", mpack_error_to_string(mpack_reader_error(reader)));
+        mpack_snprintf(buf, sizeof(buf), "\n<mpack parsing error %s>",
+            mpack_error_to_string(mpack_reader_error(reader)));
         buf[sizeof(buf) - 1] = '\0';
         mpack_print_append_cstr(print, buf);
     } else if (remaining > 0) {
-        mpack_snprintf(buf, sizeof(buf), "\n<%i extra bytes at end of message>", (int)remaining);
+        mpack_snprintf(buf, sizeof(buf), "\n<%i extra bytes at end of message>",
+            (int)remaining);
         buf[sizeof(buf) - 1] = '\0';
         mpack_print_append_cstr(print, buf);
     }
 }
 
-static void mpack_print_data(const char* data, size_t len, mpack_print_t* print, size_t depth) {
+static void
+mpack_print_data(
+    const char *data, size_t len, mpack_print_t *print, size_t depth)
+{
     mpack_reader_t reader;
     mpack_reader_init_data(&reader, data, len);
     mpack_print_and_destroy(&reader, print, depth);
 }
 
-void mpack_print_data_to_buffer(const char* data, size_t data_size, char* buffer, size_t buffer_size) {
+void
+mpack_print_data_to_buffer(
+    const char *data, size_t data_size, char *buffer, size_t buffer_size)
+{
     if (buffer_size == 0) {
         mpack_assert(false, "buffer size is zero!");
         return;
@@ -3261,7 +4002,7 @@ void mpack_print_data_to_buffer(const char* data, size_t data_size, char* buffer
     print.buffer = buffer;
     print.size = buffer_size;
     mpack_print_data(data, data_size, &print, 0);
-    mpack_print_append(&print, "",  1); // null-terminator
+    mpack_print_append(&print, "", 1); // null-terminator
     mpack_print_flush(&print);
 
     // we always make sure there's a null-terminator at the end of the buffer
@@ -3269,7 +4010,10 @@ void mpack_print_data_to_buffer(const char* data, size_t data_size, char* buffer
     print.buffer[print.size - 1] = '\0';
 }
 
-void mpack_print_data_to_callback(const char* data, size_t size, mpack_print_callback_t callback, void* context) {
+void
+mpack_print_data_to_callback(const char *data, size_t size,
+    mpack_print_callback_t callback, void *context)
+{
     char buffer[1024];
     mpack_print_t print;
     mpack_memset(&print, 0, sizeof(print));
@@ -3281,7 +4025,9 @@ void mpack_print_data_to_callback(const char* data, size_t size, mpack_print_cal
     mpack_print_flush(&print);
 }
 
-void mpack_print_data_to_file(const char* data, size_t len, FILE* file) {
+void
+mpack_print_data_to_file(const char *data, size_t len, FILE *file)
+{
     mpack_assert(data != NULL, "data is NULL");
     mpack_assert(file != NULL, "file is NULL");
 
@@ -3298,7 +4044,10 @@ void mpack_print_data_to_file(const char* data, size_t len, FILE* file) {
     mpack_print_flush(&print);
 }
 
-void mpack_print_stdfile_to_callback(FILE* file, mpack_print_callback_t callback, void* context) {
+void
+mpack_print_stdfile_to_callback(
+    FILE *file, mpack_print_callback_t callback, void *context)
+{
     char buffer[1024];
     mpack_print_t print;
     mpack_memset(&print, 0, sizeof(print));
@@ -3312,7 +4061,7 @@ void mpack_print_stdfile_to_callback(FILE* file, mpack_print_callback_t callback
     mpack_print_and_destroy(&reader, &print, 0);
     mpack_print_flush(&print);
 }
-#endif
+#    endif
 
 #endif
 
@@ -3324,10 +4073,11 @@ void mpack_print_stdfile_to_callback(FILE* file, mpack_print_callback_t callback
 
 #if MPACK_EXPECT
 
-
 // Helpers
 
-MPACK_STATIC_INLINE uint8_t mpack_expect_native_u8(mpack_reader_t* reader) {
+MPACK_STATIC_INLINE uint8_t
+mpack_expect_native_u8(mpack_reader_t *reader)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return 0;
     uint8_t type;
@@ -3338,8 +4088,10 @@ MPACK_STATIC_INLINE uint8_t mpack_expect_native_u8(mpack_reader_t* reader) {
     return type;
 }
 
-#if !MPACK_OPTIMIZE_FOR_SIZE
-MPACK_STATIC_INLINE uint16_t mpack_expect_native_u16(mpack_reader_t* reader) {
+#    if !MPACK_OPTIMIZE_FOR_SIZE
+MPACK_STATIC_INLINE uint16_t
+mpack_expect_native_u16(mpack_reader_t *reader)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return 0;
     uint16_t type;
@@ -3350,7 +4102,9 @@ MPACK_STATIC_INLINE uint16_t mpack_expect_native_u16(mpack_reader_t* reader) {
     return type;
 }
 
-MPACK_STATIC_INLINE uint32_t mpack_expect_native_u32(mpack_reader_t* reader) {
+MPACK_STATIC_INLINE uint32_t
+mpack_expect_native_u32(mpack_reader_t *reader)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return 0;
     uint32_t type;
@@ -3360,17 +4114,20 @@ MPACK_STATIC_INLINE uint32_t mpack_expect_native_u32(mpack_reader_t* reader) {
     reader->data += sizeof(type);
     return type;
 }
-#endif
+#    endif
 
-MPACK_STATIC_INLINE uint8_t mpack_expect_type_byte(mpack_reader_t* reader) {
+MPACK_STATIC_INLINE uint8_t
+mpack_expect_type_byte(mpack_reader_t *reader)
+{
     mpack_reader_track_element(reader);
     return mpack_expect_native_u8(reader);
 }
 
-
 // Basic Number Functions
 
-uint8_t mpack_expect_u8(mpack_reader_t* reader) {
+uint8_t
+mpack_expect_u8(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= UINT8_MAX)
@@ -3383,7 +4140,9 @@ uint8_t mpack_expect_u8(mpack_reader_t* reader) {
     return 0;
 }
 
-uint16_t mpack_expect_u16(mpack_reader_t* reader) {
+uint16_t
+mpack_expect_u16(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= UINT16_MAX)
@@ -3396,7 +4155,9 @@ uint16_t mpack_expect_u16(mpack_reader_t* reader) {
     return 0;
 }
 
-uint32_t mpack_expect_u32(mpack_reader_t* reader) {
+uint32_t
+mpack_expect_u32(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= UINT32_MAX)
@@ -3409,7 +4170,9 @@ uint32_t mpack_expect_u32(mpack_reader_t* reader) {
     return 0;
 }
 
-uint64_t mpack_expect_u64(mpack_reader_t* reader) {
+uint64_t
+mpack_expect_u64(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         return var.v.u;
@@ -3421,7 +4184,9 @@ uint64_t mpack_expect_u64(mpack_reader_t* reader) {
     return 0;
 }
 
-int8_t mpack_expect_i8(mpack_reader_t* reader) {
+int8_t
+mpack_expect_i8(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= INT8_MAX)
@@ -3434,7 +4199,9 @@ int8_t mpack_expect_i8(mpack_reader_t* reader) {
     return 0;
 }
 
-int16_t mpack_expect_i16(mpack_reader_t* reader) {
+int16_t
+mpack_expect_i16(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= INT16_MAX)
@@ -3447,7 +4214,9 @@ int16_t mpack_expect_i16(mpack_reader_t* reader) {
     return 0;
 }
 
-int32_t mpack_expect_i32(mpack_reader_t* reader) {
+int32_t
+mpack_expect_i32(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= INT32_MAX)
@@ -3460,7 +4229,9 @@ int32_t mpack_expect_i32(mpack_reader_t* reader) {
     return 0;
 }
 
-int64_t mpack_expect_i64(mpack_reader_t* reader) {
+int64_t
+mpack_expect_i64(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint) {
         if (var.v.u <= INT64_MAX)
@@ -3472,7 +4243,9 @@ int64_t mpack_expect_i64(mpack_reader_t* reader) {
     return 0;
 }
 
-float mpack_expect_float(mpack_reader_t* reader) {
+float
+mpack_expect_float(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint)
         return (float)var.v.u;
@@ -3486,7 +4259,9 @@ float mpack_expect_float(mpack_reader_t* reader) {
     return 0.0f;
 }
 
-double mpack_expect_double(mpack_reader_t* reader) {
+double
+mpack_expect_double(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_uint)
         return (double)var.v.u;
@@ -3500,7 +4275,9 @@ double mpack_expect_double(mpack_reader_t* reader) {
     return 0.0;
 }
 
-float mpack_expect_float_strict(mpack_reader_t* reader) {
+float
+mpack_expect_float_strict(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_float)
         return var.v.f;
@@ -3508,7 +4285,9 @@ float mpack_expect_float_strict(mpack_reader_t* reader) {
     return 0.0f;
 }
 
-double mpack_expect_double_strict(mpack_reader_t* reader) {
+double
+mpack_expect_double_strict(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_float)
         return (double)var.v.f;
@@ -3518,90 +4297,125 @@ double mpack_expect_double_strict(mpack_reader_t* reader) {
     return 0.0;
 }
 
-
 // Ranged Number Functions
 //
 // All ranged functions are identical other than the type, so we
 // define their content with a macro. The prototypes are still written
 // out in full to support ctags/IDE tools.
 
-#define MPACK_EXPECT_RANGE_IMPL(name, type_t)                           \
-                                                                        \
-    /* make sure the range is sensible */                               \
-    mpack_assert(min_value <= max_value,                                \
-            "min_value %i must be less than or equal to max_value %i",  \
-            min_value, max_value);                                      \
-                                                                        \
-    /* read the value */                                                \
-    type_t val = mpack_expect_##name(reader);                           \
-    if (mpack_reader_error(reader) != mpack_ok)                         \
-        return min_value;                                               \
-                                                                        \
-    /* make sure it fits */                                             \
-    if (val < min_value || val > max_value) {                           \
-        mpack_reader_flag_error(reader, mpack_error_type);              \
-        return min_value;                                               \
-    }                                                                   \
-                                                                        \
-    return val;
+#    define MPACK_EXPECT_RANGE_IMPL(name, type_t)                              \
+                                                                               \
+        /* make sure the range is sensible */                                  \
+        mpack_assert(min_value <= max_value,                                   \
+            "min_value %i must be less than or equal to max_value %i",         \
+            min_value, max_value);                                             \
+                                                                               \
+        /* read the value */                                                   \
+        type_t val = mpack_expect_##name(reader);                              \
+        if (mpack_reader_error(reader) != mpack_ok)                            \
+            return min_value;                                                  \
+                                                                               \
+        /* make sure it fits */                                                \
+        if (val < min_value || val > max_value) {                              \
+            mpack_reader_flag_error(reader, mpack_error_type);                 \
+            return min_value;                                                  \
+        }                                                                      \
+                                                                               \
+        return val;
 
-uint8_t mpack_expect_u8_range(mpack_reader_t* reader, uint8_t min_value, uint8_t max_value) {MPACK_EXPECT_RANGE_IMPL(u8, uint8_t)}
-uint16_t mpack_expect_u16_range(mpack_reader_t* reader, uint16_t min_value, uint16_t max_value) {MPACK_EXPECT_RANGE_IMPL(u16, uint16_t)}
-uint32_t mpack_expect_u32_range(mpack_reader_t* reader, uint32_t min_value, uint32_t max_value) {MPACK_EXPECT_RANGE_IMPL(u32, uint32_t)}
-uint64_t mpack_expect_u64_range(mpack_reader_t* reader, uint64_t min_value, uint64_t max_value) {MPACK_EXPECT_RANGE_IMPL(u64, uint64_t)}
+uint8_t
+mpack_expect_u8_range(mpack_reader_t *reader, uint8_t min_value,
+    uint8_t max_value) { MPACK_EXPECT_RANGE_IMPL(u8, uint8_t) } uint16_t
+    mpack_expect_u16_range(mpack_reader_t *reader, uint16_t min_value,
+        uint16_t max_value) { MPACK_EXPECT_RANGE_IMPL(u16, uint16_t) } uint32_t
+    mpack_expect_u32_range(mpack_reader_t *reader, uint32_t min_value,
+        uint32_t max_value) { MPACK_EXPECT_RANGE_IMPL(u32, uint32_t) } uint64_t
+    mpack_expect_u64_range(mpack_reader_t *reader, uint64_t min_value,
+        uint64_t max_value) { MPACK_EXPECT_RANGE_IMPL(u64, uint64_t) }
 
-int8_t mpack_expect_i8_range(mpack_reader_t* reader, int8_t min_value, int8_t max_value) {MPACK_EXPECT_RANGE_IMPL(i8, int8_t)}
-int16_t mpack_expect_i16_range(mpack_reader_t* reader, int16_t min_value, int16_t max_value) {MPACK_EXPECT_RANGE_IMPL(i16, int16_t)}
-int32_t mpack_expect_i32_range(mpack_reader_t* reader, int32_t min_value, int32_t max_value) {MPACK_EXPECT_RANGE_IMPL(i32, int32_t)}
-int64_t mpack_expect_i64_range(mpack_reader_t* reader, int64_t min_value, int64_t max_value) {MPACK_EXPECT_RANGE_IMPL(i64, int64_t)}
+int8_t mpack_expect_i8_range(mpack_reader_t *reader, int8_t min_value,
+    int8_t max_value) { MPACK_EXPECT_RANGE_IMPL(i8, int8_t) } int16_t
+    mpack_expect_i16_range(mpack_reader_t *reader, int16_t min_value,
+        int16_t max_value) { MPACK_EXPECT_RANGE_IMPL(i16, int16_t) } int32_t
+    mpack_expect_i32_range(mpack_reader_t *reader, int32_t min_value,
+        int32_t max_value) { MPACK_EXPECT_RANGE_IMPL(i32, int32_t) } int64_t
+    mpack_expect_i64_range(
+        mpack_reader_t *reader, int64_t min_value, int64_t max_value)
+{
+    MPACK_EXPECT_RANGE_IMPL(i64, int64_t)
+}
 
-float mpack_expect_float_range(mpack_reader_t* reader, float min_value, float max_value) {MPACK_EXPECT_RANGE_IMPL(float, float)}
-double mpack_expect_double_range(mpack_reader_t* reader, double min_value, double max_value) {MPACK_EXPECT_RANGE_IMPL(double, double)}
+float
+mpack_expect_float_range(
+    mpack_reader_t *reader, float min_value, float max_value)
+{
+    MPACK_EXPECT_RANGE_IMPL(float, float)
+}
+double
+mpack_expect_double_range(mpack_reader_t *reader, double min_value,
+    double max_value) { MPACK_EXPECT_RANGE_IMPL(double, double) }
 
-uint32_t mpack_expect_map_range(mpack_reader_t* reader, uint32_t min_value, uint32_t max_value) {MPACK_EXPECT_RANGE_IMPL(map, uint32_t)}
-uint32_t mpack_expect_array_range(mpack_reader_t* reader, uint32_t min_value, uint32_t max_value) {MPACK_EXPECT_RANGE_IMPL(array, uint32_t)}
-
+uint32_t mpack_expect_map_range(mpack_reader_t *reader, uint32_t min_value,
+    uint32_t max_value) { MPACK_EXPECT_RANGE_IMPL(map, uint32_t) } uint32_t
+    mpack_expect_array_range(
+        mpack_reader_t *reader, uint32_t min_value, uint32_t max_value)
+{
+    MPACK_EXPECT_RANGE_IMPL(array, uint32_t)
+}
 
 // Matching Number Functions
 
-void mpack_expect_uint_match(mpack_reader_t* reader, uint64_t value) {
+void
+mpack_expect_uint_match(mpack_reader_t *reader, uint64_t value)
+{
     if (mpack_expect_u64(reader) != value)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-void mpack_expect_int_match(mpack_reader_t* reader, int64_t value) {
+void
+mpack_expect_int_match(mpack_reader_t *reader, int64_t value)
+{
     if (mpack_expect_i64(reader) != value)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-
 // Other Basic Types
 
-void mpack_expect_nil(mpack_reader_t* reader) {
+void
+mpack_expect_nil(mpack_reader_t *reader)
+{
     if (mpack_expect_type_byte(reader) != 0xc0)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-bool mpack_expect_bool(mpack_reader_t* reader) {
+bool
+mpack_expect_bool(mpack_reader_t *reader)
+{
     uint8_t type = mpack_expect_type_byte(reader);
     if ((type & ~1) != 0xc2)
         mpack_reader_flag_error(reader, mpack_error_type);
     return (bool)(type & 1);
 }
 
-void mpack_expect_true(mpack_reader_t* reader) {
+void
+mpack_expect_true(mpack_reader_t *reader)
+{
     if (mpack_expect_bool(reader) != true)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-void mpack_expect_false(mpack_reader_t* reader) {
+void
+mpack_expect_false(mpack_reader_t *reader)
+{
     if (mpack_expect_bool(reader) != false)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-#if MPACK_EXTENSIONS
-mpack_timestamp_t mpack_expect_timestamp(mpack_reader_t* reader) {
-    mpack_timestamp_t zero = {0, 0};
+#    if MPACK_EXTENSIONS
+mpack_timestamp_t
+mpack_expect_timestamp(mpack_reader_t *reader)
+{
+    mpack_timestamp_t zero = { 0, 0 };
 
     mpack_tag_t tag = mpack_read_tag(reader);
     if (tag.type != mpack_type_ext) {
@@ -3616,15 +4430,18 @@ mpack_timestamp_t mpack_expect_timestamp(mpack_reader_t* reader) {
     return mpack_read_timestamp(reader, mpack_tag_ext_length(&tag));
 }
 
-int64_t mpack_expect_timestamp_truncate(mpack_reader_t* reader) {
+int64_t
+mpack_expect_timestamp_truncate(mpack_reader_t *reader)
+{
     return mpack_expect_timestamp(reader).seconds;
 }
-#endif
-
+#    endif
 
 // Compound Types
 
-uint32_t mpack_expect_map(mpack_reader_t* reader) {
+uint32_t
+mpack_expect_map(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_map)
         return var.v.n;
@@ -3632,12 +4449,16 @@ uint32_t mpack_expect_map(mpack_reader_t* reader) {
     return 0;
 }
 
-void mpack_expect_map_match(mpack_reader_t* reader, uint32_t count) {
+void
+mpack_expect_map_match(mpack_reader_t *reader, uint32_t count)
+{
     if (mpack_expect_map(reader) != count)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-bool mpack_expect_map_or_nil(mpack_reader_t* reader, uint32_t* count) {
+bool
+mpack_expect_map_or_nil(mpack_reader_t *reader, uint32_t *count)
+{
     mpack_assert(count != NULL, "count cannot be NULL");
 
     mpack_tag_t var = mpack_read_tag(reader);
@@ -3654,7 +4475,10 @@ bool mpack_expect_map_or_nil(mpack_reader_t* reader, uint32_t* count) {
     return false;
 }
 
-bool mpack_expect_map_max_or_nil(mpack_reader_t* reader, uint32_t max_count, uint32_t* count) {
+bool
+mpack_expect_map_max_or_nil(
+    mpack_reader_t *reader, uint32_t max_count, uint32_t *count)
+{
     mpack_assert(count != NULL, "count cannot be NULL");
 
     bool has_map = mpack_expect_map_or_nil(reader, count);
@@ -3666,7 +4490,9 @@ bool mpack_expect_map_max_or_nil(mpack_reader_t* reader, uint32_t max_count, uin
     return has_map;
 }
 
-uint32_t mpack_expect_array(mpack_reader_t* reader) {
+uint32_t
+mpack_expect_array(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_array)
         return var.v.n;
@@ -3674,12 +4500,16 @@ uint32_t mpack_expect_array(mpack_reader_t* reader) {
     return 0;
 }
 
-void mpack_expect_array_match(mpack_reader_t* reader, uint32_t count) {
+void
+mpack_expect_array_match(mpack_reader_t *reader, uint32_t count)
+{
     if (mpack_expect_array(reader) != count)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-bool mpack_expect_array_or_nil(mpack_reader_t* reader, uint32_t* count) {
+bool
+mpack_expect_array_or_nil(mpack_reader_t *reader, uint32_t *count)
+{
     mpack_assert(count != NULL, "count cannot be NULL");
 
     mpack_tag_t var = mpack_read_tag(reader);
@@ -3696,7 +4526,10 @@ bool mpack_expect_array_or_nil(mpack_reader_t* reader, uint32_t* count) {
     return false;
 }
 
-bool mpack_expect_array_max_or_nil(mpack_reader_t* reader, uint32_t max_count, uint32_t* count) {
+bool
+mpack_expect_array_max_or_nil(
+    mpack_reader_t *reader, uint32_t max_count, uint32_t *count)
+{
     mpack_assert(count != NULL, "count cannot be NULL");
 
     bool has_array = mpack_expect_array_or_nil(reader, count);
@@ -3708,8 +4541,11 @@ bool mpack_expect_array_max_or_nil(mpack_reader_t* reader, uint32_t max_count, u
     return has_array;
 }
 
-#ifdef MPACK_MALLOC
-void* mpack_expect_array_alloc_impl(mpack_reader_t* reader, size_t element_size, uint32_t max_count, uint32_t* out_count, bool allow_nil) {
+#    ifdef MPACK_MALLOC
+void *
+mpack_expect_array_alloc_impl(mpack_reader_t *reader, size_t element_size,
+    uint32_t max_count, uint32_t *out_count, bool allow_nil)
+{
     mpack_assert(out_count != NULL, "out_count cannot be NULL");
     *out_count = 0;
 
@@ -3732,7 +4568,7 @@ void* mpack_expect_array_alloc_impl(mpack_reader_t* reader, size_t element_size,
         return NULL;
     }
 
-    void* p = MPACK_MALLOC(element_size * count);
+    void *p = MPACK_MALLOC(element_size * count);
     if (p == NULL) {
         mpack_reader_flag_error(reader, mpack_error_memory);
         return NULL;
@@ -3741,19 +4577,20 @@ void* mpack_expect_array_alloc_impl(mpack_reader_t* reader, size_t element_size,
     *out_count = count;
     return p;
 }
-#endif
-
+#    endif
 
 // Str, Bin and Ext Functions
 
-uint32_t mpack_expect_str(mpack_reader_t* reader) {
-    #if MPACK_OPTIMIZE_FOR_SIZE
+uint32_t
+mpack_expect_str(mpack_reader_t *reader)
+{
+#    if MPACK_OPTIMIZE_FOR_SIZE
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_str)
         return var.v.l;
     mpack_reader_flag_error(reader, mpack_error_type);
     return 0;
-    #else
+#    else
     uint8_t type = mpack_expect_type_byte(reader);
     uint32_t count;
 
@@ -3770,14 +4607,17 @@ uint32_t mpack_expect_str(mpack_reader_t* reader) {
         return 0;
     }
 
-    #if MPACK_READ_TRACKING
-    mpack_reader_flag_if_error(reader, mpack_track_push(&reader->track, mpack_type_str, count));
-    #endif
+#        if MPACK_READ_TRACKING
+    mpack_reader_flag_if_error(
+        reader, mpack_track_push(&reader->track, mpack_type_str, count));
+#        endif
     return count;
-    #endif
+#    endif
 }
 
-size_t mpack_expect_str_buf(mpack_reader_t* reader, char* buf, size_t bufsize) {
+size_t
+mpack_expect_str_buf(mpack_reader_t *reader, char *buf, size_t bufsize)
+{
     mpack_assert(buf != NULL, "buf cannot be NULL");
 
     size_t length = mpack_expect_str(reader);
@@ -3797,7 +4637,9 @@ size_t mpack_expect_str_buf(mpack_reader_t* reader, char* buf, size_t bufsize) {
     return length;
 }
 
-size_t mpack_expect_utf8(mpack_reader_t* reader, char* buf, size_t size) {
+size_t
+mpack_expect_utf8(mpack_reader_t *reader, char *buf, size_t size)
+{
     mpack_assert(buf != NULL, "buf cannot be NULL");
 
     size_t length = mpack_expect_str_buf(reader, buf, size);
@@ -3810,7 +4652,9 @@ size_t mpack_expect_utf8(mpack_reader_t* reader, char* buf, size_t size) {
     return length;
 }
 
-uint32_t mpack_expect_bin(mpack_reader_t* reader) {
+uint32_t
+mpack_expect_bin(mpack_reader_t *reader)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_bin)
         return var.v.l;
@@ -3818,7 +4662,9 @@ uint32_t mpack_expect_bin(mpack_reader_t* reader) {
     return 0;
 }
 
-size_t mpack_expect_bin_buf(mpack_reader_t* reader, char* buf, size_t bufsize) {
+size_t
+mpack_expect_bin_buf(mpack_reader_t *reader, char *buf, size_t bufsize)
+{
     mpack_assert(buf != NULL, "buf cannot be NULL");
 
     size_t binsize = mpack_expect_bin(reader);
@@ -3835,8 +4681,10 @@ size_t mpack_expect_bin_buf(mpack_reader_t* reader, char* buf, size_t bufsize) {
     return binsize;
 }
 
-#if MPACK_EXTENSIONS
-uint32_t mpack_expect_ext(mpack_reader_t* reader, int8_t* type) {
+#    if MPACK_EXTENSIONS
+uint32_t
+mpack_expect_ext(mpack_reader_t *reader, int8_t *type)
+{
     mpack_tag_t var = mpack_read_tag(reader);
     if (var.type == mpack_type_ext) {
         *type = mpack_tag_ext_exttype(&var);
@@ -3847,7 +4695,10 @@ uint32_t mpack_expect_ext(mpack_reader_t* reader, int8_t* type) {
     return 0;
 }
 
-size_t mpack_expect_ext_buf(mpack_reader_t* reader, int8_t* type, char* buf, size_t bufsize) {
+size_t
+mpack_expect_ext_buf(
+    mpack_reader_t *reader, int8_t *type, char *buf, size_t bufsize)
+{
     mpack_assert(buf != NULL, "buf cannot be NULL");
 
     size_t extsize = mpack_expect_ext(reader, type);
@@ -3866,28 +4717,36 @@ size_t mpack_expect_ext_buf(mpack_reader_t* reader, int8_t* type, char* buf, siz
     mpack_done_ext(reader);
     return extsize;
 }
-#endif
+#    endif
 
-void mpack_expect_cstr(mpack_reader_t* reader, char* buf, size_t bufsize) {
+void
+mpack_expect_cstr(mpack_reader_t *reader, char *buf, size_t bufsize)
+{
     uint32_t length = mpack_expect_str(reader);
     mpack_read_cstr(reader, buf, bufsize, length);
     mpack_done_str(reader);
 }
 
-void mpack_expect_utf8_cstr(mpack_reader_t* reader, char* buf, size_t bufsize) {
+void
+mpack_expect_utf8_cstr(mpack_reader_t *reader, char *buf, size_t bufsize)
+{
     uint32_t length = mpack_expect_str(reader);
     mpack_read_utf8_cstr(reader, buf, bufsize, length);
     mpack_done_str(reader);
 }
 
-#ifdef MPACK_MALLOC
-static char* mpack_expect_cstr_alloc_unchecked(mpack_reader_t* reader, size_t maxsize, size_t* out_length) {
+#    ifdef MPACK_MALLOC
+static char *
+mpack_expect_cstr_alloc_unchecked(
+    mpack_reader_t *reader, size_t maxsize, size_t *out_length)
+{
     mpack_assert(out_length != NULL, "out_length cannot be NULL");
     *out_length = 0;
 
     // make sure argument makes sense
     if (maxsize < 1) {
-        mpack_break("maxsize is zero; you must have room for at least a null-terminator");
+        mpack_break("maxsize is zero; you must have room for at least a "
+                    "null-terminator");
         mpack_reader_flag_error(reader, mpack_error_bug);
         return NULL;
     }
@@ -3896,7 +4755,7 @@ static char* mpack_expect_cstr_alloc_unchecked(mpack_reader_t* reader, size_t ma
         maxsize = UINT32_MAX;
 
     size_t length = mpack_expect_str_max(reader, (uint32_t)maxsize - 1);
-    char* str = mpack_read_bytes_alloc_impl(reader, length, true);
+    char *str = mpack_read_bytes_alloc_impl(reader, length, true);
     mpack_done_str(reader);
 
     if (str)
@@ -3904,9 +4763,11 @@ static char* mpack_expect_cstr_alloc_unchecked(mpack_reader_t* reader, size_t ma
     return str;
 }
 
-char* mpack_expect_cstr_alloc(mpack_reader_t* reader, size_t maxsize) {
+char *
+mpack_expect_cstr_alloc(mpack_reader_t *reader, size_t maxsize)
+{
     size_t length;
-    char* str = mpack_expect_cstr_alloc_unchecked(reader, maxsize, &length);
+    char *str = mpack_expect_cstr_alloc_unchecked(reader, maxsize, &length);
 
     if (str && !mpack_str_check_no_null(str, length)) {
         MPACK_FREE(str);
@@ -3917,9 +4778,11 @@ char* mpack_expect_cstr_alloc(mpack_reader_t* reader, size_t maxsize) {
     return str;
 }
 
-char* mpack_expect_utf8_cstr_alloc(mpack_reader_t* reader, size_t maxsize) {
+char *
+mpack_expect_utf8_cstr_alloc(mpack_reader_t *reader, size_t maxsize)
+{
     size_t length;
-    char* str = mpack_expect_cstr_alloc_unchecked(reader, maxsize, &length);
+    char *str = mpack_expect_cstr_alloc_unchecked(reader, maxsize, &length);
 
     if (str && !mpack_utf8_check_no_null(str, length)) {
         MPACK_FREE(str);
@@ -3929,9 +4792,11 @@ char* mpack_expect_utf8_cstr_alloc(mpack_reader_t* reader, size_t maxsize) {
 
     return str;
 }
-#endif
+#    endif
 
-void mpack_expect_str_match(mpack_reader_t* reader, const char* str, size_t len) {
+void
+mpack_expect_str_match(mpack_reader_t *reader, const char *str, size_t len)
+{
     mpack_assert(str != NULL, "str cannot be NULL");
 
     // expect a str the correct length
@@ -3953,14 +4818,18 @@ void mpack_expect_str_match(mpack_reader_t* reader, const char* str, size_t len)
     mpack_done_str(reader);
 }
 
-void mpack_expect_tag(mpack_reader_t* reader, mpack_tag_t expected) {
+void
+mpack_expect_tag(mpack_reader_t *reader, mpack_tag_t expected)
+{
     mpack_tag_t actual = mpack_read_tag(reader);
     if (!mpack_tag_equal(actual, expected))
         mpack_reader_flag_error(reader, mpack_error_type);
 }
 
-#ifdef MPACK_MALLOC
-char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* size) {
+#    ifdef MPACK_MALLOC
+char *
+mpack_expect_bin_alloc(mpack_reader_t *reader, size_t maxsize, size_t *size)
+{
     mpack_assert(size != NULL, "size cannot be NULL");
     *size = 0;
 
@@ -3971,17 +4840,20 @@ char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* siz
     if (mpack_reader_error(reader))
         return NULL;
 
-    char* data = mpack_read_bytes_alloc(reader, length);
+    char *data = mpack_read_bytes_alloc(reader, length);
     mpack_done_bin(reader);
 
     if (data)
         *size = length;
     return data;
 }
-#endif
+#    endif
 
-#if MPACK_EXTENSIONS && defined(MPACK_MALLOC)
-char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsize, size_t* size) {
+#    if MPACK_EXTENSIONS && defined(MPACK_MALLOC)
+char *
+mpack_expect_ext_alloc(
+    mpack_reader_t *reader, int8_t *type, size_t maxsize, size_t *size)
+{
     mpack_assert(size != NULL, "size cannot be NULL");
     *size = 0;
 
@@ -3992,7 +4864,7 @@ char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsiz
     if (mpack_reader_error(reader))
         return NULL;
 
-    char* data = mpack_read_bytes_alloc(reader, length);
+    char *data = mpack_read_bytes_alloc(reader, length);
     mpack_done_ext(reader);
 
     if (data) {
@@ -4002,20 +4874,22 @@ char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsiz
     }
     return data;
 }
-#endif
+#    endif
 
-size_t mpack_expect_enum(mpack_reader_t* reader, const char* strings[], size_t count) {
+size_t
+mpack_expect_enum(mpack_reader_t *reader, const char *strings[], size_t count)
+{
 
     // read the string in-place
     size_t keylen = mpack_expect_str(reader);
-    const char* key = mpack_read_bytes_inplace(reader, keylen);
+    const char *key = mpack_read_bytes_inplace(reader, keylen);
     mpack_done_str(reader);
     if (mpack_reader_error(reader) != mpack_ok)
         return count;
 
     // find what key it matches
     for (size_t i = 0; i < count; ++i) {
-        const char* other = strings[i];
+        const char *other = strings[i];
         size_t otherlen = mpack_strlen(other);
         if (keylen == otherlen && mpack_memcmp(key, other, keylen) == 0)
             return i;
@@ -4026,7 +4900,10 @@ size_t mpack_expect_enum(mpack_reader_t* reader, const char* strings[], size_t c
     return count;
 }
 
-size_t mpack_expect_enum_optional(mpack_reader_t* reader, const char* strings[], size_t count) {
+size_t
+mpack_expect_enum_optional(
+    mpack_reader_t *reader, const char *strings[], size_t count)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return count;
 
@@ -4041,14 +4918,14 @@ size_t mpack_expect_enum_optional(mpack_reader_t* reader, const char* strings[],
 
     // read the string in-place
     size_t keylen = mpack_expect_str(reader);
-    const char* key = mpack_read_bytes_inplace(reader, keylen);
+    const char *key = mpack_read_bytes_inplace(reader, keylen);
     mpack_done_str(reader);
     if (mpack_reader_error(reader) != mpack_ok)
         return count;
 
     // find what key it matches
     for (size_t i = 0; i < count; ++i) {
-        const char* other = strings[i];
+        const char *other = strings[i];
         size_t otherlen = mpack_strlen(other);
         if (keylen == otherlen && mpack_memcmp(key, other, keylen) == 0)
             return i;
@@ -4058,7 +4935,9 @@ size_t mpack_expect_enum_optional(mpack_reader_t* reader, const char* strings[],
     return count;
 }
 
-size_t mpack_expect_key_uint(mpack_reader_t* reader, bool found[], size_t count) {
+size_t
+mpack_expect_key_uint(mpack_reader_t *reader, bool found[], size_t count)
+{
     if (mpack_reader_error(reader) != mpack_ok)
         return count;
 
@@ -4094,7 +4973,10 @@ size_t mpack_expect_key_uint(mpack_reader_t* reader, bool found[], size_t count)
     return (size_t)value;
 }
 
-size_t mpack_expect_key_cstr(mpack_reader_t* reader, const char* keys[], bool found[], size_t count) {
+size_t
+mpack_expect_key_cstr(
+    mpack_reader_t *reader, const char *keys[], bool found[], size_t count)
+{
     size_t i = mpack_expect_enum_optional(reader, keys, count);
 
     // unrecognized keys are fine, we just return count
@@ -4114,7 +4996,6 @@ size_t mpack_expect_key_cstr(mpack_reader_t* reader, const char* keys[], bool fo
 
 #endif
 
-
 /* mpack/mpack-node.c.c */
 
 #define MPACK_INTERNAL 1
@@ -4123,66 +5004,79 @@ size_t mpack_expect_key_cstr(mpack_reader_t* reader, const char* keys[], bool fo
 
 #if MPACK_NODE
 
-MPACK_STATIC_INLINE const char* mpack_node_data_unchecked(mpack_node_t node) {
-    mpack_assert(mpack_node_error(node) == mpack_ok, "tree is in an error state!");
+MPACK_STATIC_INLINE const char *
+mpack_node_data_unchecked(mpack_node_t node)
+{
+    mpack_assert(
+        mpack_node_error(node) == mpack_ok, "tree is in an error state!");
 
     mpack_type_t type = node.data->type;
     MPACK_UNUSED(type);
-    #if MPACK_EXTENSIONS
-    mpack_assert(type == mpack_type_str || type == mpack_type_bin || type == mpack_type_ext,
-            "node of type %i (%s) is not a data type!", type, mpack_type_to_string(type));
-    #else
+#    if MPACK_EXTENSIONS
+    mpack_assert(type == mpack_type_str || type == mpack_type_bin
+            || type == mpack_type_ext,
+        "node of type %i (%s) is not a data type!", type,
+        mpack_type_to_string(type));
+#    else
     mpack_assert(type == mpack_type_str || type == mpack_type_bin,
-            "node of type %i (%s) is not a data type!", type, mpack_type_to_string(type));
-    #endif
+        "node of type %i (%s) is not a data type!", type,
+        mpack_type_to_string(type));
+#    endif
 
     return node.tree->data + node.data->value.offset;
 }
 
-#if MPACK_EXTENSIONS
-MPACK_STATIC_INLINE int8_t mpack_node_exttype_unchecked(mpack_node_t node) {
-    mpack_assert(mpack_node_error(node) == mpack_ok, "tree is in an error state!");
+#    if MPACK_EXTENSIONS
+MPACK_STATIC_INLINE int8_t
+mpack_node_exttype_unchecked(mpack_node_t node)
+{
+    mpack_assert(
+        mpack_node_error(node) == mpack_ok, "tree is in an error state!");
 
     mpack_type_t type = node.data->type;
     MPACK_UNUSED(type);
-    mpack_assert(type == mpack_type_ext, "node of type %i (%s) is not an ext type!",
-            type, mpack_type_to_string(type));
+    mpack_assert(type == mpack_type_ext,
+        "node of type %i (%s) is not an ext type!", type,
+        mpack_type_to_string(type));
 
     // the exttype of an ext node is stored in the byte preceding the data
     return mpack_load_i8(mpack_node_data_unchecked(node) - 1);
 }
-#endif
-
-
+#    endif
 
 /*
  * Tree Parsing
  */
 
-#ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
 
 // fix up the alloc size to make sure it exactly fits the
 // maximum number of nodes it can contain (the allocator will
 // waste it back anyway, but we round it down just in case)
 
-#define MPACK_NODES_PER_PAGE \
-    ((MPACK_NODE_PAGE_SIZE - sizeof(mpack_tree_page_t)) / sizeof(mpack_node_data_t) + 1)
+#        define MPACK_NODES_PER_PAGE                                           \
+            ((MPACK_NODE_PAGE_SIZE - sizeof(mpack_tree_page_t))                \
+                    / sizeof(mpack_node_data_t)                                \
+                + 1)
 
-#define MPACK_PAGE_ALLOC_SIZE \
-    (sizeof(mpack_tree_page_t) + sizeof(mpack_node_data_t) * (MPACK_NODES_PER_PAGE - 1))
+#        define MPACK_PAGE_ALLOC_SIZE                                          \
+            (sizeof(mpack_tree_page_t)                                         \
+                + sizeof(mpack_node_data_t) * (MPACK_NODES_PER_PAGE - 1))
 
-#endif
+#    endif
 
-#ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
 /*
  * Fills the tree until we have at least enough bytes for the current node.
  */
-static bool mpack_tree_reserve_fill(mpack_tree_t* tree) {
+static bool
+mpack_tree_reserve_fill(mpack_tree_t *tree)
+{
     mpack_assert(tree->parser.state == mpack_tree_parse_state_in_progress);
 
     size_t bytes = tree->parser.current_node_reserved;
     mpack_assert(bytes > tree->parser.possible_nodes_left,
-            "there are already enough bytes! call mpack_tree_ensure() instead.");
+        "there are already enough bytes! call mpack_tree_ensure() instead.");
     mpack_log("filling to reserve %i bytes\n", (int)bytes);
 
     // if the necessary bytes would put us over the maximum tree
@@ -4206,19 +5100,23 @@ static bool mpack_tree_reserve_fill(mpack_tree_t* tree) {
     if (tree->data_length + bytes > tree->buffer_capacity) {
 
         // TODO: check for overflow?
-        size_t new_capacity = (tree->buffer_capacity == 0) ? MPACK_BUFFER_SIZE : tree->buffer_capacity;
+        size_t new_capacity = (tree->buffer_capacity == 0)
+            ? MPACK_BUFFER_SIZE
+            : tree->buffer_capacity;
         while (new_capacity < tree->data_length + bytes)
             new_capacity *= 2;
         if (new_capacity > tree->max_size)
             new_capacity = tree->max_size;
 
-        mpack_log("expanding buffer from %i to %i\n", (int)tree->buffer_capacity, (int)new_capacity);
+        mpack_log("expanding buffer from %i to %i\n",
+            (int)tree->buffer_capacity, (int)new_capacity);
 
-        char* new_buffer;
+        char *new_buffer;
         if (tree->buffer == NULL)
-            new_buffer = (char*)MPACK_MALLOC(new_capacity);
+            new_buffer = (char *)MPACK_MALLOC(new_capacity);
         else
-            new_buffer = (char*)mpack_realloc(tree->buffer, tree->data_length, new_capacity);
+            new_buffer = (char *)mpack_realloc(
+                tree->buffer, tree->data_length, new_capacity);
 
         if (new_buffer == NULL) {
             mpack_tree_flag_error(tree, mpack_error_memory);
@@ -4233,7 +5131,8 @@ static bool mpack_tree_reserve_fill(mpack_tree_t* tree) {
     // request as much data as possible, looping until we have
     // all the data we need
     do {
-        size_t read = tree->read_fn(tree, tree->buffer + tree->data_length, tree->buffer_capacity - tree->data_length);
+        size_t read = tree->read_fn(tree, tree->buffer + tree->data_length,
+            tree->buffer_capacity - tree->data_length);
 
         // If the fill function encounters an error, it should flag an error on
         // the tree.
@@ -4260,7 +5159,7 @@ static bool mpack_tree_reserve_fill(mpack_tree_t* tree) {
 
     return true;
 }
-#endif
+#    endif
 
 /*
  * Ensures there are enough additional bytes in the tree for the current node
@@ -4276,7 +5175,9 @@ static bool mpack_tree_reserve_fill(mpack_tree_t* tree) {
  *
  * Returns false if not enough bytes could be read.
  */
-MPACK_STATIC_INLINE bool mpack_tree_reserve_bytes(mpack_tree_t* tree, size_t extra_bytes) {
+MPACK_STATIC_INLINE bool
+mpack_tree_reserve_bytes(mpack_tree_t *tree, size_t extra_bytes)
+{
     mpack_assert(tree->parser.state == mpack_tree_parse_state_in_progress);
 
     // We guard against overflow here. A compound type could declare more than
@@ -4285,7 +5186,8 @@ MPACK_STATIC_INLINE bool mpack_tree_reserve_bytes(mpack_tree_t* tree, size_t ext
     // more likely that the message is corrupt than that the data is valid but
     // not parseable on this architecture (see test_read_node_possible() in
     // test-node.c .)
-    if ((uint64_t)tree->parser.current_node_reserved + (uint64_t)extra_bytes > SIZE_MAX) {
+    if ((uint64_t)tree->parser.current_node_reserved + (uint64_t)extra_bytes
+        > SIZE_MAX) {
         mpack_tree_flag_error(tree, mpack_error_invalid);
         return false;
     }
@@ -4298,23 +5200,28 @@ MPACK_STATIC_INLINE bool mpack_tree_reserve_bytes(mpack_tree_t* tree, size_t ext
     if (tree->parser.current_node_reserved <= tree->parser.possible_nodes_left)
         return true;
 
-    #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
     return mpack_tree_reserve_fill(tree);
-    #else
+#    else
     return false;
-    #endif
+#    endif
 }
 
-MPACK_STATIC_INLINE size_t mpack_tree_parser_stack_capacity(mpack_tree_t* tree) {
-    #ifdef MPACK_MALLOC
+MPACK_STATIC_INLINE size_t
+mpack_tree_parser_stack_capacity(mpack_tree_t *tree)
+{
+#    ifdef MPACK_MALLOC
     return tree->parser.stack_capacity;
-    #else
+#    else
     return sizeof(tree->parser.stack) / sizeof(tree->parser.stack[0]);
-    #endif
+#    endif
 }
 
-static bool mpack_tree_push_stack(mpack_tree_t* tree, mpack_node_data_t* first_child, size_t total) {
-    mpack_tree_parser_t* parser = &tree->parser;
+static bool
+mpack_tree_push_stack(
+    mpack_tree_t *tree, mpack_node_data_t *first_child, size_t total)
+{
+    mpack_tree_parser_t *parser = &tree->parser;
     mpack_assert(parser->state == mpack_tree_parse_state_in_progress);
 
     // No need to push empty containers
@@ -4323,25 +5230,28 @@ static bool mpack_tree_push_stack(mpack_tree_t* tree, mpack_node_data_t* first_c
 
     // Make sure we have enough room in the stack
     if (parser->level + 1 == mpack_tree_parser_stack_capacity(tree)) {
-        #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
         size_t new_capacity = parser->stack_capacity * 2;
         mpack_log("growing parse stack to capacity %i\n", (int)new_capacity);
 
         // Replace the stack-allocated parsing stack
         if (!parser->stack_owned) {
-            mpack_level_t* new_stack = (mpack_level_t*)MPACK_MALLOC(sizeof(mpack_level_t) * new_capacity);
+            mpack_level_t *new_stack = (mpack_level_t *)MPACK_MALLOC(
+                sizeof(mpack_level_t) * new_capacity);
             if (!new_stack) {
                 mpack_tree_flag_error(tree, mpack_error_memory);
                 return false;
             }
-            mpack_memcpy(new_stack, parser->stack, sizeof(mpack_level_t) * parser->stack_capacity);
+            mpack_memcpy(new_stack, parser->stack,
+                sizeof(mpack_level_t) * parser->stack_capacity);
             parser->stack = new_stack;
             parser->stack_owned = true;
 
-        // Realloc the allocated parsing stack
+            // Realloc the allocated parsing stack
         } else {
-            mpack_level_t* new_stack = (mpack_level_t*)mpack_realloc(parser->stack,
-                    sizeof(mpack_level_t) * parser->stack_capacity, sizeof(mpack_level_t) * new_capacity);
+            mpack_level_t *new_stack = (mpack_level_t *)mpack_realloc(
+                parser->stack, sizeof(mpack_level_t) * parser->stack_capacity,
+                sizeof(mpack_level_t) * new_capacity);
             if (!new_stack) {
                 mpack_tree_flag_error(tree, mpack_error_memory);
                 return false;
@@ -4349,10 +5259,10 @@ static bool mpack_tree_push_stack(mpack_tree_t* tree, mpack_node_data_t* first_c
             parser->stack = new_stack;
         }
         parser->stack_capacity = new_capacity;
-        #else
+#    else
         mpack_tree_flag_error(tree, mpack_error_too_big);
         return false;
-        #endif
+#    endif
     }
 
     // Push the contents of this node onto the parsing stack
@@ -4362,8 +5272,10 @@ static bool mpack_tree_push_stack(mpack_tree_t* tree, mpack_node_data_t* first_c
     return true;
 }
 
-static bool mpack_tree_parse_children(mpack_tree_t* tree, mpack_node_data_t* node) {
-    mpack_tree_parser_t* parser = &tree->parser;
+static bool
+mpack_tree_parse_children(mpack_tree_t *tree, mpack_node_data_t *node)
+{
+    mpack_tree_parser_t *parser = &tree->parser;
     mpack_assert(parser->state == mpack_tree_parse_state_in_progress);
 
     mpack_type_t type = node->type;
@@ -4398,46 +5310,52 @@ static bool mpack_tree_parse_children(mpack_tree_t* tree, mpack_node_data_t* nod
 
     } else {
 
-        #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
 
-        // We can't grow if we're using a fixed pool (i.e. we didn't start with a page)
+        // We can't grow if we're using a fixed pool (i.e. we didn't start with
+        // a page)
         if (!tree->next) {
             mpack_tree_flag_error(tree, mpack_error_too_big);
             return false;
         }
 
-        // Otherwise we need to grow, and the node's children need to be contiguous.
-        // This is a heuristic to decide whether we should waste the remaining space
-        // in the current page and start a new one, or give the children their
-        // own page. With a fraction of 1/8, this causes at most 12% additional
-        // waste. Note that reducing this too much causes less cache coherence and
-        // more malloc() overhead due to smaller allocations, so there's a tradeoff
-        // here. This heuristic could use some improvement, especially with custom
-        // page sizes.
+        // Otherwise we need to grow, and the node's children need to be
+        // contiguous. This is a heuristic to decide whether we should waste the
+        // remaining space in the current page and start a new one, or give the
+        // children their own page. With a fraction of 1/8, this causes at most
+        // 12% additional waste. Note that reducing this too much causes less
+        // cache coherence and more malloc() overhead due to smaller
+        // allocations, so there's a tradeoff here. This heuristic could use
+        // some improvement, especially with custom page sizes.
 
-        mpack_tree_page_t* page;
+        mpack_tree_page_t *page;
 
-        if (total > MPACK_NODES_PER_PAGE || parser->nodes_left > MPACK_NODES_PER_PAGE / 8) {
+        if (total > MPACK_NODES_PER_PAGE
+            || parser->nodes_left > MPACK_NODES_PER_PAGE / 8) {
             // TODO: this should check for overflow
-            page = (mpack_tree_page_t*)MPACK_MALLOC(
-                    sizeof(mpack_tree_page_t) + sizeof(mpack_node_data_t) * (total - 1));
+            page = (mpack_tree_page_t *)MPACK_MALLOC(sizeof(mpack_tree_page_t)
+                + sizeof(mpack_node_data_t) * (total - 1));
             if (page == NULL) {
                 mpack_tree_flag_error(tree, mpack_error_memory);
                 return false;
             }
-            mpack_log("allocated seperate page %p for %i children, %i left in page of %i total\n",
-                    page, (int)total, (int)parser->nodes_left, (int)MPACK_NODES_PER_PAGE);
+            mpack_log("allocated seperate page %p for %i children, %i left in "
+                      "page of %i total\n",
+                page, (int)total, (int)parser->nodes_left,
+                (int)MPACK_NODES_PER_PAGE);
 
             node->value.children = page->nodes;
 
         } else {
-            page = (mpack_tree_page_t*)MPACK_MALLOC(MPACK_PAGE_ALLOC_SIZE);
+            page = (mpack_tree_page_t *)MPACK_MALLOC(MPACK_PAGE_ALLOC_SIZE);
             if (page == NULL) {
                 mpack_tree_flag_error(tree, mpack_error_memory);
                 return false;
             }
-            mpack_log("allocated new page %p for %i children, wasting %i in page of %i total\n",
-                    page, (int)total, (int)parser->nodes_left, (int)MPACK_NODES_PER_PAGE);
+            mpack_log("allocated new page %p for %i children, wasting %i in "
+                      "page of %i total\n",
+                page, (int)total, (int)parser->nodes_left,
+                (int)MPACK_NODES_PER_PAGE);
 
             node->value.children = page->nodes;
             parser->nodes = page->nodes + total;
@@ -4447,31 +5365,37 @@ static bool mpack_tree_parse_children(mpack_tree_t* tree, mpack_node_data_t* nod
         page->next = tree->next;
         tree->next = page;
 
-        #else
+#    else
         // We can't grow if we don't have an allocator
         mpack_tree_flag_error(tree, mpack_error_too_big);
         return false;
-        #endif
+#    endif
     }
 
     return mpack_tree_push_stack(tree, node->value.children, total);
 }
 
-static bool mpack_tree_parse_bytes(mpack_tree_t* tree, mpack_node_data_t* node) {
+static bool
+mpack_tree_parse_bytes(mpack_tree_t *tree, mpack_node_data_t *node)
+{
     node->value.offset = tree->size + tree->parser.current_node_reserved + 1;
     return mpack_tree_reserve_bytes(tree, node->len);
 }
 
-#if MPACK_EXTENSIONS
-static bool mpack_tree_parse_ext(mpack_tree_t* tree, mpack_node_data_t* node) {
+#    if MPACK_EXTENSIONS
+static bool
+mpack_tree_parse_ext(mpack_tree_t *tree, mpack_node_data_t *node)
+{
     // reserve space for exttype
     tree->parser.current_node_reserved += sizeof(int8_t);
     node->type = mpack_type_ext;
     return mpack_tree_parse_bytes(tree, node);
 }
-#endif
+#    endif
 
-static bool mpack_tree_parse_node_contents(mpack_tree_t* tree, mpack_node_data_t* node) {
+static bool
+mpack_tree_parse_node_contents(mpack_tree_t *tree, mpack_node_data_t *node)
+{
     mpack_assert(tree->parser.state == mpack_tree_parse_state_in_progress);
     mpack_assert(node != NULL, "null node?");
 
@@ -4487,358 +5411,565 @@ static bool mpack_tree_parse_node_contents(mpack_tree_t* tree, mpack_node_data_t
     // on the first byte, and to explicitly list every possible byte. we switch
     // on the first four bits in size-optimized builds.
 
-    #if MPACK_OPTIMIZE_FOR_SIZE
+#    if MPACK_OPTIMIZE_FOR_SIZE
     switch (type >> 4) {
 
-        // positive fixnum
-        case 0x0: case 0x1: case 0x2: case 0x3:
-        case 0x4: case 0x5: case 0x6: case 0x7:
-            node->type = mpack_type_uint;
-            node->value.u = type;
-            return true;
+    // positive fixnum
+    case 0x0:
+    case 0x1:
+    case 0x2:
+    case 0x3:
+    case 0x4:
+    case 0x5:
+    case 0x6:
+    case 0x7:
+        node->type = mpack_type_uint;
+        node->value.u = type;
+        return true;
 
-        // negative fixnum
-        case 0xe: case 0xf:
-            node->type = mpack_type_int;
-            node->value.i = (int8_t)type;
-            return true;
+    // negative fixnum
+    case 0xe:
+    case 0xf:
+        node->type = mpack_type_int;
+        node->value.i = (int8_t)type;
+        return true;
 
-        // fixmap
-        case 0x8:
-            node->type = mpack_type_map;
-            node->len = (uint32_t)(type & ~0xf0);
-            return mpack_tree_parse_children(tree, node);
+    // fixmap
+    case 0x8:
+        node->type = mpack_type_map;
+        node->len = (uint32_t)(type & ~0xf0);
+        return mpack_tree_parse_children(tree, node);
 
-        // fixarray
-        case 0x9:
-            node->type = mpack_type_array;
-            node->len = (uint32_t)(type & ~0xf0);
-            return mpack_tree_parse_children(tree, node);
+    // fixarray
+    case 0x9:
+        node->type = mpack_type_array;
+        node->len = (uint32_t)(type & ~0xf0);
+        return mpack_tree_parse_children(tree, node);
 
-        // fixstr
-        case 0xa: case 0xb:
-            node->type = mpack_type_str;
-            node->len = (uint32_t)(type & ~0xe0);
-            return mpack_tree_parse_bytes(tree, node);
+    // fixstr
+    case 0xa:
+    case 0xb:
+        node->type = mpack_type_str;
+        node->len = (uint32_t)(type & ~0xe0);
+        return mpack_tree_parse_bytes(tree, node);
 
-        // not one of the common infix types
-        default:
-            break;
+    // not one of the common infix types
+    default:
+        break;
     }
-    #endif
+#    endif
 
     switch (type) {
 
-        #if !MPACK_OPTIMIZE_FOR_SIZE
-        // positive fixnum
-        case 0x00: case 0x01: case 0x02: case 0x03: case 0x04: case 0x05: case 0x06: case 0x07:
-        case 0x08: case 0x09: case 0x0a: case 0x0b: case 0x0c: case 0x0d: case 0x0e: case 0x0f:
-        case 0x10: case 0x11: case 0x12: case 0x13: case 0x14: case 0x15: case 0x16: case 0x17:
-        case 0x18: case 0x19: case 0x1a: case 0x1b: case 0x1c: case 0x1d: case 0x1e: case 0x1f:
-        case 0x20: case 0x21: case 0x22: case 0x23: case 0x24: case 0x25: case 0x26: case 0x27:
-        case 0x28: case 0x29: case 0x2a: case 0x2b: case 0x2c: case 0x2d: case 0x2e: case 0x2f:
-        case 0x30: case 0x31: case 0x32: case 0x33: case 0x34: case 0x35: case 0x36: case 0x37:
-        case 0x38: case 0x39: case 0x3a: case 0x3b: case 0x3c: case 0x3d: case 0x3e: case 0x3f:
-        case 0x40: case 0x41: case 0x42: case 0x43: case 0x44: case 0x45: case 0x46: case 0x47:
-        case 0x48: case 0x49: case 0x4a: case 0x4b: case 0x4c: case 0x4d: case 0x4e: case 0x4f:
-        case 0x50: case 0x51: case 0x52: case 0x53: case 0x54: case 0x55: case 0x56: case 0x57:
-        case 0x58: case 0x59: case 0x5a: case 0x5b: case 0x5c: case 0x5d: case 0x5e: case 0x5f:
-        case 0x60: case 0x61: case 0x62: case 0x63: case 0x64: case 0x65: case 0x66: case 0x67:
-        case 0x68: case 0x69: case 0x6a: case 0x6b: case 0x6c: case 0x6d: case 0x6e: case 0x6f:
-        case 0x70: case 0x71: case 0x72: case 0x73: case 0x74: case 0x75: case 0x76: case 0x77:
-        case 0x78: case 0x79: case 0x7a: case 0x7b: case 0x7c: case 0x7d: case 0x7e: case 0x7f:
-            node->type = mpack_type_uint;
-            node->value.u = type;
-            return true;
+#    if !MPACK_OPTIMIZE_FOR_SIZE
+    // positive fixnum
+    case 0x00:
+    case 0x01:
+    case 0x02:
+    case 0x03:
+    case 0x04:
+    case 0x05:
+    case 0x06:
+    case 0x07:
+    case 0x08:
+    case 0x09:
+    case 0x0a:
+    case 0x0b:
+    case 0x0c:
+    case 0x0d:
+    case 0x0e:
+    case 0x0f:
+    case 0x10:
+    case 0x11:
+    case 0x12:
+    case 0x13:
+    case 0x14:
+    case 0x15:
+    case 0x16:
+    case 0x17:
+    case 0x18:
+    case 0x19:
+    case 0x1a:
+    case 0x1b:
+    case 0x1c:
+    case 0x1d:
+    case 0x1e:
+    case 0x1f:
+    case 0x20:
+    case 0x21:
+    case 0x22:
+    case 0x23:
+    case 0x24:
+    case 0x25:
+    case 0x26:
+    case 0x27:
+    case 0x28:
+    case 0x29:
+    case 0x2a:
+    case 0x2b:
+    case 0x2c:
+    case 0x2d:
+    case 0x2e:
+    case 0x2f:
+    case 0x30:
+    case 0x31:
+    case 0x32:
+    case 0x33:
+    case 0x34:
+    case 0x35:
+    case 0x36:
+    case 0x37:
+    case 0x38:
+    case 0x39:
+    case 0x3a:
+    case 0x3b:
+    case 0x3c:
+    case 0x3d:
+    case 0x3e:
+    case 0x3f:
+    case 0x40:
+    case 0x41:
+    case 0x42:
+    case 0x43:
+    case 0x44:
+    case 0x45:
+    case 0x46:
+    case 0x47:
+    case 0x48:
+    case 0x49:
+    case 0x4a:
+    case 0x4b:
+    case 0x4c:
+    case 0x4d:
+    case 0x4e:
+    case 0x4f:
+    case 0x50:
+    case 0x51:
+    case 0x52:
+    case 0x53:
+    case 0x54:
+    case 0x55:
+    case 0x56:
+    case 0x57:
+    case 0x58:
+    case 0x59:
+    case 0x5a:
+    case 0x5b:
+    case 0x5c:
+    case 0x5d:
+    case 0x5e:
+    case 0x5f:
+    case 0x60:
+    case 0x61:
+    case 0x62:
+    case 0x63:
+    case 0x64:
+    case 0x65:
+    case 0x66:
+    case 0x67:
+    case 0x68:
+    case 0x69:
+    case 0x6a:
+    case 0x6b:
+    case 0x6c:
+    case 0x6d:
+    case 0x6e:
+    case 0x6f:
+    case 0x70:
+    case 0x71:
+    case 0x72:
+    case 0x73:
+    case 0x74:
+    case 0x75:
+    case 0x76:
+    case 0x77:
+    case 0x78:
+    case 0x79:
+    case 0x7a:
+    case 0x7b:
+    case 0x7c:
+    case 0x7d:
+    case 0x7e:
+    case 0x7f:
+        node->type = mpack_type_uint;
+        node->value.u = type;
+        return true;
 
-        // negative fixnum
-        case 0xe0: case 0xe1: case 0xe2: case 0xe3: case 0xe4: case 0xe5: case 0xe6: case 0xe7:
-        case 0xe8: case 0xe9: case 0xea: case 0xeb: case 0xec: case 0xed: case 0xee: case 0xef:
-        case 0xf0: case 0xf1: case 0xf2: case 0xf3: case 0xf4: case 0xf5: case 0xf6: case 0xf7:
-        case 0xf8: case 0xf9: case 0xfa: case 0xfb: case 0xfc: case 0xfd: case 0xfe: case 0xff:
-            node->type = mpack_type_int;
-            node->value.i = (int8_t)type;
-            return true;
+    // negative fixnum
+    case 0xe0:
+    case 0xe1:
+    case 0xe2:
+    case 0xe3:
+    case 0xe4:
+    case 0xe5:
+    case 0xe6:
+    case 0xe7:
+    case 0xe8:
+    case 0xe9:
+    case 0xea:
+    case 0xeb:
+    case 0xec:
+    case 0xed:
+    case 0xee:
+    case 0xef:
+    case 0xf0:
+    case 0xf1:
+    case 0xf2:
+    case 0xf3:
+    case 0xf4:
+    case 0xf5:
+    case 0xf6:
+    case 0xf7:
+    case 0xf8:
+    case 0xf9:
+    case 0xfa:
+    case 0xfb:
+    case 0xfc:
+    case 0xfd:
+    case 0xfe:
+    case 0xff:
+        node->type = mpack_type_int;
+        node->value.i = (int8_t)type;
+        return true;
 
-        // fixmap
-        case 0x80: case 0x81: case 0x82: case 0x83: case 0x84: case 0x85: case 0x86: case 0x87:
-        case 0x88: case 0x89: case 0x8a: case 0x8b: case 0x8c: case 0x8d: case 0x8e: case 0x8f:
-            node->type = mpack_type_map;
-            node->len = (uint32_t)(type & ~0xf0);
-            return mpack_tree_parse_children(tree, node);
+    // fixmap
+    case 0x80:
+    case 0x81:
+    case 0x82:
+    case 0x83:
+    case 0x84:
+    case 0x85:
+    case 0x86:
+    case 0x87:
+    case 0x88:
+    case 0x89:
+    case 0x8a:
+    case 0x8b:
+    case 0x8c:
+    case 0x8d:
+    case 0x8e:
+    case 0x8f:
+        node->type = mpack_type_map;
+        node->len = (uint32_t)(type & ~0xf0);
+        return mpack_tree_parse_children(tree, node);
 
-        // fixarray
-        case 0x90: case 0x91: case 0x92: case 0x93: case 0x94: case 0x95: case 0x96: case 0x97:
-        case 0x98: case 0x99: case 0x9a: case 0x9b: case 0x9c: case 0x9d: case 0x9e: case 0x9f:
-            node->type = mpack_type_array;
-            node->len = (uint32_t)(type & ~0xf0);
-            return mpack_tree_parse_children(tree, node);
+    // fixarray
+    case 0x90:
+    case 0x91:
+    case 0x92:
+    case 0x93:
+    case 0x94:
+    case 0x95:
+    case 0x96:
+    case 0x97:
+    case 0x98:
+    case 0x99:
+    case 0x9a:
+    case 0x9b:
+    case 0x9c:
+    case 0x9d:
+    case 0x9e:
+    case 0x9f:
+        node->type = mpack_type_array;
+        node->len = (uint32_t)(type & ~0xf0);
+        return mpack_tree_parse_children(tree, node);
 
-        // fixstr
-        case 0xa0: case 0xa1: case 0xa2: case 0xa3: case 0xa4: case 0xa5: case 0xa6: case 0xa7:
-        case 0xa8: case 0xa9: case 0xaa: case 0xab: case 0xac: case 0xad: case 0xae: case 0xaf:
-        case 0xb0: case 0xb1: case 0xb2: case 0xb3: case 0xb4: case 0xb5: case 0xb6: case 0xb7:
-        case 0xb8: case 0xb9: case 0xba: case 0xbb: case 0xbc: case 0xbd: case 0xbe: case 0xbf:
-            node->type = mpack_type_str;
-            node->len = (uint32_t)(type & ~0xe0);
-            return mpack_tree_parse_bytes(tree, node);
-        #endif
+    // fixstr
+    case 0xa0:
+    case 0xa1:
+    case 0xa2:
+    case 0xa3:
+    case 0xa4:
+    case 0xa5:
+    case 0xa6:
+    case 0xa7:
+    case 0xa8:
+    case 0xa9:
+    case 0xaa:
+    case 0xab:
+    case 0xac:
+    case 0xad:
+    case 0xae:
+    case 0xaf:
+    case 0xb0:
+    case 0xb1:
+    case 0xb2:
+    case 0xb3:
+    case 0xb4:
+    case 0xb5:
+    case 0xb6:
+    case 0xb7:
+    case 0xb8:
+    case 0xb9:
+    case 0xba:
+    case 0xbb:
+    case 0xbc:
+    case 0xbd:
+    case 0xbe:
+    case 0xbf:
+        node->type = mpack_type_str;
+        node->len = (uint32_t)(type & ~0xe0);
+        return mpack_tree_parse_bytes(tree, node);
+#    endif
 
-        // nil
-        case 0xc0:
-            node->type = mpack_type_nil;
-            return true;
+    // nil
+    case 0xc0:
+        node->type = mpack_type_nil;
+        return true;
 
-        // bool
-        case 0xc2: case 0xc3:
-            node->type = mpack_type_bool;
-            node->value.b = type & 1;
-            return true;
+    // bool
+    case 0xc2:
+    case 0xc3:
+        node->type = mpack_type_bool;
+        node->value.b = type & 1;
+        return true;
 
-        // bin8
-        case 0xc4:
-            node->type = mpack_type_bin;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
-                return false;
-            node->len = mpack_load_u8(tree->data + tree->size + 1);
-            return mpack_tree_parse_bytes(tree, node);
-
-        // bin16
-        case 0xc5:
-            node->type = mpack_type_bin;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
-                return false;
-            node->len = mpack_load_u16(tree->data + tree->size + 1);
-            return mpack_tree_parse_bytes(tree, node);
-
-        // bin32
-        case 0xc6:
-            node->type = mpack_type_bin;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
-                return false;
-            node->len = mpack_load_u32(tree->data + tree->size + 1);
-            return mpack_tree_parse_bytes(tree, node);
-
-        #if MPACK_EXTENSIONS
-        // ext8
-        case 0xc7:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
-                return false;
-            node->len = mpack_load_u8(tree->data + tree->size + 1);
-            return mpack_tree_parse_ext(tree, node);
-
-        // ext16
-        case 0xc8:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
-                return false;
-            node->len = mpack_load_u16(tree->data + tree->size + 1);
-            return mpack_tree_parse_ext(tree, node);
-
-        // ext32
-        case 0xc9:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
-                return false;
-            node->len = mpack_load_u32(tree->data + tree->size + 1);
-            return mpack_tree_parse_ext(tree, node);
-        #endif
-
-        // float
-        case 0xca:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(float)))
-                return false;
-            node->value.f = mpack_load_float(tree->data + tree->size + 1);
-            node->type = mpack_type_float;
-            return true;
-
-        // double
-        case 0xcb:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(double)))
-                return false;
-            node->value.d = mpack_load_double(tree->data + tree->size + 1);
-            node->type = mpack_type_double;
-            return true;
-
-        // uint8
-        case 0xcc:
-            node->type = mpack_type_uint;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
-                return false;
-            node->value.u = mpack_load_u8(tree->data + tree->size + 1);
-            return true;
-
-        // uint16
-        case 0xcd:
-            node->type = mpack_type_uint;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
-                return false;
-            node->value.u = mpack_load_u16(tree->data + tree->size + 1);
-            return true;
-
-        // uint32
-        case 0xce:
-            node->type = mpack_type_uint;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
-                return false;
-            node->value.u = mpack_load_u32(tree->data + tree->size + 1);
-            return true;
-
-        // uint64
-        case 0xcf:
-            node->type = mpack_type_uint;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint64_t)))
-                return false;
-            node->value.u = mpack_load_u64(tree->data + tree->size + 1);
-            return true;
-
-        // int8
-        case 0xd0:
-            node->type = mpack_type_int;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(int8_t)))
-                return false;
-            node->value.i = mpack_load_i8(tree->data + tree->size + 1);
-            return true;
-
-        // int16
-        case 0xd1:
-            node->type = mpack_type_int;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(int16_t)))
-                return false;
-            node->value.i = mpack_load_i16(tree->data + tree->size + 1);
-            return true;
-
-        // int32
-        case 0xd2:
-            node->type = mpack_type_int;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(int32_t)))
-                return false;
-            node->value.i = mpack_load_i32(tree->data + tree->size + 1);
-            return true;
-
-        // int64
-        case 0xd3:
-            node->type = mpack_type_int;
-            if (!mpack_tree_reserve_bytes(tree, sizeof(int64_t)))
-                return false;
-            node->value.i = mpack_load_i64(tree->data + tree->size + 1);
-            return true;
-
-        #if MPACK_EXTENSIONS
-        // fixext1
-        case 0xd4:
-            node->len = 1;
-            return mpack_tree_parse_ext(tree, node);
-
-        // fixext2
-        case 0xd5:
-            node->len = 2;
-            return mpack_tree_parse_ext(tree, node);
-
-        // fixext4
-        case 0xd6:
-            node->len = 4;
-            return mpack_tree_parse_ext(tree, node);
-
-        // fixext8
-        case 0xd7:
-            node->len = 8;
-            return mpack_tree_parse_ext(tree, node);
-
-        // fixext16
-        case 0xd8:
-            node->len = 16;
-            return mpack_tree_parse_ext(tree, node);
-        #endif
-
-        // str8
-        case 0xd9:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
-                return false;
-            node->len = mpack_load_u8(tree->data + tree->size + 1);
-            node->type = mpack_type_str;
-            return mpack_tree_parse_bytes(tree, node);
-
-        // str16
-        case 0xda:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
-                return false;
-            node->len = mpack_load_u16(tree->data + tree->size + 1);
-            node->type = mpack_type_str;
-            return mpack_tree_parse_bytes(tree, node);
-
-        // str32
-        case 0xdb:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
-                return false;
-            node->len = mpack_load_u32(tree->data + tree->size + 1);
-            node->type = mpack_type_str;
-            return mpack_tree_parse_bytes(tree, node);
-
-        // array16
-        case 0xdc:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
-                return false;
-            node->len = mpack_load_u16(tree->data + tree->size + 1);
-            node->type = mpack_type_array;
-            return mpack_tree_parse_children(tree, node);
-
-        // array32
-        case 0xdd:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
-                return false;
-            node->len = mpack_load_u32(tree->data + tree->size + 1);
-            node->type = mpack_type_array;
-            return mpack_tree_parse_children(tree, node);
-
-        // map16
-        case 0xde:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
-                return false;
-            node->len = mpack_load_u16(tree->data + tree->size + 1);
-            node->type = mpack_type_map;
-            return mpack_tree_parse_children(tree, node);
-
-        // map32
-        case 0xdf:
-            if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
-                return false;
-            node->len = mpack_load_u32(tree->data + tree->size + 1);
-            node->type = mpack_type_map;
-            return mpack_tree_parse_children(tree, node);
-
-        // reserved
-        case 0xc1:
-            mpack_tree_flag_error(tree, mpack_error_invalid);
+    // bin8
+    case 0xc4:
+        node->type = mpack_type_bin;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
             return false;
+        node->len = mpack_load_u8(tree->data + tree->size + 1);
+        return mpack_tree_parse_bytes(tree, node);
 
-        #if !MPACK_EXTENSIONS
-        // ext
-        case 0xc7: // fallthrough
-        case 0xc8: // fallthrough
-        case 0xc9: // fallthrough
-        // fixext
-        case 0xd4: // fallthrough
-        case 0xd5: // fallthrough
-        case 0xd6: // fallthrough
-        case 0xd7: // fallthrough
-        case 0xd8:
-            mpack_tree_flag_error(tree, mpack_error_unsupported);
+    // bin16
+    case 0xc5:
+        node->type = mpack_type_bin;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
             return false;
-        #endif
+        node->len = mpack_load_u16(tree->data + tree->size + 1);
+        return mpack_tree_parse_bytes(tree, node);
 
-        #if MPACK_OPTIMIZE_FOR_SIZE
-        // any other bytes should have been handled by the infix switch
-        default:
-            break;
-        #endif
+    // bin32
+    case 0xc6:
+        node->type = mpack_type_bin;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
+            return false;
+        node->len = mpack_load_u32(tree->data + tree->size + 1);
+        return mpack_tree_parse_bytes(tree, node);
+
+#    if MPACK_EXTENSIONS
+    // ext8
+    case 0xc7:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
+            return false;
+        node->len = mpack_load_u8(tree->data + tree->size + 1);
+        return mpack_tree_parse_ext(tree, node);
+
+    // ext16
+    case 0xc8:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
+            return false;
+        node->len = mpack_load_u16(tree->data + tree->size + 1);
+        return mpack_tree_parse_ext(tree, node);
+
+    // ext32
+    case 0xc9:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
+            return false;
+        node->len = mpack_load_u32(tree->data + tree->size + 1);
+        return mpack_tree_parse_ext(tree, node);
+#    endif
+
+    // float
+    case 0xca:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(float)))
+            return false;
+        node->value.f = mpack_load_float(tree->data + tree->size + 1);
+        node->type = mpack_type_float;
+        return true;
+
+    // double
+    case 0xcb:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(double)))
+            return false;
+        node->value.d = mpack_load_double(tree->data + tree->size + 1);
+        node->type = mpack_type_double;
+        return true;
+
+    // uint8
+    case 0xcc:
+        node->type = mpack_type_uint;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
+            return false;
+        node->value.u = mpack_load_u8(tree->data + tree->size + 1);
+        return true;
+
+    // uint16
+    case 0xcd:
+        node->type = mpack_type_uint;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
+            return false;
+        node->value.u = mpack_load_u16(tree->data + tree->size + 1);
+        return true;
+
+    // uint32
+    case 0xce:
+        node->type = mpack_type_uint;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
+            return false;
+        node->value.u = mpack_load_u32(tree->data + tree->size + 1);
+        return true;
+
+    // uint64
+    case 0xcf:
+        node->type = mpack_type_uint;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint64_t)))
+            return false;
+        node->value.u = mpack_load_u64(tree->data + tree->size + 1);
+        return true;
+
+    // int8
+    case 0xd0:
+        node->type = mpack_type_int;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(int8_t)))
+            return false;
+        node->value.i = mpack_load_i8(tree->data + tree->size + 1);
+        return true;
+
+    // int16
+    case 0xd1:
+        node->type = mpack_type_int;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(int16_t)))
+            return false;
+        node->value.i = mpack_load_i16(tree->data + tree->size + 1);
+        return true;
+
+    // int32
+    case 0xd2:
+        node->type = mpack_type_int;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(int32_t)))
+            return false;
+        node->value.i = mpack_load_i32(tree->data + tree->size + 1);
+        return true;
+
+    // int64
+    case 0xd3:
+        node->type = mpack_type_int;
+        if (!mpack_tree_reserve_bytes(tree, sizeof(int64_t)))
+            return false;
+        node->value.i = mpack_load_i64(tree->data + tree->size + 1);
+        return true;
+
+#    if MPACK_EXTENSIONS
+    // fixext1
+    case 0xd4:
+        node->len = 1;
+        return mpack_tree_parse_ext(tree, node);
+
+    // fixext2
+    case 0xd5:
+        node->len = 2;
+        return mpack_tree_parse_ext(tree, node);
+
+    // fixext4
+    case 0xd6:
+        node->len = 4;
+        return mpack_tree_parse_ext(tree, node);
+
+    // fixext8
+    case 0xd7:
+        node->len = 8;
+        return mpack_tree_parse_ext(tree, node);
+
+    // fixext16
+    case 0xd8:
+        node->len = 16;
+        return mpack_tree_parse_ext(tree, node);
+#    endif
+
+    // str8
+    case 0xd9:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint8_t)))
+            return false;
+        node->len = mpack_load_u8(tree->data + tree->size + 1);
+        node->type = mpack_type_str;
+        return mpack_tree_parse_bytes(tree, node);
+
+    // str16
+    case 0xda:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
+            return false;
+        node->len = mpack_load_u16(tree->data + tree->size + 1);
+        node->type = mpack_type_str;
+        return mpack_tree_parse_bytes(tree, node);
+
+    // str32
+    case 0xdb:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
+            return false;
+        node->len = mpack_load_u32(tree->data + tree->size + 1);
+        node->type = mpack_type_str;
+        return mpack_tree_parse_bytes(tree, node);
+
+    // array16
+    case 0xdc:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
+            return false;
+        node->len = mpack_load_u16(tree->data + tree->size + 1);
+        node->type = mpack_type_array;
+        return mpack_tree_parse_children(tree, node);
+
+    // array32
+    case 0xdd:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
+            return false;
+        node->len = mpack_load_u32(tree->data + tree->size + 1);
+        node->type = mpack_type_array;
+        return mpack_tree_parse_children(tree, node);
+
+    // map16
+    case 0xde:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint16_t)))
+            return false;
+        node->len = mpack_load_u16(tree->data + tree->size + 1);
+        node->type = mpack_type_map;
+        return mpack_tree_parse_children(tree, node);
+
+    // map32
+    case 0xdf:
+        if (!mpack_tree_reserve_bytes(tree, sizeof(uint32_t)))
+            return false;
+        node->len = mpack_load_u32(tree->data + tree->size + 1);
+        node->type = mpack_type_map;
+        return mpack_tree_parse_children(tree, node);
+
+    // reserved
+    case 0xc1:
+        mpack_tree_flag_error(tree, mpack_error_invalid);
+        return false;
+
+#    if !MPACK_EXTENSIONS
+    // ext
+    case 0xc7: // fallthrough
+    case 0xc8: // fallthrough
+    case 0xc9: // fallthrough
+    // fixext
+    case 0xd4: // fallthrough
+    case 0xd5: // fallthrough
+    case 0xd6: // fallthrough
+    case 0xd7: // fallthrough
+    case 0xd8:
+        mpack_tree_flag_error(tree, mpack_error_unsupported);
+        return false;
+#    endif
+
+#    if MPACK_OPTIMIZE_FOR_SIZE
+    // any other bytes should have been handled by the infix switch
+    default:
+        break;
+#    endif
     }
 
     mpack_assert(0, "unreachable");
     return false;
 }
 
-static bool mpack_tree_parse_node(mpack_tree_t* tree, mpack_node_data_t* node) {
-    mpack_log("parsing a node at position %i in level %i\n",
-            (int)tree->size, (int)tree->parser.level);
+static bool
+mpack_tree_parse_node(mpack_tree_t *tree, mpack_node_data_t *node)
+{
+    mpack_log("parsing a node at position %i in level %i\n", (int)tree->size,
+        (int)tree->parser.level);
 
     if (!mpack_tree_parse_node_contents(tree, node)) {
         mpack_log("node parsing returned false\n");
@@ -4861,9 +5992,9 @@ static bool mpack_tree_parse_node(mpack_tree_t* tree, mpack_node_data_t* node) {
     tree->size += node_size;
 
     mpack_log("parsed a node of type %s of %i bytes and "
-            "%i additional bytes reserved for children.\n",
-            mpack_type_to_string(node->type), (int)node_size,
-            (int)tree->parser.current_node_reserved + 1 - (int)node_size);
+              "%i additional bytes reserved for children.\n",
+        mpack_type_to_string(node->type), (int)node_size,
+        (int)tree->parser.current_node_reserved + 1 - (int)node_size);
 
     return true;
 }
@@ -4873,18 +6004,21 @@ static bool mpack_tree_parse_node(mpack_tree_t* tree, mpack_node_data_t* node) {
  * stack holds the amount of children left to read in each level of the tree.
  * Parsing can pause and resume when more data becomes available.
  */
-static bool mpack_tree_continue_parsing(mpack_tree_t* tree) {
+static bool
+mpack_tree_continue_parsing(mpack_tree_t *tree)
+{
     if (mpack_tree_error(tree) != mpack_ok)
         return false;
 
-    mpack_tree_parser_t* parser = &tree->parser;
+    mpack_tree_parser_t *parser = &tree->parser;
     mpack_assert(parser->state == mpack_tree_parse_state_in_progress);
-    mpack_log("parsing tree elements, %i bytes in buffer\n", (int)tree->data_length);
+    mpack_log(
+        "parsing tree elements, %i bytes in buffer\n", (int)tree->data_length);
 
     // we loop parsing nodes until the parse stack is empty. we break
     // by returning out of the function.
     while (true) {
-        mpack_node_data_t* node = parser->stack[parser->level].child;
+        mpack_node_data_t *node = parser->stack[parser->level].child;
         size_t level = parser->level;
         if (!mpack_tree_parse_node(tree, node))
             return false;
@@ -4892,14 +6026,14 @@ static bool mpack_tree_continue_parsing(mpack_tree_t* tree) {
         ++parser->stack[level].child;
 
         mpack_assert(mpack_tree_error(tree) == mpack_ok,
-                "mpack_tree_parse_node() should have returned false due to error!");
+            "mpack_tree_parse_node() should have returned false due to error!");
 
-        // pop empty stack levels, exiting the outer loop when the stack is empty.
-        // (we could tail-optimize containers by pre-emptively popping empty
-        // stack levels before reading the new element, this way we wouldn't
-        // have to loop. but we eventually want to use the parse stack to give
-        // better error messages that contain the location of the error, so
-        // it needs to be complete.)
+        // pop empty stack levels, exiting the outer loop when the stack is
+        // empty. (we could tail-optimize containers by pre-emptively popping
+        // empty stack levels before reading the new element, this way we
+        // wouldn't have to loop. but we eventually want to use the parse stack
+        // to give better error messages that contain the location of the error,
+        // so it needs to be complete.)
         while (parser->stack[parser->level].left == 0) {
             if (parser->level == 0)
                 return true;
@@ -4908,34 +6042,38 @@ static bool mpack_tree_continue_parsing(mpack_tree_t* tree) {
     }
 }
 
-static void mpack_tree_cleanup(mpack_tree_t* tree) {
+static void
+mpack_tree_cleanup(mpack_tree_t *tree)
+{
     MPACK_UNUSED(tree);
 
-    #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
     if (tree->parser.stack_owned) {
         MPACK_FREE(tree->parser.stack);
         tree->parser.stack = NULL;
         tree->parser.stack_owned = false;
     }
 
-    mpack_tree_page_t* page = tree->next;
+    mpack_tree_page_t *page = tree->next;
     while (page != NULL) {
-        mpack_tree_page_t* next = page->next;
+        mpack_tree_page_t *next = page->next;
         mpack_log("freeing page %p\n", page);
         MPACK_FREE(page);
         page = next;
     }
     tree->next = NULL;
-    #endif
+#    endif
 }
 
-static bool mpack_tree_parse_start(mpack_tree_t* tree) {
+static bool
+mpack_tree_parse_start(mpack_tree_t *tree)
+{
     if (mpack_tree_error(tree) != mpack_ok)
         return false;
 
-    mpack_tree_parser_t* parser = &tree->parser;
+    mpack_tree_parser_t *parser = &tree->parser;
     mpack_assert(parser->state != mpack_tree_parse_state_in_progress,
-            "previous parsing was not finished!");
+        "previous parsing was not finished!");
 
     if (parser->state == mpack_tree_parse_state_parsed)
         mpack_tree_cleanup(tree);
@@ -4946,7 +6084,7 @@ static bool mpack_tree_parse_start(mpack_tree_t* tree) {
 
     // check if we previously parsed a tree
     if (tree->size > 0) {
-        #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
         // if we're buffered, move the remaining data back to the
         // start of the buffer
         // TODO: This is not ideal performance-wise. We should only move data
@@ -4956,10 +6094,10 @@ static bool mpack_tree_parse_start(mpack_tree_t* tree) {
         // the buffer size or if messages take up less than a quarter of the
         // buffer size. Maybe this should be configurable.
         if (tree->buffer != NULL) {
-            mpack_memmove(tree->buffer, tree->buffer + tree->size, tree->data_length - tree->size);
-        }
-        else
-        #endif
+            mpack_memmove(tree->buffer, tree->buffer + tree->size,
+                tree->data_length - tree->size);
+        } else
+#    endif
         // otherwise advance past the parsed data
         {
             tree->data += tree->size;
@@ -4975,21 +6113,24 @@ static bool mpack_tree_parse_start(mpack_tree_t* tree) {
         tree->parser.state = mpack_tree_parse_state_not_started;
         return false;
     }
-    mpack_log("parsing tree at %p starting with byte %x\n", tree->data, (uint8_t)tree->data[0]);
+    mpack_log("parsing tree at %p starting with byte %x\n", tree->data,
+        (uint8_t)tree->data[0]);
     parser->possible_nodes_left -= 1;
     tree->node_count = 1;
 
-    #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
     parser->stack = parser->stack_local;
     parser->stack_owned = false;
-    parser->stack_capacity = sizeof(parser->stack_local) / sizeof(*parser->stack_local);
+    parser->stack_capacity
+        = sizeof(parser->stack_local) / sizeof(*parser->stack_local);
 
     if (tree->pool == NULL) {
 
         // allocate first page
-        mpack_tree_page_t* page = (mpack_tree_page_t*)MPACK_MALLOC(MPACK_PAGE_ALLOC_SIZE);
-        mpack_log("allocated initial page %p of size %i count %i\n",
-                page, (int)MPACK_PAGE_ALLOC_SIZE, (int)MPACK_NODES_PER_PAGE);
+        mpack_tree_page_t *page
+            = (mpack_tree_page_t *)MPACK_MALLOC(MPACK_PAGE_ALLOC_SIZE);
+        mpack_log("allocated initial page %p of size %i count %i\n", page,
+            (int)MPACK_PAGE_ALLOC_SIZE, (int)MPACK_NODES_PER_PAGE);
         if (page == NULL) {
             tree->error = mpack_error_memory;
             return false;
@@ -4999,9 +6140,8 @@ static bool mpack_tree_parse_start(mpack_tree_t* tree) {
 
         parser->nodes = page->nodes;
         parser->nodes_left = MPACK_NODES_PER_PAGE;
-    }
-    else
-    #endif
+    } else
+#    endif
     {
         // otherwise use the provided pool
         mpack_assert(tree->pool != NULL, "no pool provided?");
@@ -5020,14 +6160,16 @@ static bool mpack_tree_parse_start(mpack_tree_t* tree) {
     return true;
 }
 
-void mpack_tree_parse(mpack_tree_t* tree) {
+void
+mpack_tree_parse(mpack_tree_t *tree)
+{
     if (mpack_tree_error(tree) != mpack_ok)
         return;
 
     if (tree->parser.state != mpack_tree_parse_state_in_progress) {
         if (!mpack_tree_parse_start(tree)) {
-            mpack_tree_flag_error(tree, (tree->read_fn == NULL) ?
-                    mpack_error_invalid : mpack_error_io);
+            mpack_tree_flag_error(tree,
+                (tree->read_fn == NULL) ? mpack_error_invalid : mpack_error_io);
             return;
         }
     }
@@ -5039,19 +6181,22 @@ void mpack_tree_parse(mpack_tree_t* tree) {
         // We're parsing synchronously on a blocking fill function. If we
         // didn't completely finish parsing the tree, it's an error.
         mpack_log("tree parsing incomplete. flagging error.\n");
-        mpack_tree_flag_error(tree, (tree->read_fn == NULL) ?
-                mpack_error_invalid : mpack_error_io);
+        mpack_tree_flag_error(tree,
+            (tree->read_fn == NULL) ? mpack_error_invalid : mpack_error_io);
         return;
     }
 
     mpack_assert(mpack_tree_error(tree) == mpack_ok);
     mpack_assert(tree->parser.level == 0);
     tree->parser.state = mpack_tree_parse_state_parsed;
-    mpack_log("parsed tree of %i bytes, %i bytes left\n", (int)tree->size, (int)tree->parser.possible_nodes_left);
+    mpack_log("parsed tree of %i bytes, %i bytes left\n", (int)tree->size,
+        (int)tree->parser.possible_nodes_left);
     mpack_log("%i nodes in final page\n", (int)tree->parser.nodes_left);
 }
 
-bool mpack_tree_try_parse(mpack_tree_t* tree) {
+bool
+mpack_tree_try_parse(mpack_tree_t *tree)
+{
     if (mpack_tree_error(tree) != mpack_ok)
         return false;
 
@@ -5068,13 +6213,13 @@ bool mpack_tree_try_parse(mpack_tree_t* tree) {
     return true;
 }
 
-
-
 /*
  * Tree functions
  */
 
-mpack_node_t mpack_tree_root(mpack_tree_t* tree) {
+mpack_node_t
+mpack_tree_root(mpack_tree_t *tree)
+{
     if (mpack_tree_error(tree) != mpack_ok)
         return mpack_tree_nil_node(tree);
 
@@ -5082,8 +6227,9 @@ mpack_node_t mpack_tree_root(mpack_tree_t* tree) {
     // call mpack_tree_parse() (or mpack_tree_try_parse() with a success
     // result) in order to access the root node.
     if (tree->parser.state != mpack_tree_parse_state_parsed) {
-        mpack_break("Tree has not been parsed! "
-                "Did you call mpack_tree_parse() or mpack_tree_try_parse()?");
+        mpack_break(
+            "Tree has not been parsed! "
+            "Did you call mpack_tree_parse() or mpack_tree_try_parse()?");
         mpack_tree_flag_error(tree, mpack_error_bug);
         return mpack_tree_nil_node(tree);
     }
@@ -5091,7 +6237,9 @@ mpack_node_t mpack_tree_root(mpack_tree_t* tree) {
     return mpack_node(tree, tree->root);
 }
 
-static void mpack_tree_init_clear(mpack_tree_t* tree) {
+static void
+mpack_tree_init_clear(mpack_tree_t *tree)
+{
     mpack_memset(tree, 0, sizeof(*tree));
     tree->nil_node.type = mpack_type_nil;
     tree->missing_node.type = mpack_type_missing;
@@ -5099,15 +6247,17 @@ static void mpack_tree_init_clear(mpack_tree_t* tree) {
     tree->max_nodes = SIZE_MAX;
 }
 
-#ifdef MPACK_MALLOC
-void mpack_tree_init_data(mpack_tree_t* tree, const char* data, size_t length) {
+#    ifdef MPACK_MALLOC
+void
+mpack_tree_init_data(mpack_tree_t *tree, const char *data, size_t length)
+{
     mpack_tree_init_clear(tree);
 
     MPACK_STATIC_ASSERT(MPACK_NODE_PAGE_SIZE >= sizeof(mpack_tree_page_t),
-            "MPACK_NODE_PAGE_SIZE is too small");
+        "MPACK_NODE_PAGE_SIZE is too small");
 
     MPACK_STATIC_ASSERT(MPACK_PAGE_ALLOC_SIZE <= MPACK_NODE_PAGE_SIZE,
-            "incorrect page rounding?");
+        "incorrect page rounding?");
 
     tree->data = data;
     tree->data_length = length;
@@ -5118,15 +6268,16 @@ void mpack_tree_init_data(mpack_tree_t* tree, const char* data, size_t length) {
     mpack_log("===========================\n");
     mpack_log("initializing tree with data of size %i\n", (int)length);
 }
-#endif
+#    endif
 
-void mpack_tree_init_pool(mpack_tree_t* tree, const char* data, size_t length,
-        mpack_node_data_t* node_pool, size_t node_pool_count)
+void
+mpack_tree_init_pool(mpack_tree_t *tree, const char *data, size_t length,
+    mpack_node_data_t *node_pool, size_t node_pool_count)
 {
     mpack_tree_init_clear(tree);
-    #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
     tree->next = NULL;
-    #endif
+#    endif
 
     if (node_pool_count == 0) {
         mpack_break("initial page has no nodes!");
@@ -5141,10 +6292,12 @@ void mpack_tree_init_pool(mpack_tree_t* tree, const char* data, size_t length,
 
     mpack_log("===========================\n");
     mpack_log("initializing tree with data of size %i and pool of count %i\n",
-            (int)length, (int)node_pool_count);
+        (int)length, (int)node_pool_count);
 }
 
-void mpack_tree_init_error(mpack_tree_t* tree, mpack_error_t error) {
+void
+mpack_tree_init_error(mpack_tree_t *tree, mpack_error_t error)
+{
     mpack_tree_init_clear(tree);
     tree->error = error;
 
@@ -5152,9 +6305,11 @@ void mpack_tree_init_error(mpack_tree_t* tree, mpack_error_t error) {
     mpack_log("initializing tree error state %i\n", (int)error);
 }
 
-#ifdef MPACK_MALLOC
-void mpack_tree_init_stream(mpack_tree_t* tree, mpack_tree_read_t read_fn, void* context,
-        size_t max_message_size, size_t max_message_nodes) {
+#    ifdef MPACK_MALLOC
+void
+mpack_tree_init_stream(mpack_tree_t *tree, mpack_tree_read_t read_fn,
+    void *context, size_t max_message_size, size_t max_message_nodes)
+{
     mpack_tree_init_clear(tree);
 
     tree->read_fn = read_fn;
@@ -5166,31 +6321,39 @@ void mpack_tree_init_stream(mpack_tree_t* tree, mpack_tree_read_t read_fn, void*
 
     mpack_log("===========================\n");
     mpack_log("initializing tree with stream, max size %i max nodes %i\n",
-            (int)max_message_size, (int)max_message_nodes);
+        (int)max_message_size, (int)max_message_nodes);
 }
-#endif
+#    endif
 
-void mpack_tree_set_limits(mpack_tree_t* tree, size_t max_message_size, size_t max_message_nodes) {
+void
+mpack_tree_set_limits(
+    mpack_tree_t *tree, size_t max_message_size, size_t max_message_nodes)
+{
     mpack_assert(max_message_size > 0);
     mpack_assert(max_message_nodes > 0);
     tree->max_size = max_message_size;
     tree->max_nodes = max_message_nodes;
 }
 
-#if MPACK_STDIO
+#    if MPACK_STDIO
 typedef struct mpack_file_tree_t {
-    char* data;
+    char *data;
     size_t size;
     char buffer[MPACK_BUFFER_SIZE];
 } mpack_file_tree_t;
 
-static void mpack_file_tree_teardown(mpack_tree_t* tree) {
-    mpack_file_tree_t* file_tree = (mpack_file_tree_t*)tree->context;
+static void
+mpack_file_tree_teardown(mpack_tree_t *tree)
+{
+    mpack_file_tree_t *file_tree = (mpack_file_tree_t *)tree->context;
     MPACK_FREE(file_tree->data);
     MPACK_FREE(file_tree);
 }
 
-static bool mpack_file_tree_read(mpack_tree_t* tree, mpack_file_tree_t* file_tree, FILE* file, size_t max_bytes) {
+static bool
+mpack_file_tree_read(mpack_tree_t *tree, mpack_file_tree_t *file_tree,
+    FILE *file, size_t max_bytes)
+{
 
     // get the file size
     errno = 0;
@@ -5213,14 +6376,17 @@ static bool mpack_file_tree_read(mpack_tree_t* tree, mpack_file_tree_t* file_tre
     }
 
     // make sure the size is less than max_bytes
-    // (this mess exists to safely convert between long and size_t regardless of their widths)
-    if (max_bytes != 0 && (((uint64_t)LONG_MAX > (uint64_t)SIZE_MAX && size > (long)SIZE_MAX) || (size_t)size > max_bytes)) {
+    // (this mess exists to safely convert between long and size_t regardless of
+    // their widths)
+    if (max_bytes != 0
+        && (((uint64_t)LONG_MAX > (uint64_t)SIZE_MAX && size > (long)SIZE_MAX)
+            || (size_t)size > max_bytes)) {
         mpack_tree_init_error(tree, mpack_error_too_big);
         return false;
     }
 
     // allocate data
-    file_tree->data = (char*)MPACK_MALLOC((size_t)size);
+    file_tree->data = (char *)MPACK_MALLOC((size_t)size);
     if (file_tree->data == NULL) {
         mpack_tree_init_error(tree, mpack_error_memory);
         return false;
@@ -5229,7 +6395,8 @@ static bool mpack_file_tree_read(mpack_tree_t* tree, mpack_file_tree_t* file_tre
     // read the file
     long total = 0;
     while (total < size) {
-        size_t read = fread(file_tree->data + total, 1, (size_t)(size - total), file);
+        size_t read
+            = fread(file_tree->data + total, 1, (size_t)(size - total), file);
         if (read <= 0) {
             mpack_tree_init_error(tree, mpack_error_io);
             MPACK_FREE(file_tree->data);
@@ -5242,11 +6409,14 @@ static bool mpack_file_tree_read(mpack_tree_t* tree, mpack_file_tree_t* file_tre
     return true;
 }
 
-static bool mpack_tree_file_check_max_bytes(mpack_tree_t* tree, size_t max_bytes) {
+static bool
+mpack_tree_file_check_max_bytes(mpack_tree_t *tree, size_t max_bytes)
+{
 
     // the C STDIO family of file functions use long (e.g. ftell)
     if (max_bytes > LONG_MAX) {
-        mpack_break("max_bytes of %" PRIu64 " is invalid, maximum is LONG_MAX", (uint64_t)max_bytes);
+        mpack_break("max_bytes of %" PRIu64 " is invalid, maximum is LONG_MAX",
+            (uint64_t)max_bytes);
         mpack_tree_init_error(tree, mpack_error_bug);
         return false;
     }
@@ -5254,10 +6424,14 @@ static bool mpack_tree_file_check_max_bytes(mpack_tree_t* tree, size_t max_bytes
     return true;
 }
 
-static void mpack_tree_init_stdfile_noclose(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes) {
+static void
+mpack_tree_init_stdfile_noclose(
+    mpack_tree_t *tree, FILE *stdfile, size_t max_bytes)
+{
 
     // allocate file tree
-    mpack_file_tree_t* file_tree = (mpack_file_tree_t*) MPACK_MALLOC(sizeof(mpack_file_tree_t));
+    mpack_file_tree_t *file_tree
+        = (mpack_file_tree_t *)MPACK_MALLOC(sizeof(mpack_file_tree_t));
     if (file_tree == NULL) {
         mpack_tree_init_error(tree, mpack_error_memory);
         return;
@@ -5274,7 +6448,10 @@ static void mpack_tree_init_stdfile_noclose(mpack_tree_t* tree, FILE* stdfile, s
     mpack_tree_set_teardown(tree, mpack_file_tree_teardown);
 }
 
-void mpack_tree_init_stdfile(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes, bool close_when_done) {
+void
+mpack_tree_init_stdfile(
+    mpack_tree_t *tree, FILE *stdfile, size_t max_bytes, bool close_when_done)
+{
     if (!mpack_tree_file_check_max_bytes(tree, max_bytes))
         return;
 
@@ -5284,12 +6461,15 @@ void mpack_tree_init_stdfile(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes
         fclose(stdfile);
 }
 
-void mpack_tree_init_filename(mpack_tree_t* tree, const char* filename, size_t max_bytes) {
+void
+mpack_tree_init_filename(
+    mpack_tree_t *tree, const char *filename, size_t max_bytes)
+{
     if (!mpack_tree_file_check_max_bytes(tree, max_bytes))
         return;
 
     // open the file
-    FILE* file = fopen(filename, "rb");
+    FILE *file = fopen(filename, "rb");
     if (!file) {
         mpack_tree_init_error(tree, mpack_error_io);
         return;
@@ -5297,15 +6477,17 @@ void mpack_tree_init_filename(mpack_tree_t* tree, const char* filename, size_t m
 
     mpack_tree_init_stdfile(tree, file, max_bytes, true);
 }
-#endif
+#    endif
 
-mpack_error_t mpack_tree_destroy(mpack_tree_t* tree) {
+mpack_error_t
+mpack_tree_destroy(mpack_tree_t *tree)
+{
     mpack_tree_cleanup(tree);
 
-    #ifdef MPACK_MALLOC
+#    ifdef MPACK_MALLOC
     if (tree->buffer)
         MPACK_FREE(tree->buffer);
-    #endif
+#    endif
 
     if (tree->teardown)
         tree->teardown(tree);
@@ -5314,27 +6496,31 @@ mpack_error_t mpack_tree_destroy(mpack_tree_t* tree) {
     return tree->error;
 }
 
-void mpack_tree_flag_error(mpack_tree_t* tree, mpack_error_t error) {
+void
+mpack_tree_flag_error(mpack_tree_t *tree, mpack_error_t error)
+{
     if (tree->error == mpack_ok) {
-        mpack_log("tree %p setting error %i: %s\n", tree, (int)error, mpack_error_to_string(error));
+        mpack_log("tree %p setting error %i: %s\n", tree, (int)error,
+            mpack_error_to_string(error));
         tree->error = error;
         if (tree->error_fn)
             tree->error_fn(tree, error);
     }
-
 }
-
-
 
 /*
  * Node misc functions
  */
 
-void mpack_node_flag_error(mpack_node_t node, mpack_error_t error) {
+void
+mpack_node_flag_error(mpack_node_t node, mpack_error_t error)
+{
     mpack_tree_flag_error(node.tree, error);
 }
 
-mpack_tag_t mpack_node_tag(mpack_node_t node) {
+mpack_tag_t
+mpack_node_tag(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return mpack_tag_nil();
 
@@ -5342,115 +6528,146 @@ mpack_tag_t mpack_node_tag(mpack_node_t node) {
 
     tag.type = node.data->type;
     switch (node.data->type) {
-        case mpack_type_missing:
-            // If a node is missing, I don't know if it makes sense to ask for
-            // a tag for it. We'll return a missing tag to match the missing
-            // node I guess, but attempting to use the tag for anything (like
-            // writing it for example) will flag mpack_error_bug.
-            break;
-        case mpack_type_nil:                                            break;
-        case mpack_type_bool:    tag.v.b = node.data->value.b;          break;
-        case mpack_type_float:   tag.v.f = node.data->value.f;          break;
-        case mpack_type_double:  tag.v.d = node.data->value.d;          break;
-        case mpack_type_int:     tag.v.i = node.data->value.i;          break;
-        case mpack_type_uint:    tag.v.u = node.data->value.u;          break;
+    case mpack_type_missing:
+        // If a node is missing, I don't know if it makes sense to ask for
+        // a tag for it. We'll return a missing tag to match the missing
+        // node I guess, but attempting to use the tag for anything (like
+        // writing it for example) will flag mpack_error_bug.
+        break;
+    case mpack_type_nil:
+        break;
+    case mpack_type_bool:
+        tag.v.b = node.data->value.b;
+        break;
+    case mpack_type_float:
+        tag.v.f = node.data->value.f;
+        break;
+    case mpack_type_double:
+        tag.v.d = node.data->value.d;
+        break;
+    case mpack_type_int:
+        tag.v.i = node.data->value.i;
+        break;
+    case mpack_type_uint:
+        tag.v.u = node.data->value.u;
+        break;
 
-        case mpack_type_str:     tag.v.l = node.data->len;     break;
-        case mpack_type_bin:     tag.v.l = node.data->len;     break;
+    case mpack_type_str:
+        tag.v.l = node.data->len;
+        break;
+    case mpack_type_bin:
+        tag.v.l = node.data->len;
+        break;
 
-        #if MPACK_EXTENSIONS
-        case mpack_type_ext:
-            tag.v.l = node.data->len;
-            tag.exttype = mpack_node_exttype_unchecked(node);
-            break;
-        #endif
+#    if MPACK_EXTENSIONS
+    case mpack_type_ext:
+        tag.v.l = node.data->len;
+        tag.exttype = mpack_node_exttype_unchecked(node);
+        break;
+#    endif
 
-        case mpack_type_array:   tag.v.n = node.data->len;  break;
-        case mpack_type_map:     tag.v.n = node.data->len;  break;
+    case mpack_type_array:
+        tag.v.n = node.data->len;
+        break;
+    case mpack_type_map:
+        tag.v.n = node.data->len;
+        break;
 
-        default:
-            mpack_assert(0, "unrecognized type %i", (int)node.data->type);
-            break;
+    default:
+        mpack_assert(0, "unrecognized type %i", (int)node.data->type);
+        break;
     }
     return tag;
 }
 
-#if MPACK_DEBUG && MPACK_STDIO
-static void mpack_node_print_element(mpack_node_t node, mpack_print_t* print, size_t depth) {
-    mpack_node_data_t* data = node.data;
+#    if MPACK_DEBUG && MPACK_STDIO
+static void
+mpack_node_print_element(mpack_node_t node, mpack_print_t *print, size_t depth)
+{
+    mpack_node_data_t *data = node.data;
     switch (data->type) {
-        case mpack_type_str:
-            {
-                mpack_print_append_cstr(print, "\"");
-                const char* bytes = mpack_node_data_unchecked(node);
-                for (size_t i = 0; i < data->len; ++i) {
-                    char c = bytes[i];
-                    switch (c) {
-                        case '\n': mpack_print_append_cstr(print, "\\n"); break;
-                        case '\\': mpack_print_append_cstr(print, "\\\\"); break;
-                        case '"': mpack_print_append_cstr(print, "\\\""); break;
-                        default: mpack_print_append(print, &c, 1); break;
-                    }
-                }
-                mpack_print_append_cstr(print, "\"");
+    case mpack_type_str: {
+        mpack_print_append_cstr(print, "\"");
+        const char *bytes = mpack_node_data_unchecked(node);
+        for (size_t i = 0; i < data->len; ++i) {
+            char c = bytes[i];
+            switch (c) {
+            case '\n':
+                mpack_print_append_cstr(print, "\\n");
+                break;
+            case '\\':
+                mpack_print_append_cstr(print, "\\\\");
+                break;
+            case '"':
+                mpack_print_append_cstr(print, "\\\"");
+                break;
+            default:
+                mpack_print_append(print, &c, 1);
+                break;
             }
-            break;
+        }
+        mpack_print_append_cstr(print, "\"");
+    } break;
 
-        case mpack_type_array:
-            mpack_print_append_cstr(print, "[\n");
-            for (size_t i = 0; i < data->len; ++i) {
-                for (size_t j = 0; j < depth + 1; ++j)
-                    mpack_print_append_cstr(print, "    ");
-                mpack_node_print_element(mpack_node_array_at(node, i), print, depth + 1);
-                if (i != data->len - 1)
-                    mpack_print_append_cstr(print, ",");
-                mpack_print_append_cstr(print, "\n");
-            }
-            for (size_t i = 0; i < depth; ++i)
+    case mpack_type_array:
+        mpack_print_append_cstr(print, "[\n");
+        for (size_t i = 0; i < data->len; ++i) {
+            for (size_t j = 0; j < depth + 1; ++j)
                 mpack_print_append_cstr(print, "    ");
-            mpack_print_append_cstr(print, "]");
-            break;
+            mpack_node_print_element(
+                mpack_node_array_at(node, i), print, depth + 1);
+            if (i != data->len - 1)
+                mpack_print_append_cstr(print, ",");
+            mpack_print_append_cstr(print, "\n");
+        }
+        for (size_t i = 0; i < depth; ++i)
+            mpack_print_append_cstr(print, "    ");
+        mpack_print_append_cstr(print, "]");
+        break;
 
-        case mpack_type_map:
-            mpack_print_append_cstr(print, "{\n");
-            for (size_t i = 0; i < data->len; ++i) {
-                for (size_t j = 0; j < depth + 1; ++j)
-                    mpack_print_append_cstr(print, "    ");
-                mpack_node_print_element(mpack_node_map_key_at(node, i), print, depth + 1);
-                mpack_print_append_cstr(print, ": ");
-                mpack_node_print_element(mpack_node_map_value_at(node, i), print, depth + 1);
-                if (i != data->len - 1)
-                    mpack_print_append_cstr(print, ",");
-                mpack_print_append_cstr(print, "\n");
-            }
-            for (size_t i = 0; i < depth; ++i)
+    case mpack_type_map:
+        mpack_print_append_cstr(print, "{\n");
+        for (size_t i = 0; i < data->len; ++i) {
+            for (size_t j = 0; j < depth + 1; ++j)
                 mpack_print_append_cstr(print, "    ");
-            mpack_print_append_cstr(print, "}");
-            break;
+            mpack_node_print_element(
+                mpack_node_map_key_at(node, i), print, depth + 1);
+            mpack_print_append_cstr(print, ": ");
+            mpack_node_print_element(
+                mpack_node_map_value_at(node, i), print, depth + 1);
+            if (i != data->len - 1)
+                mpack_print_append_cstr(print, ",");
+            mpack_print_append_cstr(print, "\n");
+        }
+        for (size_t i = 0; i < depth; ++i)
+            mpack_print_append_cstr(print, "    ");
+        mpack_print_append_cstr(print, "}");
+        break;
 
-        default:
-            {
-                const char* prefix = NULL;
-                size_t prefix_length = 0;
-                if (mpack_node_type(node) == mpack_type_bin
-                        #if MPACK_EXTENSIONS
-                        || mpack_node_type(node) == mpack_type_ext
-                        #endif
-                ) {
-                    prefix = mpack_node_data(node);
-                    prefix_length = mpack_node_data_len(node);
-                }
+    default: {
+        const char *prefix = NULL;
+        size_t prefix_length = 0;
+        if (mpack_node_type(node) == mpack_type_bin
+#        if MPACK_EXTENSIONS
+            || mpack_node_type(node) == mpack_type_ext
+#        endif
+        ) {
+            prefix = mpack_node_data(node);
+            prefix_length = mpack_node_data_len(node);
+        }
 
-                char buf[256];
-                mpack_tag_t tag = mpack_node_tag(node);
-                mpack_tag_debug_pseudo_json(tag, buf, sizeof(buf), prefix, prefix_length);
-                mpack_print_append_cstr(print, buf);
-            }
-            break;
+        char buf[256];
+        mpack_tag_t tag = mpack_node_tag(node);
+        mpack_tag_debug_pseudo_json(
+            tag, buf, sizeof(buf), prefix, prefix_length);
+        mpack_print_append_cstr(print, buf);
+    } break;
     }
 }
 
-void mpack_node_print_to_buffer(mpack_node_t node, char* buffer, size_t buffer_size) {
+void
+mpack_node_print_to_buffer(mpack_node_t node, char *buffer, size_t buffer_size)
+{
     if (buffer_size == 0) {
         mpack_assert(false, "buffer size is zero!");
         return;
@@ -5461,7 +6678,7 @@ void mpack_node_print_to_buffer(mpack_node_t node, char* buffer, size_t buffer_s
     print.buffer = buffer;
     print.size = buffer_size;
     mpack_node_print_element(node, &print, 0);
-    mpack_print_append(&print, "",  1); // null-terminator
+    mpack_print_append(&print, "", 1); // null-terminator
     mpack_print_flush(&print);
 
     // we always make sure there's a null-terminator at the end of the buffer
@@ -5469,7 +6686,10 @@ void mpack_node_print_to_buffer(mpack_node_t node, char* buffer, size_t buffer_s
     print.buffer[print.size - 1] = '\0';
 }
 
-void mpack_node_print_to_callback(mpack_node_t node, mpack_print_callback_t callback, void* context) {
+void
+mpack_node_print_to_callback(
+    mpack_node_t node, mpack_print_callback_t callback, void *context)
+{
     char buffer[1024];
     mpack_print_t print;
     mpack_memset(&print, 0, sizeof(print));
@@ -5481,7 +6701,9 @@ void mpack_node_print_to_callback(mpack_node_t node, mpack_print_callback_t call
     mpack_print_flush(&print);
 }
 
-void mpack_node_print_to_file(mpack_node_t node, FILE* file) {
+void
+mpack_node_print_to_file(mpack_node_t node, FILE *file)
+{
     mpack_assert(file != NULL, "file is NULL");
 
     char buffer[1024];
@@ -5499,17 +6721,17 @@ void mpack_node_print_to_file(mpack_node_t node, FILE* file) {
     mpack_print_append_cstr(&print, "\n");
     mpack_print_flush(&print);
 }
-#endif
- 
+#    endif
 
- 
 /*
  * Node Value Functions
  */
 
-#if MPACK_EXTENSIONS
-mpack_timestamp_t mpack_node_timestamp(mpack_node_t node) {
-    mpack_timestamp_t timestamp = {0, 0};
+#    if MPACK_EXTENSIONS
+mpack_timestamp_t
+mpack_node_timestamp(mpack_node_t node)
+{
+    mpack_timestamp_t timestamp = { 0, 0 };
 
     // we'll let mpack_node_exttype() do most checks
     if (mpack_node_exttype(node) != MPACK_EXTTYPE_TIMESTAMP) {
@@ -5518,82 +6740,94 @@ mpack_timestamp_t mpack_node_timestamp(mpack_node_t node) {
         return timestamp;
     }
 
-    const char* p = mpack_node_data_unchecked(node);
+    const char *p = mpack_node_data_unchecked(node);
 
     switch (node.data->len) {
-        case 4:
-            timestamp.nanoseconds = 0;
-            timestamp.seconds = mpack_load_u32(p);
-            break;
+    case 4:
+        timestamp.nanoseconds = 0;
+        timestamp.seconds = mpack_load_u32(p);
+        break;
 
-        case 8: {
-            uint64_t value = mpack_load_u64(p);
-            timestamp.nanoseconds = (uint32_t)(value >> 34);
-            timestamp.seconds = value & ((UINT64_C(1) << 34) - 1);
-            break;
-        }
+    case 8: {
+        uint64_t value = mpack_load_u64(p);
+        timestamp.nanoseconds = (uint32_t)(value >> 34);
+        timestamp.seconds = value & ((UINT64_C(1) << 34) - 1);
+        break;
+    }
 
-        case 12:
-            timestamp.nanoseconds = mpack_load_u32(p);
-            timestamp.seconds = mpack_load_i64(p + 4);
-            break;
+    case 12:
+        timestamp.nanoseconds = mpack_load_u32(p);
+        timestamp.seconds = mpack_load_i64(p + 4);
+        break;
 
-        default:
-            mpack_tree_flag_error(node.tree, mpack_error_invalid);
-            return timestamp;
+    default:
+        mpack_tree_flag_error(node.tree, mpack_error_invalid);
+        return timestamp;
     }
 
     if (timestamp.nanoseconds > MPACK_TIMESTAMP_NANOSECONDS_MAX) {
         mpack_tree_flag_error(node.tree, mpack_error_invalid);
-        mpack_timestamp_t zero = {0, 0};
+        mpack_timestamp_t zero = { 0, 0 };
         return zero;
     }
 
     return timestamp;
 }
 
-int64_t mpack_node_timestamp_seconds(mpack_node_t node) {
+int64_t
+mpack_node_timestamp_seconds(mpack_node_t node)
+{
     return mpack_node_timestamp(node).seconds;
 }
 
-uint32_t mpack_node_timestamp_nanoseconds(mpack_node_t node) {
+uint32_t
+mpack_node_timestamp_nanoseconds(mpack_node_t node)
+{
     return mpack_node_timestamp(node).nanoseconds;
 }
-#endif
-
-
+#    endif
 
 /*
  * Node Data Functions
  */
 
-void mpack_node_check_utf8(mpack_node_t node) {
+void
+mpack_node_check_utf8(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return;
-    mpack_node_data_t* data = node.data;
-    if (data->type != mpack_type_str || !mpack_utf8_check(mpack_node_data_unchecked(node), data->len))
+    mpack_node_data_t *data = node.data;
+    if (data->type != mpack_type_str
+        || !mpack_utf8_check(mpack_node_data_unchecked(node), data->len))
         mpack_node_flag_error(node, mpack_error_type);
 }
 
-void mpack_node_check_utf8_cstr(mpack_node_t node) {
+void
+mpack_node_check_utf8_cstr(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return;
-    mpack_node_data_t* data = node.data;
-    if (data->type != mpack_type_str || !mpack_utf8_check_no_null(mpack_node_data_unchecked(node), data->len))
+    mpack_node_data_t *data = node.data;
+    if (data->type != mpack_type_str
+        || !mpack_utf8_check_no_null(
+            mpack_node_data_unchecked(node), data->len))
         mpack_node_flag_error(node, mpack_error_type);
 }
 
-size_t mpack_node_copy_data(mpack_node_t node, char* buffer, size_t bufsize) {
+size_t
+mpack_node_copy_data(mpack_node_t node, char *buffer, size_t bufsize)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
-    mpack_assert(bufsize == 0 || buffer != NULL, "buffer is NULL for maximum of %i bytes", (int)bufsize);
+    mpack_assert(bufsize == 0 || buffer != NULL,
+        "buffer is NULL for maximum of %i bytes", (int)bufsize);
 
     mpack_type_t type = node.data->type;
     if (type != mpack_type_str && type != mpack_type_bin
-            #if MPACK_EXTENSIONS
-            && type != mpack_type_ext
-            #endif
+#    if MPACK_EXTENSIONS
+        && type != mpack_type_ext
+#    endif
     ) {
         mpack_node_flag_error(node, mpack_error_type);
         return 0;
@@ -5608,11 +6842,14 @@ size_t mpack_node_copy_data(mpack_node_t node, char* buffer, size_t bufsize) {
     return (size_t)node.data->len;
 }
 
-size_t mpack_node_copy_utf8(mpack_node_t node, char* buffer, size_t bufsize) {
+size_t
+mpack_node_copy_utf8(mpack_node_t node, char *buffer, size_t bufsize)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
-    mpack_assert(bufsize == 0 || buffer != NULL, "buffer is NULL for maximum of %i bytes", (int)bufsize);
+    mpack_assert(bufsize == 0 || buffer != NULL,
+        "buffer is NULL for maximum of %i bytes", (int)bufsize);
 
     mpack_type_t type = node.data->type;
     if (type != mpack_type_str) {
@@ -5634,12 +6871,16 @@ size_t mpack_node_copy_utf8(mpack_node_t node, char* buffer, size_t bufsize) {
     return (size_t)node.data->len;
 }
 
-void mpack_node_copy_cstr(mpack_node_t node, char* buffer, size_t bufsize) {
+void
+mpack_node_copy_cstr(mpack_node_t node, char *buffer, size_t bufsize)
+{
 
     // we can't break here because the error isn't recoverable; we
     // have to add a null-terminator.
     mpack_assert(buffer != NULL, "buffer is NULL");
-    mpack_assert(bufsize >= 1, "buffer size is zero; you must have room for at least a null-terminator");
+    mpack_assert(bufsize >= 1,
+        "buffer size is zero; you must have room for at least a "
+        "null-terminator");
 
     if (mpack_node_error(node) != mpack_ok) {
         buffer[0] = '\0';
@@ -5658,7 +6899,8 @@ void mpack_node_copy_cstr(mpack_node_t node, char* buffer, size_t bufsize) {
         return;
     }
 
-    if (!mpack_str_check_no_null(mpack_node_data_unchecked(node), node.data->len)) {
+    if (!mpack_str_check_no_null(
+            mpack_node_data_unchecked(node), node.data->len)) {
         buffer[0] = '\0';
         mpack_node_flag_error(node, mpack_error_type);
         return;
@@ -5668,12 +6910,16 @@ void mpack_node_copy_cstr(mpack_node_t node, char* buffer, size_t bufsize) {
     buffer[node.data->len] = '\0';
 }
 
-void mpack_node_copy_utf8_cstr(mpack_node_t node, char* buffer, size_t bufsize) {
+void
+mpack_node_copy_utf8_cstr(mpack_node_t node, char *buffer, size_t bufsize)
+{
 
     // we can't break here because the error isn't recoverable; we
     // have to add a null-terminator.
     mpack_assert(buffer != NULL, "buffer is NULL");
-    mpack_assert(bufsize >= 1, "buffer size is zero; you must have room for at least a null-terminator");
+    mpack_assert(bufsize >= 1,
+        "buffer size is zero; you must have room for at least a "
+        "null-terminator");
 
     if (mpack_node_error(node) != mpack_ok) {
         buffer[0] = '\0';
@@ -5692,7 +6938,8 @@ void mpack_node_copy_utf8_cstr(mpack_node_t node, char* buffer, size_t bufsize) 
         return;
     }
 
-    if (!mpack_utf8_check_no_null(mpack_node_data_unchecked(node), node.data->len)) {
+    if (!mpack_utf8_check_no_null(
+            mpack_node_data_unchecked(node), node.data->len)) {
         buffer[0] = '\0';
         mpack_node_flag_error(node, mpack_error_type);
         return;
@@ -5702,17 +6949,19 @@ void mpack_node_copy_utf8_cstr(mpack_node_t node, char* buffer, size_t bufsize) 
     buffer[node.data->len] = '\0';
 }
 
-#ifdef MPACK_MALLOC
-char* mpack_node_data_alloc(mpack_node_t node, size_t maxlen) {
+#    ifdef MPACK_MALLOC
+char *
+mpack_node_data_alloc(mpack_node_t node, size_t maxlen)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
     // make sure this is a valid data type
     mpack_type_t type = node.data->type;
     if (type != mpack_type_str && type != mpack_type_bin
-            #if MPACK_EXTENSIONS
-            && type != mpack_type_ext
-            #endif
+#        if MPACK_EXTENSIONS
+        && type != mpack_type_ext
+#        endif
     ) {
         mpack_node_flag_error(node, mpack_error_type);
         return NULL;
@@ -5723,7 +6972,7 @@ char* mpack_node_data_alloc(mpack_node_t node, size_t maxlen) {
         return NULL;
     }
 
-    char* ret = (char*) MPACK_MALLOC((size_t)node.data->len);
+    char *ret = (char *)MPACK_MALLOC((size_t)node.data->len);
     if (ret == NULL) {
         mpack_node_flag_error(node, mpack_error_memory);
         return NULL;
@@ -5733,13 +6982,16 @@ char* mpack_node_data_alloc(mpack_node_t node, size_t maxlen) {
     return ret;
 }
 
-char* mpack_node_cstr_alloc(mpack_node_t node, size_t maxlen) {
+char *
+mpack_node_cstr_alloc(mpack_node_t node, size_t maxlen)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
     // make sure maxlen makes sense
     if (maxlen < 1) {
-        mpack_break("maxlen is zero; you must have room for at least a null-terminator");
+        mpack_break("maxlen is zero; you must have room for at least a "
+                    "null-terminator");
         mpack_node_flag_error(node, mpack_error_bug);
         return NULL;
     }
@@ -5754,12 +7006,13 @@ char* mpack_node_cstr_alloc(mpack_node_t node, size_t maxlen) {
         return NULL;
     }
 
-    if (!mpack_str_check_no_null(mpack_node_data_unchecked(node), node.data->len)) {
+    if (!mpack_str_check_no_null(
+            mpack_node_data_unchecked(node), node.data->len)) {
         mpack_node_flag_error(node, mpack_error_type);
         return NULL;
     }
 
-    char* ret = (char*) MPACK_MALLOC((size_t)(node.data->len + 1));
+    char *ret = (char *)MPACK_MALLOC((size_t)(node.data->len + 1));
     if (ret == NULL) {
         mpack_node_flag_error(node, mpack_error_memory);
         return NULL;
@@ -5770,13 +7023,16 @@ char* mpack_node_cstr_alloc(mpack_node_t node, size_t maxlen) {
     return ret;
 }
 
-char* mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxlen) {
+char *
+mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxlen)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
     // make sure maxlen makes sense
     if (maxlen < 1) {
-        mpack_break("maxlen is zero; you must have room for at least a null-terminator");
+        mpack_break("maxlen is zero; you must have room for at least a "
+                    "null-terminator");
         mpack_node_flag_error(node, mpack_error_bug);
         return NULL;
     }
@@ -5791,12 +7047,13 @@ char* mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxlen) {
         return NULL;
     }
 
-    if (!mpack_utf8_check_no_null(mpack_node_data_unchecked(node), node.data->len)) {
+    if (!mpack_utf8_check_no_null(
+            mpack_node_data_unchecked(node), node.data->len)) {
         mpack_node_flag_error(node, mpack_error_type);
         return NULL;
     }
 
-    char* ret = (char*) MPACK_MALLOC((size_t)(node.data->len + 1));
+    char *ret = (char *)MPACK_MALLOC((size_t)(node.data->len + 1));
     if (ret == NULL) {
         mpack_node_flag_error(node, mpack_error_memory);
         return NULL;
@@ -5806,14 +7063,15 @@ char* mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxlen) {
     ret[node.data->len] = '\0';
     return ret;
 }
-#endif
-
+#    endif
 
 /*
  * Compound Node Functions
  */
 
-static mpack_node_data_t* mpack_node_map_int_impl(mpack_node_t node, int64_t num) {
+static mpack_node_data_t *
+mpack_node_map_int_impl(mpack_node_t node, int64_t num)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
@@ -5822,14 +7080,14 @@ static mpack_node_data_t* mpack_node_map_int_impl(mpack_node_t node, int64_t num
         return NULL;
     }
 
-    mpack_node_data_t* found = NULL;
+    mpack_node_data_t *found = NULL;
 
     for (size_t i = 0; i < node.data->len; ++i) {
-        mpack_node_data_t* key = mpack_node_child(node, i * 2);
+        mpack_node_data_t *key = mpack_node_child(node, i * 2);
 
-        if ((key->type == mpack_type_int && key->value.i == num) ||
-            (key->type == mpack_type_uint && num >= 0 && key->value.u == (uint64_t)num))
-        {
+        if ((key->type == mpack_type_int && key->value.i == num)
+            || (key->type == mpack_type_uint && num >= 0
+                && key->value.u == (uint64_t)num)) {
             if (found) {
                 mpack_node_flag_error(node, mpack_error_data);
                 return NULL;
@@ -5844,7 +7102,9 @@ static mpack_node_data_t* mpack_node_map_int_impl(mpack_node_t node, int64_t num
     return NULL;
 }
 
-static mpack_node_data_t* mpack_node_map_uint_impl(mpack_node_t node, uint64_t num) {
+static mpack_node_data_t *
+mpack_node_map_uint_impl(mpack_node_t node, uint64_t num)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
@@ -5853,14 +7113,14 @@ static mpack_node_data_t* mpack_node_map_uint_impl(mpack_node_t node, uint64_t n
         return NULL;
     }
 
-    mpack_node_data_t* found = NULL;
+    mpack_node_data_t *found = NULL;
 
     for (size_t i = 0; i < node.data->len; ++i) {
-        mpack_node_data_t* key = mpack_node_child(node, i * 2);
+        mpack_node_data_t *key = mpack_node_child(node, i * 2);
 
-        if ((key->type == mpack_type_uint && key->value.u == num) ||
-            (key->type == mpack_type_int && key->value.i >= 0 && (uint64_t)key->value.i == num))
-        {
+        if ((key->type == mpack_type_uint && key->value.u == num)
+            || (key->type == mpack_type_int && key->value.i >= 0
+                && (uint64_t)key->value.i == num)) {
             if (found) {
                 mpack_node_flag_error(node, mpack_error_data);
                 return NULL;
@@ -5875,25 +7135,30 @@ static mpack_node_data_t* mpack_node_map_uint_impl(mpack_node_t node, uint64_t n
     return NULL;
 }
 
-static mpack_node_data_t* mpack_node_map_str_impl(mpack_node_t node, const char* str, size_t length) {
+static mpack_node_data_t *
+mpack_node_map_str_impl(mpack_node_t node, const char *str, size_t length)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
-    mpack_assert(length == 0 || str != NULL, "str of length %i is NULL", (int)length);
+    mpack_assert(
+        length == 0 || str != NULL, "str of length %i is NULL", (int)length);
 
     if (node.data->type != mpack_type_map) {
         mpack_node_flag_error(node, mpack_error_type);
         return NULL;
     }
 
-    mpack_tree_t* tree = node.tree;
-    mpack_node_data_t* found = NULL;
+    mpack_tree_t *tree = node.tree;
+    mpack_node_data_t *found = NULL;
 
     for (size_t i = 0; i < node.data->len; ++i) {
-        mpack_node_data_t* key = mpack_node_child(node, i * 2);
+        mpack_node_data_t *key = mpack_node_child(node, i * 2);
 
-        if (key->type == mpack_type_str && key->len == length &&
-                mpack_memcmp(str, mpack_node_data_unchecked(mpack_node(tree, key)), length) == 0) {
+        if (key->type == mpack_type_str && key->len == length
+            && mpack_memcmp(str,
+                   mpack_node_data_unchecked(mpack_node(tree, key)), length)
+                == 0) {
             if (found) {
                 mpack_node_flag_error(node, mpack_error_data);
                 return NULL;
@@ -5908,7 +7173,9 @@ static mpack_node_data_t* mpack_node_map_str_impl(mpack_node_t node, const char*
     return NULL;
 }
 
-static mpack_node_t mpack_node_wrap_lookup(mpack_tree_t* tree, mpack_node_data_t* data) {
+static mpack_node_t
+mpack_node_wrap_lookup(mpack_tree_t *tree, mpack_node_data_t *data)
+{
     if (!data) {
         if (tree->error == mpack_ok)
             mpack_tree_flag_error(tree, mpack_error_data);
@@ -5917,7 +7184,9 @@ static mpack_node_t mpack_node_wrap_lookup(mpack_tree_t* tree, mpack_node_data_t
     return mpack_node(tree, data);
 }
 
-static mpack_node_t mpack_node_wrap_lookup_optional(mpack_tree_t* tree, mpack_node_data_t* data) {
+static mpack_node_t
+mpack_node_wrap_lookup_optional(mpack_tree_t *tree, mpack_node_data_t *data)
+{
     if (!data) {
         if (tree->error == mpack_ok)
             return mpack_tree_missing_node(tree);
@@ -5926,58 +7195,90 @@ static mpack_node_t mpack_node_wrap_lookup_optional(mpack_tree_t* tree, mpack_no
     return mpack_node(tree, data);
 }
 
-mpack_node_t mpack_node_map_int(mpack_node_t node, int64_t num) {
-    return mpack_node_wrap_lookup(node.tree, mpack_node_map_int_impl(node, num));
+mpack_node_t
+mpack_node_map_int(mpack_node_t node, int64_t num)
+{
+    return mpack_node_wrap_lookup(
+        node.tree, mpack_node_map_int_impl(node, num));
 }
 
-mpack_node_t mpack_node_map_int_optional(mpack_node_t node, int64_t num) {
-    return mpack_node_wrap_lookup_optional(node.tree, mpack_node_map_int_impl(node, num));
+mpack_node_t
+mpack_node_map_int_optional(mpack_node_t node, int64_t num)
+{
+    return mpack_node_wrap_lookup_optional(
+        node.tree, mpack_node_map_int_impl(node, num));
 }
 
-mpack_node_t mpack_node_map_uint(mpack_node_t node, uint64_t num) {
-    return mpack_node_wrap_lookup(node.tree, mpack_node_map_uint_impl(node, num));
+mpack_node_t
+mpack_node_map_uint(mpack_node_t node, uint64_t num)
+{
+    return mpack_node_wrap_lookup(
+        node.tree, mpack_node_map_uint_impl(node, num));
 }
 
-mpack_node_t mpack_node_map_uint_optional(mpack_node_t node, uint64_t num) {
-    return mpack_node_wrap_lookup_optional(node.tree, mpack_node_map_uint_impl(node, num));
+mpack_node_t
+mpack_node_map_uint_optional(mpack_node_t node, uint64_t num)
+{
+    return mpack_node_wrap_lookup_optional(
+        node.tree, mpack_node_map_uint_impl(node, num));
 }
 
-mpack_node_t mpack_node_map_str(mpack_node_t node, const char* str, size_t length) {
-    return mpack_node_wrap_lookup(node.tree, mpack_node_map_str_impl(node, str, length));
+mpack_node_t
+mpack_node_map_str(mpack_node_t node, const char *str, size_t length)
+{
+    return mpack_node_wrap_lookup(
+        node.tree, mpack_node_map_str_impl(node, str, length));
 }
 
-mpack_node_t mpack_node_map_str_optional(mpack_node_t node, const char* str, size_t length) {
-    return mpack_node_wrap_lookup_optional(node.tree, mpack_node_map_str_impl(node, str, length));
+mpack_node_t
+mpack_node_map_str_optional(mpack_node_t node, const char *str, size_t length)
+{
+    return mpack_node_wrap_lookup_optional(
+        node.tree, mpack_node_map_str_impl(node, str, length));
 }
 
-mpack_node_t mpack_node_map_cstr(mpack_node_t node, const char* cstr) {
+mpack_node_t
+mpack_node_map_cstr(mpack_node_t node, const char *cstr)
+{
     mpack_assert(cstr != NULL, "cstr is NULL");
     return mpack_node_map_str(node, cstr, mpack_strlen(cstr));
 }
 
-mpack_node_t mpack_node_map_cstr_optional(mpack_node_t node, const char* cstr) {
+mpack_node_t
+mpack_node_map_cstr_optional(mpack_node_t node, const char *cstr)
+{
     mpack_assert(cstr != NULL, "cstr is NULL");
     return mpack_node_map_str_optional(node, cstr, mpack_strlen(cstr));
 }
 
-bool mpack_node_map_contains_int(mpack_node_t node, int64_t num) {
+bool
+mpack_node_map_contains_int(mpack_node_t node, int64_t num)
+{
     return mpack_node_map_int_impl(node, num) != NULL;
 }
 
-bool mpack_node_map_contains_uint(mpack_node_t node, uint64_t num) {
+bool
+mpack_node_map_contains_uint(mpack_node_t node, uint64_t num)
+{
     return mpack_node_map_uint_impl(node, num) != NULL;
 }
 
-bool mpack_node_map_contains_str(mpack_node_t node, const char* str, size_t length) {
+bool
+mpack_node_map_contains_str(mpack_node_t node, const char *str, size_t length)
+{
     return mpack_node_map_str_impl(node, str, length) != NULL;
 }
 
-bool mpack_node_map_contains_cstr(mpack_node_t node, const char* cstr) {
+bool
+mpack_node_map_contains_cstr(mpack_node_t node, const char *cstr)
+{
     mpack_assert(cstr != NULL, "cstr is NULL");
     return mpack_node_map_contains_str(node, cstr, mpack_strlen(cstr));
 }
 
-size_t mpack_node_enum_optional(mpack_node_t node, const char* strings[], size_t count) {
+size_t
+mpack_node_enum_optional(mpack_node_t node, const char *strings[], size_t count)
+{
     if (mpack_node_error(node) != mpack_ok)
         return count;
 
@@ -5986,13 +7287,13 @@ size_t mpack_node_enum_optional(mpack_node_t node, const char* strings[], size_t
         return count;
 
     // fetch the string
-    const char* key = mpack_node_str(node);
+    const char *key = mpack_node_str(node);
     size_t keylen = mpack_node_strlen(node);
     mpack_assert(mpack_node_error(node) == mpack_ok, "these should not fail");
 
     // find what key it matches
     for (size_t i = 0; i < count; ++i) {
-        const char* other = strings[i];
+        const char *other = strings[i];
         size_t otherlen = mpack_strlen(other);
         if (keylen == otherlen && mpack_memcmp(key, other, keylen) == 0)
             return i;
@@ -6002,20 +7303,26 @@ size_t mpack_node_enum_optional(mpack_node_t node, const char* strings[], size_t
     return count;
 }
 
-size_t mpack_node_enum(mpack_node_t node, const char* strings[], size_t count) {
+size_t
+mpack_node_enum(mpack_node_t node, const char *strings[], size_t count)
+{
     size_t value = mpack_node_enum_optional(node, strings, count);
     if (value == count)
         mpack_node_flag_error(node, mpack_error_type);
     return value;
 }
 
-mpack_type_t mpack_node_type(mpack_node_t node) {
+mpack_type_t
+mpack_node_type(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return mpack_type_nil;
     return node.data->type;
 }
 
-bool mpack_node_is_nil(mpack_node_t node) {
+bool
+mpack_node_is_nil(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok) {
         // All nodes are treated as nil nodes when we are in error.
         return true;
@@ -6023,7 +7330,9 @@ bool mpack_node_is_nil(mpack_node_t node) {
     return node.data->type == mpack_type_nil;
 }
 
-bool mpack_node_is_missing(mpack_node_t node) {
+bool
+mpack_node_is_missing(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok) {
         // errors still return nil nodes, not missing nodes.
         return false;
@@ -6031,21 +7340,27 @@ bool mpack_node_is_missing(mpack_node_t node) {
     return node.data->type == mpack_type_missing;
 }
 
-void mpack_node_nil(mpack_node_t node) {
+void
+mpack_node_nil(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return;
     if (node.data->type != mpack_type_nil)
         mpack_node_flag_error(node, mpack_error_type);
 }
 
-void mpack_node_missing(mpack_node_t node) {
+void
+mpack_node_missing(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return;
     if (node.data->type != mpack_type_missing)
         mpack_node_flag_error(node, mpack_error_type);
 }
 
-bool mpack_node_bool(mpack_node_t node) {
+bool
+mpack_node_bool(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return false;
 
@@ -6056,17 +7371,23 @@ bool mpack_node_bool(mpack_node_t node) {
     return false;
 }
 
-void mpack_node_true(mpack_node_t node) {
+void
+mpack_node_true(mpack_node_t node)
+{
     if (mpack_node_bool(node) != true)
         mpack_node_flag_error(node, mpack_error_type);
 }
 
-void mpack_node_false(mpack_node_t node) {
+void
+mpack_node_false(mpack_node_t node)
+{
     if (mpack_node_bool(node) != false)
         mpack_node_flag_error(node, mpack_error_type);
 }
 
-uint8_t mpack_node_u8(mpack_node_t node) {
+uint8_t
+mpack_node_u8(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6082,7 +7403,9 @@ uint8_t mpack_node_u8(mpack_node_t node) {
     return 0;
 }
 
-int8_t mpack_node_i8(mpack_node_t node) {
+int8_t
+mpack_node_i8(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6098,7 +7421,9 @@ int8_t mpack_node_i8(mpack_node_t node) {
     return 0;
 }
 
-uint16_t mpack_node_u16(mpack_node_t node) {
+uint16_t
+mpack_node_u16(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6114,7 +7439,9 @@ uint16_t mpack_node_u16(mpack_node_t node) {
     return 0;
 }
 
-int16_t mpack_node_i16(mpack_node_t node) {
+int16_t
+mpack_node_i16(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6130,7 +7457,9 @@ int16_t mpack_node_i16(mpack_node_t node) {
     return 0;
 }
 
-uint32_t mpack_node_u32(mpack_node_t node) {
+uint32_t
+mpack_node_u32(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6146,7 +7475,9 @@ uint32_t mpack_node_u32(mpack_node_t node) {
     return 0;
 }
 
-int32_t mpack_node_i32(mpack_node_t node) {
+int32_t
+mpack_node_i32(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6162,7 +7493,9 @@ int32_t mpack_node_i32(mpack_node_t node) {
     return 0;
 }
 
-uint64_t mpack_node_u64(mpack_node_t node) {
+uint64_t
+mpack_node_u64(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6177,7 +7510,9 @@ uint64_t mpack_node_u64(mpack_node_t node) {
     return 0;
 }
 
-int64_t mpack_node_i64(mpack_node_t node) {
+int64_t
+mpack_node_i64(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6192,9 +7527,12 @@ int64_t mpack_node_i64(mpack_node_t node) {
     return 0;
 }
 
-unsigned int mpack_node_uint(mpack_node_t node) {
+unsigned int
+mpack_node_uint(mpack_node_t node)
+{
 
-    // This should be true at compile-time, so this just wraps the 32-bit function.
+    // This should be true at compile-time, so this just wraps the 32-bit
+    // function.
     if (sizeof(unsigned int) == 4)
         return (unsigned int)mpack_node_u32(node);
 
@@ -6207,9 +7545,12 @@ unsigned int mpack_node_uint(mpack_node_t node) {
     return 0;
 }
 
-int mpack_node_int(mpack_node_t node) {
+int
+mpack_node_int(mpack_node_t node)
+{
 
-    // This should be true at compile-time, so this just wraps the 32-bit function.
+    // This should be true at compile-time, so this just wraps the 32-bit
+    // function.
     if (sizeof(int) == 4)
         return (int)mpack_node_i32(node);
 
@@ -6222,7 +7563,9 @@ int mpack_node_int(mpack_node_t node) {
     return 0;
 }
 
-float mpack_node_float(mpack_node_t node) {
+float
+mpack_node_float(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0.0f;
 
@@ -6239,7 +7582,9 @@ float mpack_node_float(mpack_node_t node) {
     return 0.0f;
 }
 
-double mpack_node_double(mpack_node_t node) {
+double
+mpack_node_double(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0.0;
 
@@ -6256,7 +7601,9 @@ double mpack_node_double(mpack_node_t node) {
     return 0.0;
 }
 
-float mpack_node_float_strict(mpack_node_t node) {
+float
+mpack_node_float_strict(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0.0f;
 
@@ -6267,7 +7614,9 @@ float mpack_node_float_strict(mpack_node_t node) {
     return 0.0f;
 }
 
-double mpack_node_double_strict(mpack_node_t node) {
+double
+mpack_node_double_strict(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0.0;
 
@@ -6280,8 +7629,10 @@ double mpack_node_double_strict(mpack_node_t node) {
     return 0.0;
 }
 
-#if MPACK_EXTENSIONS
-int8_t mpack_node_exttype(mpack_node_t node) {
+#    if MPACK_EXTENSIONS
+int8_t
+mpack_node_exttype(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6291,25 +7642,29 @@ int8_t mpack_node_exttype(mpack_node_t node) {
     mpack_node_flag_error(node, mpack_error_type);
     return 0;
 }
-#endif
+#    endif
 
-uint32_t mpack_node_data_len(mpack_node_t node) {
+uint32_t
+mpack_node_data_len(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
     mpack_type_t type = node.data->type;
     if (type == mpack_type_str || type == mpack_type_bin
-            #if MPACK_EXTENSIONS
-            || type == mpack_type_ext
-            #endif
-            )
+#    if MPACK_EXTENSIONS
+        || type == mpack_type_ext
+#    endif
+    )
         return (uint32_t)node.data->len;
 
     mpack_node_flag_error(node, mpack_error_type);
     return 0;
 }
 
-size_t mpack_node_strlen(mpack_node_t node) {
+size_t
+mpack_node_strlen(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6320,7 +7675,9 @@ size_t mpack_node_strlen(mpack_node_t node) {
     return 0;
 }
 
-const char* mpack_node_str(mpack_node_t node) {
+const char *
+mpack_node_str(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
@@ -6332,23 +7689,27 @@ const char* mpack_node_str(mpack_node_t node) {
     return NULL;
 }
 
-const char* mpack_node_data(mpack_node_t node) {
+const char *
+mpack_node_data(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
     mpack_type_t type = node.data->type;
     if (type == mpack_type_str || type == mpack_type_bin
-            #if MPACK_EXTENSIONS
-            || type == mpack_type_ext
-            #endif
-            )
+#    if MPACK_EXTENSIONS
+        || type == mpack_type_ext
+#    endif
+    )
         return mpack_node_data_unchecked(node);
 
     mpack_node_flag_error(node, mpack_error_type);
     return NULL;
 }
 
-const char* mpack_node_bin_data(mpack_node_t node) {
+const char *
+mpack_node_bin_data(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return NULL;
 
@@ -6359,7 +7720,9 @@ const char* mpack_node_bin_data(mpack_node_t node) {
     return NULL;
 }
 
-size_t mpack_node_bin_size(mpack_node_t node) {
+size_t
+mpack_node_bin_size(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6370,7 +7733,9 @@ size_t mpack_node_bin_size(mpack_node_t node) {
     return 0;
 }
 
-size_t mpack_node_array_length(mpack_node_t node) {
+size_t
+mpack_node_array_length(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6382,7 +7747,9 @@ size_t mpack_node_array_length(mpack_node_t node) {
     return (size_t)node.data->len;
 }
 
-mpack_node_t mpack_node_array_at(mpack_node_t node, size_t index) {
+mpack_node_t
+mpack_node_array_at(mpack_node_t node, size_t index)
+{
     if (mpack_node_error(node) != mpack_ok)
         return mpack_tree_nil_node(node.tree);
 
@@ -6399,7 +7766,9 @@ mpack_node_t mpack_node_array_at(mpack_node_t node, size_t index) {
     return mpack_node(node.tree, mpack_node_child(node, index));
 }
 
-size_t mpack_node_map_count(mpack_node_t node) {
+size_t
+mpack_node_map_count(mpack_node_t node)
+{
     if (mpack_node_error(node) != mpack_ok)
         return 0;
 
@@ -6412,7 +7781,9 @@ size_t mpack_node_map_count(mpack_node_t node) {
 }
 
 // internal node map lookup
-static mpack_node_t mpack_node_map_at(mpack_node_t node, size_t index, size_t offset) {
+static mpack_node_t
+mpack_node_map_at(mpack_node_t node, size_t index, size_t offset)
+{
     if (mpack_node_error(node) != mpack_ok)
         return mpack_tree_nil_node(node.tree);
 
@@ -6429,11 +7800,15 @@ static mpack_node_t mpack_node_map_at(mpack_node_t node, size_t index, size_t of
     return mpack_node(node.tree, mpack_node_child(node, index * 2 + offset));
 }
 
-mpack_node_t mpack_node_map_key_at(mpack_node_t node, size_t index) {
+mpack_node_t
+mpack_node_map_key_at(mpack_node_t node, size_t index)
+{
     return mpack_node_map_at(node, index, 0);
 }
 
-mpack_node_t mpack_node_map_value_at(mpack_node_t node, size_t index) {
+mpack_node_t
+mpack_node_map_value_at(mpack_node_t node, size_t index)
+{
     return mpack_node_map_at(node, index, 1);
 }
 

--- a/vendor/mpack.h
+++ b/vendor/mpack.h
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015-2018 Nicholas Fraser
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- * 
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  */
 
 /*
@@ -36,12 +36,10 @@
 #define MPACK_RELEASE_VERSION 1
 
 #if defined(MPACK_HAS_CONFIG) && MPACK_HAS_CONFIG
-#include "mpack-config.h"
+#    include "mpack-config.h"
 #endif
 
-
 /* mpack/mpack-defaults.h.h */
-
 
 /**
  * @name Features
@@ -54,7 +52,7 @@
  * Enables compilation of the base Tag Reader.
  */
 #ifndef MPACK_READER
-#define MPACK_READER 1
+#    define MPACK_READER 1
 #endif
 
 /**
@@ -63,7 +61,7 @@
  * Enables compilation of the static Expect API.
  */
 #ifndef MPACK_EXPECT
-#define MPACK_EXPECT 1
+#    define MPACK_EXPECT 1
 #endif
 
 /**
@@ -72,7 +70,7 @@
  * Enables compilation of the dynamic Node API.
  */
 #ifndef MPACK_NODE
-#define MPACK_NODE 1
+#    define MPACK_NODE 1
 #endif
 
 /**
@@ -81,7 +79,7 @@
  * Enables compilation of the Writer.
  */
 #ifndef MPACK_WRITER
-#define MPACK_WRITER 1
+#    define MPACK_WRITER 1
 #endif
 
 /**
@@ -98,7 +96,7 @@
  * compatibility in @ref docs/protocol.md for more information.
  */
 #ifndef MPACK_COMPATIBILITY
-#define MPACK_COMPATIBILITY 0
+#    define MPACK_COMPATIBILITY 0
 #endif
 
 /**
@@ -114,14 +112,12 @@
  * types in @ref docs/protocol.md for more information.
  */
 #ifndef MPACK_EXTENSIONS
-#define MPACK_EXTENSIONS 0
+#    define MPACK_EXTENSIONS 0
 #endif
-
 
 /**
  * @}
  */
-
 
 /**
  * @name Dependencies
@@ -144,7 +140,7 @@
  * for debugging and in allocation helpers.
  */
 #ifndef MPACK_STDLIB
-#define MPACK_STDLIB 1
+#    define MPACK_STDLIB 1
 #endif
 
 /**
@@ -154,13 +150,12 @@
  * reading/writing C files and makes debugging easier.
  */
 #ifndef MPACK_STDIO
-#define MPACK_STDIO 1
+#    define MPACK_STDIO 1
 #endif
 
 /**
  * @}
  */
-
 
 /**
  * @name System Functions
@@ -196,20 +191,19 @@
  * The default is @c realloc() if @ref MPACK_MALLOC has not been customized and
  * @ref MPACK_STDLIB is enabled.
  *
- * This is optional, even when @ref MPACK_MALLOC is used. If @ref MPACK_MALLOC is
- * set and @ref MPACK_REALLOC is not, @ref MPACK_MALLOC is used with a simple copy
- * to grow buffers.
+ * This is optional, even when @ref MPACK_MALLOC is used. If @ref MPACK_MALLOC
+ * is set and @ref MPACK_REALLOC is not, @ref MPACK_MALLOC is used with a simple
+ * copy to grow buffers.
  */
 #if defined(MPACK_STDLIB) && MPACK_STDLIB && !defined(MPACK_MALLOC)
-#define MPACK_MALLOC malloc
-#define MPACK_REALLOC realloc
-#define MPACK_FREE free
+#    define MPACK_MALLOC malloc
+#    define MPACK_REALLOC realloc
+#    define MPACK_FREE free
 #endif
 
 /**
  * @}
  */
-
 
 /**
  * @name Debugging Options
@@ -224,7 +218,7 @@
  * different values in different translation units.)
  */
 #if !defined(MPACK_DEBUG) && (defined(DEBUG) || defined(_DEBUG))
-#define MPACK_DEBUG 1
+#    define MPACK_DEBUG 1
 #endif
 
 /**
@@ -237,7 +231,7 @@
  * mpack_error_to_string() and mpack_type_to_string() return an empty string.
  */
 #ifndef MPACK_STRINGS
-#define MPACK_STRINGS 1
+#    define MPACK_STRINGS 1
 #endif
 
 /**
@@ -248,7 +242,7 @@
  * triggered by bugs in MPack or bugs due to incorrect usage of MPack.
  */
 #ifndef MPACK_CUSTOM_ASSERT
-#define MPACK_CUSTOM_ASSERT 0
+#    define MPACK_CUSTOM_ASSERT 0
 #endif
 
 /**
@@ -260,11 +254,9 @@
  * This is enabled by default in debug builds (provided a @c malloc() is
  * available.)
  */
-#if !defined(MPACK_READ_TRACKING) && \
-        defined(MPACK_DEBUG) && MPACK_DEBUG && \
-        defined(MPACK_READER) && MPACK_READER && \
-        defined(MPACK_MALLOC)
-#define MPACK_READ_TRACKING 1
+#if !defined(MPACK_READ_TRACKING) && defined(MPACK_DEBUG) && MPACK_DEBUG       \
+    && defined(MPACK_READER) && MPACK_READER && defined(MPACK_MALLOC)
+#    define MPACK_READ_TRACKING 1
 #endif
 
 /**
@@ -281,17 +273,14 @@
  * This is enabled by default in debug builds (provided a @c malloc() is
  * available.)
  */
-#if !defined(MPACK_WRITE_TRACKING) && \
-        defined(MPACK_DEBUG) && MPACK_DEBUG && \
-        defined(MPACK_WRITER) && MPACK_WRITER && \
-        defined(MPACK_MALLOC)
-#define MPACK_WRITE_TRACKING 1
+#if !defined(MPACK_WRITE_TRACKING) && defined(MPACK_DEBUG) && MPACK_DEBUG      \
+    && defined(MPACK_WRITER) && MPACK_WRITER && defined(MPACK_MALLOC)
+#    define MPACK_WRITE_TRACKING 1
 #endif
 
 /**
  * @}
  */
-
 
 /**
  * @name Miscellaneous Options
@@ -309,11 +298,11 @@
  * doesn't seem to be a macro defined for /Os under MSVC.
  */
 #ifndef MPACK_OPTIMIZE_FOR_SIZE
-#ifdef __OPTIMIZE_SIZE__
-#define MPACK_OPTIMIZE_FOR_SIZE 1
-#else
-#define MPACK_OPTIMIZE_FOR_SIZE 0
-#endif
+#    ifdef __OPTIMIZE_SIZE__
+#        define MPACK_OPTIMIZE_FOR_SIZE 1
+#    else
+#        define MPACK_OPTIMIZE_FOR_SIZE 0
+#    endif
 #endif
 
 /**
@@ -321,7 +310,7 @@
  * with a stack-allocated buffer.
  */
 #ifndef MPACK_STACK_SIZE
-#define MPACK_STACK_SIZE 4096
+#    define MPACK_STACK_SIZE 4096
 #endif
 
 /**
@@ -333,7 +322,7 @@
  * huge messages.
  */
 #ifndef MPACK_BUFFER_SIZE
-#define MPACK_BUFFER_SIZE 4096
+#    define MPACK_BUFFER_SIZE 4096
 #endif
 
 /**
@@ -350,7 +339,7 @@
  * messages.
  */
 #ifndef MPACK_NODE_PAGE_SIZE
-#define MPACK_NODE_PAGE_SIZE 4096
+#    define MPACK_NODE_PAGE_SIZE 4096
 #endif
 
 /**
@@ -359,25 +348,23 @@
  * so there is no risk of overflowing the call stack.
  */
 #ifndef MPACK_NODE_INITIAL_DEPTH
-#define MPACK_NODE_INITIAL_DEPTH 8
+#    define MPACK_NODE_INITIAL_DEPTH 8
 #endif
 
 /**
  * The maximum depth for the node parser if @ref MPACK_MALLOC is not available.
  */
 #ifndef MPACK_NODE_MAX_DEPTH_WITHOUT_MALLOC
-#define MPACK_NODE_MAX_DEPTH_WITHOUT_MALLOC 32
+#    define MPACK_NODE_MAX_DEPTH_WITHOUT_MALLOC 32
 #endif
 
 /**
  * @}
  */
 
-
 /**
  * @}
  */
-
 
 /* mpack/mpack-platform.h.h */
 
@@ -390,187 +377,175 @@
  */
 
 #ifndef MPACK_PLATFORM_H
-#define MPACK_PLATFORM_H 1
-
-
+#    define MPACK_PLATFORM_H 1
 
 /* Pre-include checks */
 
-#if defined(_MSC_VER) && _MSC_VER < 1800 && !defined(__cplusplus)
-#error "In Visual Studio 2012 and earlier, MPack must be compiled as C++. Enable the /Tp compiler flag."
-#endif
+#    if defined(_MSC_VER) && _MSC_VER < 1800 && !defined(__cplusplus)
+#        error                                                                 \
+            "In Visual Studio 2012 and earlier, MPack must be compiled as C++. Enable the /Tp compiler flag."
+#    endif
 
-#if defined(WIN32) && defined(MPACK_INTERNAL) && MPACK_INTERNAL
-#define _CRT_SECURE_NO_WARNINGS 1
-#endif
-
-
+#    if defined(WIN32) && defined(MPACK_INTERNAL) && MPACK_INTERNAL
+#        define _CRT_SECURE_NO_WARNINGS 1
+#    endif
 
 /* Doxygen preprocs */
-#if defined(MPACK_DOXYGEN) && MPACK_DOXYGEN
-#define MPACK_HAS_CONFIG 0
+#    if defined(MPACK_DOXYGEN) && MPACK_DOXYGEN
+#        define MPACK_HAS_CONFIG 0
 // We give these their default values of 0 here even though they are defined to
 // 1 in the doxyfile. Doxygen will show this as the value in the docs, even
 // though it ignores it when parsing the rest of the source. This is what we
 // want, since we want the documentation to show these defaults but still
 // generate documentation for the functions they add when they're on.
-#define MPACK_COMPATIBILITY 0
-#define MPACK_EXTENSIONS 0
-#endif
-
-
+#        define MPACK_COMPATIBILITY 0
+#        define MPACK_EXTENSIONS 0
+#    endif
 
 /* Include the custom config file if enabled */
 
-#if defined(MPACK_HAS_CONFIG) && MPACK_HAS_CONFIG
+#    if defined(MPACK_HAS_CONFIG) && MPACK_HAS_CONFIG
 /* #include "mpack-config.h" */
-#endif
+#    endif
 
 /*
  * Now that the optional config is included, we define the defaults
  * for any of the configuration options and other switches that aren't
  * yet defined.
  */
-#if defined(MPACK_DOXYGEN) && MPACK_DOXYGEN
+#    if defined(MPACK_DOXYGEN) && MPACK_DOXYGEN
 /* #include "mpack-defaults-doxygen.h" */
-#else
+#    else
 /* #include "mpack-defaults.h" */
-#endif
+#    endif
 
 /*
  * All remaining configuration options that have not yet been set must
  * be defined here in order to support -Wundef.
  */
-#ifndef MPACK_DEBUG
-#define MPACK_DEBUG 0
-#endif
-#ifndef MPACK_CUSTOM_BREAK
-#define MPACK_CUSTOM_BREAK 0
-#endif
-#ifndef MPACK_READ_TRACKING
-#define MPACK_READ_TRACKING 0
-#endif
-#ifndef MPACK_WRITE_TRACKING
-#define MPACK_WRITE_TRACKING 0
-#endif
-#ifndef MPACK_EMIT_INLINE_DEFS
-#define MPACK_EMIT_INLINE_DEFS 0
-#endif
-#ifndef MPACK_AMALGAMATED
-#define MPACK_AMALGAMATED 0
-#endif
-#ifndef MPACK_RELEASE_VERSION
-#define MPACK_RELEASE_VERSION 0
-#endif
-#ifndef MPACK_INTERNAL
-#define MPACK_INTERNAL 0
-#endif
-#ifndef MPACK_NO_BUILTINS
-#define MPACK_NO_BUILTINS 0
-#endif
-
-
+#    ifndef MPACK_DEBUG
+#        define MPACK_DEBUG 0
+#    endif
+#    ifndef MPACK_CUSTOM_BREAK
+#        define MPACK_CUSTOM_BREAK 0
+#    endif
+#    ifndef MPACK_READ_TRACKING
+#        define MPACK_READ_TRACKING 0
+#    endif
+#    ifndef MPACK_WRITE_TRACKING
+#        define MPACK_WRITE_TRACKING 0
+#    endif
+#    ifndef MPACK_EMIT_INLINE_DEFS
+#        define MPACK_EMIT_INLINE_DEFS 0
+#    endif
+#    ifndef MPACK_AMALGAMATED
+#        define MPACK_AMALGAMATED 0
+#    endif
+#    ifndef MPACK_RELEASE_VERSION
+#        define MPACK_RELEASE_VERSION 0
+#    endif
+#    ifndef MPACK_INTERNAL
+#        define MPACK_INTERNAL 0
+#    endif
+#    ifndef MPACK_NO_BUILTINS
+#        define MPACK_NO_BUILTINS 0
+#    endif
 
 /* System headers (based on configuration) */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS 1
-#endif
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS 1
-#endif
-#ifndef __STDC_CONSTANT_MACROS
-#define __STDC_CONSTANT_MACROS 1
-#endif
+#    ifndef __STDC_LIMIT_MACROS
+#        define __STDC_LIMIT_MACROS 1
+#    endif
+#    ifndef __STDC_FORMAT_MACROS
+#        define __STDC_FORMAT_MACROS 1
+#    endif
+#    ifndef __STDC_CONSTANT_MACROS
+#        define __STDC_CONSTANT_MACROS 1
+#    endif
 
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <inttypes.h>
-#include <limits.h>
+#    include <inttypes.h>
+#    include <limits.h>
+#    include <stdbool.h>
+#    include <stddef.h>
+#    include <stdint.h>
 
-#if MPACK_STDLIB
-#include <string.h>
-#include <stdlib.h>
-#endif
+#    if MPACK_STDLIB
+#        include <stdlib.h>
+#        include <string.h>
+#    endif
 
-#if MPACK_STDIO
-#include <stdio.h>
-#include <errno.h>
-#endif
-
-
+#    if MPACK_STDIO
+#        include <errno.h>
+#        include <stdio.h>
+#    endif
 
 /*
  * Header configuration
  */
 
-#ifdef __cplusplus
-    #define MPACK_EXTERN_C_START extern "C" {
-    #define MPACK_EXTERN_C_END   }
-#else
-    #define MPACK_EXTERN_C_START /* nothing */
-    #define MPACK_EXTERN_C_END   /* nothing */
-#endif
+#    ifdef __cplusplus
+#        define MPACK_EXTERN_C_START extern "C" {
+#        define MPACK_EXTERN_C_END }
+#    else
+#        define MPACK_EXTERN_C_START /* nothing */
+#        define MPACK_EXTERN_C_END /* nothing */
+#    endif
 
 /* GCC versions from 4.6 to before 5.1 warn about defining a C99
  * non-static inline function before declaring it (see issue #20) */
-#ifdef __GNUC__
-    #if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-        #ifdef __cplusplus
-            #define MPACK_DECLARED_INLINE_WARNING_START \
-                _Pragma ("GCC diagnostic push") \
-                _Pragma ("GCC diagnostic ignored \"-Wmissing-declarations\"")
-        #else
-            #define MPACK_DECLARED_INLINE_WARNING_START \
-                _Pragma ("GCC diagnostic push") \
-                _Pragma ("GCC diagnostic ignored \"-Wmissing-prototypes\"")
-        #endif
-        #define MPACK_DECLARED_INLINE_WARNING_END \
-            _Pragma ("GCC diagnostic pop")
-    #endif
-#endif
-#ifndef MPACK_DECLARED_INLINE_WARNING_START
-    #define MPACK_DECLARED_INLINE_WARNING_START /* nothing */
-    #define MPACK_DECLARED_INLINE_WARNING_END /* nothing */
-#endif
+#    ifdef __GNUC__
+#        if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#            ifdef __cplusplus
+#                define MPACK_DECLARED_INLINE_WARNING_START                    \
+                    _Pragma("GCC diagnostic push") _Pragma(                    \
+                        "GCC diagnostic ignored \"-Wmissing-declarations\"")
+#            else
+#                define MPACK_DECLARED_INLINE_WARNING_START                    \
+                    _Pragma("GCC diagnostic push") _Pragma(                    \
+                        "GCC diagnostic ignored \"-Wmissing-prototypes\"")
+#            endif
+#            define MPACK_DECLARED_INLINE_WARNING_END                          \
+                _Pragma("GCC diagnostic pop")
+#        endif
+#    endif
+#    ifndef MPACK_DECLARED_INLINE_WARNING_START
+#        define MPACK_DECLARED_INLINE_WARNING_START /* nothing */
+#        define MPACK_DECLARED_INLINE_WARNING_END /* nothing */
+#    endif
 
 /* GCC versions before 4.8 warn about shadowing a function with a
  * variable that isn't a function or function pointer (like "index") */
-#ifdef __GNUC__
-    #if (__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
-        #define MPACK_WSHADOW_WARNING_START \
-            _Pragma ("GCC diagnostic push") \
-            _Pragma ("GCC diagnostic ignored \"-Wshadow\"")
-        #define MPACK_WSHADOW_WARNING_END \
-            _Pragma ("GCC diagnostic pop")
-    #endif
-#endif
-#ifndef MPACK_WSHADOW_WARNING_START
-    #define MPACK_WSHADOW_WARNING_START /* nothing */
-    #define MPACK_WSHADOW_WARNING_END /* nothing */
-#endif
+#    ifdef __GNUC__
+#        if (__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#            define MPACK_WSHADOW_WARNING_START                                \
+                _Pragma("GCC diagnostic push")                                 \
+                    _Pragma("GCC diagnostic ignored \"-Wshadow\"")
+#            define MPACK_WSHADOW_WARNING_END _Pragma("GCC diagnostic pop")
+#        endif
+#    endif
+#    ifndef MPACK_WSHADOW_WARNING_START
+#        define MPACK_WSHADOW_WARNING_START /* nothing */
+#        define MPACK_WSHADOW_WARNING_END /* nothing */
+#    endif
 
-#define MPACK_HEADER_START \
-    MPACK_EXTERN_C_START \
-    MPACK_WSHADOW_WARNING_START \
-    MPACK_DECLARED_INLINE_WARNING_START
+#    define MPACK_HEADER_START                                                 \
+        MPACK_EXTERN_C_START                                                   \
+        MPACK_WSHADOW_WARNING_START                                            \
+        MPACK_DECLARED_INLINE_WARNING_START
 
-#define MPACK_HEADER_END \
-    MPACK_DECLARED_INLINE_WARNING_END \
-    MPACK_WSHADOW_WARNING_END \
-    MPACK_EXTERN_C_END
+#    define MPACK_HEADER_END                                                   \
+        MPACK_DECLARED_INLINE_WARNING_END                                      \
+        MPACK_WSHADOW_WARNING_END                                              \
+        MPACK_EXTERN_C_END
 
 MPACK_HEADER_START
 
-
-
 /* Miscellaneous helper macros */
 
-#define MPACK_UNUSED(var) ((void)(var))
+#    define MPACK_UNUSED(var) ((void)(var))
 
-#define MPACK_STRINGIFY_IMPL(arg) #arg
-#define MPACK_STRINGIFY(arg) MPACK_STRINGIFY_IMPL(arg)
+#    define MPACK_STRINGIFY_IMPL(arg) #    arg
+#    define MPACK_STRINGIFY(arg) MPACK_STRINGIFY_IMPL(arg)
 
 // This is a workaround for MSVC's incorrect expansion of __VA_ARGS__. It
 // treats __VA_ARGS__ as a single preprocessor token when passed in the
@@ -579,97 +554,100 @@ MPACK_HEADER_START
 // that don't ignore the variadic arguments regardless of whether __VA_ARGS__
 // is passed to another macro.)
 //     https://stackoverflow.com/a/32400131
-#define MPACK_EXPAND(x) x
+#    define MPACK_EXPAND(x) x
 
 // Extracts the first argument of a variadic macro list, where there might only
 // be one argument.
-#define MPACK_EXTRACT_ARG0_IMPL(first, ...) first
-#define MPACK_EXTRACT_ARG0(...) MPACK_EXPAND(MPACK_EXTRACT_ARG0_IMPL( __VA_ARGS__ , ignored))
+#    define MPACK_EXTRACT_ARG0_IMPL(first, ...) first
+#    define MPACK_EXTRACT_ARG0(...)                                            \
+        MPACK_EXPAND(MPACK_EXTRACT_ARG0_IMPL(__VA_ARGS__, ignored))
 
 // Stringifies the first argument of a variadic macro list, where there might
 // only be one argument.
-#define MPACK_STRINGIFY_ARG0_impl(first, ...) #first
-#define MPACK_STRINGIFY_ARG0(...) MPACK_EXPAND(MPACK_STRINGIFY_ARG0_impl( __VA_ARGS__ , ignored))
-
-
+#    define MPACK_STRINGIFY_ARG0_impl(first, ...) #    first
+#    define MPACK_STRINGIFY_ARG0(...)                                          \
+        MPACK_EXPAND(MPACK_STRINGIFY_ARG0_impl(__VA_ARGS__, ignored))
 
 /*
  * Definition of inline macros.
  *
- * MPack does not use static inline in header files; only one non-inline definition
- * of each function should exist in the final build. This can reduce the binary size
- * in cases where the compiler cannot or chooses not to inline a function.
- * The addresses of functions should also compare equal across translation units
- * regardless of whether they are declared inline.
+ * MPack does not use static inline in header files; only one non-inline
+ * definition of each function should exist in the final build. This can reduce
+ * the binary size in cases where the compiler cannot or chooses not to inline a
+ * function. The addresses of functions should also compare equal across
+ * translation units regardless of whether they are declared inline.
  *
- * The above requirements mean that the declaration and definition of non-trivial
- * inline functions must be separated so that the definitions will only
- * appear when necessary. In addition, three different linkage models need
+ * The above requirements mean that the declaration and definition of
+ * non-trivial inline functions must be separated so that the definitions will
+ * only appear when necessary. In addition, three different linkage models need
  * to be supported:
  *
  *  - The C99 model, where a standalone function is emitted only if there is any
- *    `extern inline` or non-`inline` declaration (including the definition itself)
+ *    `extern inline` or non-`inline` declaration (including the definition
+ * itself)
  *
- *  - The GNU model, where an `inline` definition emits a standalone function and an
- *    `extern inline` definition does not, regardless of other declarations
+ *  - The GNU model, where an `inline` definition emits a standalone function
+ * and an `extern inline` definition does not, regardless of other declarations
  *
  *  - The C++ model, where `inline` emits a standalone function with special
  *    (COMDAT) linkage
  *
- * The macros below wrap up everything above. All inline functions defined in header
- * files have a single non-inline definition emitted in the compilation of
- * mpack-platform.c. All inline declarations and definitions use the same MPACK_INLINE
- * specification to simplify the rules on when standalone functions are emitted.
- * Inline functions in source files are defined MPACK_STATIC_INLINE.
+ * The macros below wrap up everything above. All inline functions defined in
+ * header files have a single non-inline definition emitted in the compilation
+ * of mpack-platform.c. All inline declarations and definitions use the same
+ * MPACK_INLINE specification to simplify the rules on when standalone functions
+ * are emitted. Inline functions in source files are defined
+ * MPACK_STATIC_INLINE.
  *
  * Additional reading:
  *     http://www.greenend.org.uk/rjk/tech/inline.html
  */
 
-#if defined(__cplusplus)
-    // C++ rules
-    // The linker will need COMDAT support to link C++ object files,
-    // so we don't need to worry about emitting definitions from C++
-    // translation units. If mpack-platform.c (or the amalgamation)
-    // is compiled as C, its definition will be used, otherwise a
-    // C++ definition will be used, and no other C files will emit
-    // a defition.
-    #define MPACK_INLINE inline
+#    if defined(__cplusplus)
+// C++ rules
+// The linker will need COMDAT support to link C++ object files,
+// so we don't need to worry about emitting definitions from C++
+// translation units. If mpack-platform.c (or the amalgamation)
+// is compiled as C, its definition will be used, otherwise a
+// C++ definition will be used, and no other C files will emit
+// a defition.
+#        define MPACK_INLINE inline
 
-#elif defined(_MSC_VER)
-    // MSVC 2013 always uses COMDAT linkage, but it doesn't treat 'inline' as a
-    // keyword in C99 mode. (This appears to be fixed in a later version of
-    // MSVC but we don't bother detecting it.)
-    #define MPACK_INLINE __inline
-    #define MPACK_STATIC_INLINE static __inline
+#    elif defined(_MSC_VER)
+// MSVC 2013 always uses COMDAT linkage, but it doesn't treat 'inline' as a
+// keyword in C99 mode. (This appears to be fixed in a later version of
+// MSVC but we don't bother detecting it.)
+#        define MPACK_INLINE __inline
+#        define MPACK_STATIC_INLINE static __inline
 
-#elif defined(__GNUC__) && (defined(__GNUC_GNU_INLINE__) || \
-        !defined(__GNUC_STDC_INLINE__) && !defined(__GNUC_GNU_INLINE__))
-    // GNU rules
-    #if MPACK_EMIT_INLINE_DEFS
-        #define MPACK_INLINE inline
-    #else
-        #define MPACK_INLINE extern inline
-    #endif
+#    elif defined(__GNUC__)                                                    \
+        && (defined(__GNUC_GNU_INLINE__)                                       \
+            || !defined(__GNUC_STDC_INLINE__)                                  \
+                && !defined(__GNUC_GNU_INLINE__))
+// GNU rules
+#        if MPACK_EMIT_INLINE_DEFS
+#            define MPACK_INLINE inline
+#        else
+#            define MPACK_INLINE extern inline
+#        endif
 
-#else
-    // C99 rules
-    #if MPACK_EMIT_INLINE_DEFS
-        #define MPACK_INLINE extern inline
-    #else
-        #define MPACK_INLINE inline
-    #endif
-#endif
+#    else
+// C99 rules
+#        if MPACK_EMIT_INLINE_DEFS
+#            define MPACK_INLINE extern inline
+#        else
+#            define MPACK_INLINE inline
+#        endif
+#    endif
 
-#ifndef MPACK_STATIC_INLINE
-#define MPACK_STATIC_INLINE static inline
-#endif
+#    ifndef MPACK_STATIC_INLINE
+#        define MPACK_STATIC_INLINE static inline
+#    endif
 
-#ifdef MPACK_OPTIMIZE_FOR_SPEED
-    #error "You should define MPACK_OPTIMIZE_FOR_SIZE, not MPACK_OPTIMIZE_FOR_SPEED."
-#endif
-
-
+#    ifdef MPACK_OPTIMIZE_FOR_SPEED
+#        error                                                                 \
+            "You should define MPACK_OPTIMIZE_FOR_SIZE, not MPACK_OPTIMIZE_FOR_SPEED."
+#    endif
 
 /*
  * Prevent inlining
@@ -680,49 +658,45 @@ MPACK_HEADER_START
  * will get inlined into the middle of a hot code path.
  */
 
-#if !MPACK_NO_BUILTINS
-    #if defined(_MSC_VER)
-        #define MPACK_NOINLINE __declspec(noinline)
-    #elif defined(__GNUC__) || defined(__clang__)
-        #define MPACK_NOINLINE __attribute__((noinline))
-    #endif
-#endif
-#ifndef MPACK_NOINLINE
-    #define MPACK_NOINLINE /* nothing */
-#endif
-
-
+#    if !MPACK_NO_BUILTINS
+#        if defined(_MSC_VER)
+#            define MPACK_NOINLINE __declspec(noinline)
+#        elif defined(__GNUC__) || defined(__clang__)
+#            define MPACK_NOINLINE __attribute__((noinline))
+#        endif
+#    endif
+#    ifndef MPACK_NOINLINE
+#        define MPACK_NOINLINE /* nothing */
+#    endif
 
 /* Some compiler-specific keywords and builtins */
 
-#if !MPACK_NO_BUILTINS
-    #if defined(__GNUC__) || defined(__clang__)
-        #define MPACK_UNREACHABLE __builtin_unreachable()
-        #define MPACK_NORETURN(fn) fn __attribute__((noreturn))
-        #define MPACK_RESTRICT __restrict__
-    #elif defined(_MSC_VER)
-        #define MPACK_UNREACHABLE __assume(0)
-        #define MPACK_NORETURN(fn) __declspec(noreturn) fn
-        #define MPACK_RESTRICT __restrict
-    #endif
-#endif
+#    if !MPACK_NO_BUILTINS
+#        if defined(__GNUC__) || defined(__clang__)
+#            define MPACK_UNREACHABLE __builtin_unreachable()
+#            define MPACK_NORETURN(fn) fn __attribute__((noreturn))
+#            define MPACK_RESTRICT __restrict__
+#        elif defined(_MSC_VER)
+#            define MPACK_UNREACHABLE __assume(0)
+#            define MPACK_NORETURN(fn) __declspec(noreturn) fn
+#            define MPACK_RESTRICT __restrict
+#        endif
+#    endif
 
-#ifndef MPACK_RESTRICT
-#ifdef __cplusplus
-#define MPACK_RESTRICT /* nothing, unavailable in C++ */
-#else
-#define MPACK_RESTRICT restrict /* required in C99 */
-#endif
-#endif
+#    ifndef MPACK_RESTRICT
+#        ifdef __cplusplus
+#            define MPACK_RESTRICT /* nothing, unavailable in C++ */
+#        else
+#            define MPACK_RESTRICT restrict /* required in C99 */
+#        endif
+#    endif
 
-#ifndef MPACK_UNREACHABLE
-#define MPACK_UNREACHABLE ((void)0)
-#endif
-#ifndef MPACK_NORETURN
-#define MPACK_NORETURN(fn) fn
-#endif
-
-
+#    ifndef MPACK_UNREACHABLE
+#        define MPACK_UNREACHABLE ((void)0)
+#    endif
+#    ifndef MPACK_NORETURN
+#        define MPACK_NORETURN(fn) fn
+#    endif
 
 /*
  * Likely/unlikely
@@ -732,122 +706,121 @@ MPACK_HEADER_START
  * elements are a good example.
  */
 
-#if !MPACK_NO_BUILTINS
-    #if defined(__GNUC__) || defined(__clang__)
-        #ifndef MPACK_LIKELY
-            #define MPACK_LIKELY(x) __builtin_expect((x),1)
-        #endif
-        #ifndef MPACK_UNLIKELY
-            #define MPACK_UNLIKELY(x) __builtin_expect((x),0)
-        #endif
-    #endif
-#endif
+#    if !MPACK_NO_BUILTINS
+#        if defined(__GNUC__) || defined(__clang__)
+#            ifndef MPACK_LIKELY
+#                define MPACK_LIKELY(x) __builtin_expect((x), 1)
+#            endif
+#            ifndef MPACK_UNLIKELY
+#                define MPACK_UNLIKELY(x) __builtin_expect((x), 0)
+#            endif
+#        endif
+#    endif
 
-#ifndef MPACK_LIKELY
-    #define MPACK_LIKELY(x) (x)
-#endif
-#ifndef MPACK_UNLIKELY
-    #define MPACK_UNLIKELY(x) (x)
-#endif
-
-
+#    ifndef MPACK_LIKELY
+#        define MPACK_LIKELY(x) (x)
+#    endif
+#    ifndef MPACK_UNLIKELY
+#        define MPACK_UNLIKELY(x) (x)
+#    endif
 
 /* Static assert */
 
-#ifndef MPACK_STATIC_ASSERT
-    #if defined(__cplusplus)
-        #if __cplusplus >= 201103L
-            #define MPACK_STATIC_ASSERT static_assert
-        #endif
-    #elif defined(__STDC_VERSION__)
-        #if __STDC_VERSION__ >= 201112L
-            #define MPACK_STATIC_ASSERT _Static_assert
-        #endif
-    #endif
-#endif
+#    ifndef MPACK_STATIC_ASSERT
+#        if defined(__cplusplus)
+#            if __cplusplus >= 201103L
+#                define MPACK_STATIC_ASSERT static_assert
+#            endif
+#        elif defined(__STDC_VERSION__)
+#            if __STDC_VERSION__ >= 201112L
+#                define MPACK_STATIC_ASSERT _Static_assert
+#            endif
+#        endif
+#    endif
 
-#if !MPACK_NO_BUILTINS
-    #ifndef MPACK_STATIC_ASSERT
-        #if defined(__has_feature)
-            #if __has_feature(cxx_static_assert)
-                #define MPACK_STATIC_ASSERT static_assert
-            #elif __has_feature(c_static_assert)
-                #define MPACK_STATIC_ASSERT _Static_assert
-            #endif
-        #endif
-    #endif
+#    if !MPACK_NO_BUILTINS
+#        ifndef MPACK_STATIC_ASSERT
+#            if defined(__has_feature)
+#                if __has_feature(cxx_static_assert)
+#                    define MPACK_STATIC_ASSERT static_assert
+#                elif __has_feature(c_static_assert)
+#                    define MPACK_STATIC_ASSERT _Static_assert
+#                endif
+#            endif
+#        endif
 
-    #ifndef MPACK_STATIC_ASSERT
-        #if defined(__GNUC__)
-            #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-                #ifndef __cplusplus
-                    #if __GNUC__ >= 5
-                    #define MPACK_IGNORE_PEDANTIC "GCC diagnostic ignored \"-Wpedantic\""
-                    #else
-                    #define MPACK_IGNORE_PEDANTIC "GCC diagnostic ignored \"-pedantic\""
-                    #endif
-                    #define MPACK_STATIC_ASSERT(expr, str) do { \
-                        _Pragma ("GCC diagnostic push") \
-                        _Pragma (MPACK_IGNORE_PEDANTIC) \
-                        _Pragma ("GCC diagnostic ignored \"-Wc++-compat\"") \
-                        _Static_assert(expr, str); \
-                        _Pragma ("GCC diagnostic pop") \
-                    } while (0)
-                #endif
-            #endif
-        #endif
-    #endif
+#        ifndef MPACK_STATIC_ASSERT
+#            if defined(__GNUC__)
+#                if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#                    ifndef __cplusplus
+#                        if __GNUC__ >= 5
+#                            define MPACK_IGNORE_PEDANTIC                      \
+                                "GCC diagnostic ignored \"-Wpedantic\""
+#                        else
+#                            define MPACK_IGNORE_PEDANTIC                      \
+                                "GCC diagnostic ignored \"-pedantic\""
+#                        endif
+#                        define MPACK_STATIC_ASSERT(expr, str)                 \
+                            do {                                               \
+                                _Pragma("GCC diagnostic push")                 \
+                                    _Pragma(MPACK_IGNORE_PEDANTIC) _Pragma(    \
+                                        "GCC diagnostic ignored "              \
+                                        "\"-Wc++-"                             \
+                                        "compat\"") _Static_assert(expr, str); \
+                                _Pragma("GCC diagnostic pop")                  \
+                            } while (0)
+#                    endif
+#                endif
+#            endif
+#        endif
 
-    #ifndef MPACK_STATIC_ASSERT
-        #ifdef _MSC_VER
-            #if _MSC_VER >= 1600
-                #define MPACK_STATIC_ASSERT static_assert
-            #endif
-        #endif
-    #endif
-#endif
+#        ifndef MPACK_STATIC_ASSERT
+#            ifdef _MSC_VER
+#                if _MSC_VER >= 1600
+#                    define MPACK_STATIC_ASSERT static_assert
+#                endif
+#            endif
+#        endif
+#    endif
 
-#ifndef MPACK_STATIC_ASSERT
-    #define MPACK_STATIC_ASSERT(expr, str) (MPACK_UNUSED(sizeof(char[1 - 2*!(expr)])))
-#endif
-
-
+#    ifndef MPACK_STATIC_ASSERT
+#        define MPACK_STATIC_ASSERT(expr, str)                                 \
+            (MPACK_UNUSED(sizeof(char[1 - 2 * !(expr)])))
+#    endif
 
 /* _Generic */
 
-#ifndef MPACK_HAS_GENERIC
-    #if defined(__clang__) && defined(__has_feature)
-        // With Clang we can test for _Generic support directly
-        // and ignore C/C++ version
-        #if __has_feature(c_generic_selections)
-            #define MPACK_HAS_GENERIC 1
-        #else
-            #define MPACK_HAS_GENERIC 0
-        #endif
-    #endif
-#endif
+#    ifndef MPACK_HAS_GENERIC
+#        if defined(__clang__) && defined(__has_feature)
+// With Clang we can test for _Generic support directly
+// and ignore C/C++ version
+#            if __has_feature(c_generic_selections)
+#                define MPACK_HAS_GENERIC 1
+#            else
+#                define MPACK_HAS_GENERIC 0
+#            endif
+#        endif
+#    endif
 
-#ifndef MPACK_HAS_GENERIC
-    #if defined(__STDC_VERSION__)
-        #if __STDC_VERSION__ >= 201112L
-            #if defined(__GNUC__) && !defined(__clang__)
-                // GCC does not have full C11 support in GCC 4.7 and 4.8
-                #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
-                    #define MPACK_HAS_GENERIC 1
-                #endif
-            #else
-                // We hope other compilers aren't lying about C11/_Generic support
-                #define MPACK_HAS_GENERIC 1
-            #endif
-        #endif
-    #endif
-#endif
+#    ifndef MPACK_HAS_GENERIC
+#        if defined(__STDC_VERSION__)
+#            if __STDC_VERSION__ >= 201112L
+#                if defined(__GNUC__) && !defined(__clang__)
+// GCC does not have full C11 support in GCC 4.7 and 4.8
+#                    if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)
+#                        define MPACK_HAS_GENERIC 1
+#                    endif
+#                else
+// We hope other compilers aren't lying about C11/_Generic support
+#                    define MPACK_HAS_GENERIC 1
+#                endif
+#            endif
+#        endif
+#    endif
 
-#ifndef MPACK_HAS_GENERIC
-    #define MPACK_HAS_GENERIC 0
-#endif
-
-
+#    ifndef MPACK_HAS_GENERIC
+#        define MPACK_HAS_GENERIC 0
+#    endif
 
 /*
  * Finite Math
@@ -859,17 +832,15 @@ MPACK_HEADER_START
  * non-finite reals. This isn't currently implemented.
  */
 
-#ifndef MPACK_FINITE_MATH
-#if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__
-#define MPACK_FINITE_MATH 1
-#endif
-#endif
+#    ifndef MPACK_FINITE_MATH
+#        if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__
+#            define MPACK_FINITE_MATH 1
+#        endif
+#    endif
 
-#ifndef MPACK_FINITE_MATH
-#define MPACK_FINITE_MATH 0
-#endif
-
-
+#    ifndef MPACK_FINITE_MATH
+#        define MPACK_FINITE_MATH 0
+#    endif
 
 /*
  * Endianness checks
@@ -883,100 +854,102 @@ MPACK_HEADER_START
  * See the notes in mpack-common.h.
  */
 
-#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
-    #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        #define MPACK_NHSWAP16(x) (x)
-        #define MPACK_NHSWAP32(x) (x)
-        #define MPACK_NHSWAP64(x) (x)
-    #elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)            \
+        && defined(__ORDER_BIG_ENDIAN__)
+#        if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#            define MPACK_NHSWAP16(x) (x)
+#            define MPACK_NHSWAP32(x) (x)
+#            define MPACK_NHSWAP64(x) (x)
+#        elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 
-        #if !MPACK_NO_BUILTINS
-            #if defined(__clang__)
-                #ifdef __has_builtin
-                    // Unlike the GCC builtins, the bswap builtins in Clang
-                    // significantly improve ARM performance.
-                    #if __has_builtin(__builtin_bswap16)
-                        #define MPACK_NHSWAP16(x) __builtin_bswap16(x)
-                    #endif
-                    #if __has_builtin(__builtin_bswap32)
-                        #define MPACK_NHSWAP32(x) __builtin_bswap32(x)
-                    #endif
-                    #if __has_builtin(__builtin_bswap64)
-                        #define MPACK_NHSWAP64(x) __builtin_bswap64(x)
-                    #endif
-                #endif
+#            if !MPACK_NO_BUILTINS
+#                if defined(__clang__)
+#                    ifdef __has_builtin
+// Unlike the GCC builtins, the bswap builtins in Clang
+// significantly improve ARM performance.
+#                        if __has_builtin(__builtin_bswap16)
+#                            define MPACK_NHSWAP16(x) __builtin_bswap16(x)
+#                        endif
+#                        if __has_builtin(__builtin_bswap32)
+#                            define MPACK_NHSWAP32(x) __builtin_bswap32(x)
+#                        endif
+#                        if __has_builtin(__builtin_bswap64)
+#                            define MPACK_NHSWAP64(x) __builtin_bswap64(x)
+#                        endif
+#                    endif
 
-            #elif defined(__GNUC__)
+#                elif defined(__GNUC__)
 
-                // The GCC bswap builtins are apparently poorly optimized on older
-                // versions of GCC, so we set a minimum version here just in case.
-                //     http://hardwarebug.org/2010/01/14/beware-the-builtins/
+// The GCC bswap builtins are apparently poorly optimized on older
+// versions of GCC, so we set a minimum version here just in case.
+//     http://hardwarebug.org/2010/01/14/beware-the-builtins/
 
-                #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
-                    #define MPACK_NHSWAP64(x) __builtin_bswap64(x)
-                #endif
+#                    if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+#                        define MPACK_NHSWAP64(x) __builtin_bswap64(x)
+#                    endif
 
-                // __builtin_bswap16() was not implemented on all platforms
-                // until GCC 4.8.0:
-                //     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52624
-                //
-                // The 16- and 32-bit versions in GCC significantly reduce performance
-                // on ARM with little effect on code size so we don't use them.
+// __builtin_bswap16() was not implemented on all platforms
+// until GCC 4.8.0:
+//     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52624
+//
+// The 16- and 32-bit versions in GCC significantly reduce performance
+// on ARM with little effect on code size so we don't use them.
 
-            #endif
-        #endif
-    #endif
+#                endif
+#            endif
+#        endif
 
-#elif defined(_MSC_VER) && defined(_WIN32) && !MPACK_NO_BUILTINS
+#    elif defined(_MSC_VER) && defined(_WIN32) && !MPACK_NO_BUILTINS
 
-    // On Windows, we assume x86 and x86_64 are always little-endian.
-    // We make no assumptions about ARM even though all current
-    // Windows Phone devices are little-endian in case Microsoft's
-    // compiler is ever used with a big-endian ARM device.
+// On Windows, we assume x86 and x86_64 are always little-endian.
+// We make no assumptions about ARM even though all current
+// Windows Phone devices are little-endian in case Microsoft's
+// compiler is ever used with a big-endian ARM device.
 
-    #if defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64)
-        #define MPACK_NHSWAP16(x) _byteswap_ushort(x)
-        #define MPACK_NHSWAP32(x) _byteswap_ulong(x)
-        #define MPACK_NHSWAP64(x) _byteswap_uint64(x)
-    #endif
+#        if defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64)
+#            define MPACK_NHSWAP16(x) _byteswap_ushort(x)
+#            define MPACK_NHSWAP32(x) _byteswap_ulong(x)
+#            define MPACK_NHSWAP64(x) _byteswap_uint64(x)
+#        endif
 
-#endif
+#    endif
 
-#if defined(__FLOAT_WORD_ORDER__) && defined(__BYTE_ORDER__)
+#    if defined(__FLOAT_WORD_ORDER__) && defined(__BYTE_ORDER__)
 
-    // We check where possible that the float byte order matches the
-    // integer byte order. This is extremely unlikely to fail, but
-    // we check anyway just in case.
-    //
-    // (The static assert is placed in float/double encoders instead
-    // of here because our static assert fallback doesn't work at
-    // file scope)
+// We check where possible that the float byte order matches the
+// integer byte order. This is extremely unlikely to fail, but
+// we check anyway just in case.
+//
+// (The static assert is placed in float/double encoders instead
+// of here because our static assert fallback doesn't work at
+// file scope)
 
-    #define MPACK_CHECK_FLOAT_ORDER() \
-        MPACK_STATIC_ASSERT(__FLOAT_WORD_ORDER__ == __BYTE_ORDER__, \
-            "float byte order does not match int byte order! float/double " \
-            "encoding is not properly implemented on this platform.")
+#        define MPACK_CHECK_FLOAT_ORDER()                                      \
+            MPACK_STATIC_ASSERT(__FLOAT_WORD_ORDER__ == __BYTE_ORDER__,        \
+                "float byte order does not match int byte order! "             \
+                "float/double "                                                \
+                "encoding is not properly implemented on this platform.")
 
-#endif
+#    endif
 
-#ifndef MPACK_CHECK_FLOAT_ORDER
-    #define MPACK_CHECK_FLOAT_ORDER() /* nothing */
-#endif
-
+#    ifndef MPACK_CHECK_FLOAT_ORDER
+#        define MPACK_CHECK_FLOAT_ORDER() /* nothing */
+#    endif
 
 /*
  * Here we define mpack_assert() and mpack_break(). They both work like a normal
- * assertion function in debug mode, causing a trap or abort. However, on some platforms
- * you can safely resume execution from mpack_break(), whereas mpack_assert() is
- * always fatal.
+ * assertion function in debug mode, causing a trap or abort. However, on some
+ * platforms you can safely resume execution from mpack_break(), whereas
+ * mpack_assert() is always fatal.
  *
  * In release mode, mpack_assert() is converted to an assurance to the compiler
- * that the expression cannot be false (via e.g. __assume() or __builtin_unreachable())
- * to improve optimization where supported. There is thus no point in "safely" handling
- * the case of this being false. Writing mpack_assert(0) rarely makes sense (except
- * possibly as a default handler in a switch) since the compiler will throw away any
- * code after it. If at any time an mpack_assert() is not true, the behaviour is
- * undefined. This also means the expression is evaluated even in release.
+ * that the expression cannot be false (via e.g. __assume() or
+ * __builtin_unreachable()) to improve optimization where supported. There is
+ * thus no point in "safely" handling the case of this being false. Writing
+ * mpack_assert(0) rarely makes sense (except possibly as a default handler in a
+ * switch) since the compiler will throw away any code after it. If at any time
+ * an mpack_assert() is not true, the behaviour is undefined. This also means
+ * the expression is evaluated even in release.
  *
  * mpack_break() on the other hand is compiled to nothing in release. It is
  * used in situations where we want to highlight a programming error as early as
@@ -986,9 +959,9 @@ MPACK_HEADER_START
  * belongs in a safe-handling block after its failing condition has been tested.
  *
  * If stdio is available, we can add a format string describing the error, and
- * on some compilers we can declare it noreturn to get correct results from static
- * analysis tools. Note that the format string and arguments are not evaluated unless
- * the assertion is hit.
+ * on some compilers we can declare it noreturn to get correct results from
+ * static analysis tools. Note that the format string and arguments are not
+ * evaluated unless the assertion is hit.
  *
  * Note that any arguments to mpack_assert() beyond the first are only evaluated
  * if the expression is false (and are never evaluated in release.)
@@ -998,218 +971,225 @@ MPACK_HEADER_START
  * important for static analysis tools to give correct results.
  */
 
-#if MPACK_DEBUG
+#    if MPACK_DEBUG
 
-    /**
-     * @addtogroup config
-     * @{
-     */
-    /**
-     * @name Debug Functions
-     */
-    /**
-     * Implement this and define @ref MPACK_CUSTOM_ASSERT to use a custom
-     * assertion function.
-     *
-     * This function should not return. If it does, MPack will @c abort().
-     *
-     * If you use C++, make sure you include @c mpack.h where you define
-     * this to get the correct linkage (or define it <code>extern "C"</code>.)
-     *
-     * Asserts are only used when @ref MPACK_DEBUG is enabled, and can be
-     * triggered by bugs in MPack or bugs due to incorrect usage of MPack.
-     */
-    void mpack_assert_fail(const char* message);
-    /**
-     * @}
-     */
-    /**
-     * @}
-     */
+/**
+ * @addtogroup config
+ * @{
+ */
+/**
+ * @name Debug Functions
+ */
+/**
+ * Implement this and define @ref MPACK_CUSTOM_ASSERT to use a custom
+ * assertion function.
+ *
+ * This function should not return. If it does, MPack will @c abort().
+ *
+ * If you use C++, make sure you include @c mpack.h where you define
+ * this to get the correct linkage (or define it <code>extern "C"</code>.)
+ *
+ * Asserts are only used when @ref MPACK_DEBUG is enabled, and can be
+ * triggered by bugs in MPack or bugs due to incorrect usage of MPack.
+ */
+void mpack_assert_fail(const char *message);
+/**
+ * @}
+ */
+/**
+ * @}
+ */
 
-    MPACK_NORETURN(void mpack_assert_fail_wrapper(const char* message));
-    #if MPACK_STDIO
-        MPACK_NORETURN(void mpack_assert_fail_format(const char* format, ...));
-        #define mpack_assert_fail_at(line, file, exprstr, format, ...) \
-                MPACK_EXPAND(mpack_assert_fail_format("mpack assertion failed at " file ":" #line "\n%s\n" format, exprstr, __VA_ARGS__))
-    #else
-        #define mpack_assert_fail_at(line, file, exprstr, format, ...) \
-                mpack_assert_fail_wrapper("mpack assertion failed at " file ":" #line "\n" exprstr "\n")
-    #endif
+MPACK_NORETURN(void mpack_assert_fail_wrapper(const char *message));
+#        if MPACK_STDIO
+MPACK_NORETURN(void mpack_assert_fail_format(const char *format, ...));
+#            define mpack_assert_fail_at(line, file, exprstr, format, ...)     \
+                MPACK_EXPAND(                                                  \
+                    mpack_assert_fail_format("mpack assertion failed at " file \
+                                             ":" #line "\n%s\n" format,        \
+                        exprstr, __VA_ARGS__))
+#        else
+#            define mpack_assert_fail_at(line, file, exprstr, format, ...)     \
+                mpack_assert_fail_wrapper("mpack assertion failed at " file    \
+                                          ":" #line "\n" exprstr "\n")
+#        endif
 
-    #define mpack_assert_fail_pos(line, file, exprstr, expr, ...) \
+#        define mpack_assert_fail_pos(line, file, exprstr, expr, ...)          \
             MPACK_EXPAND(mpack_assert_fail_at(line, file, exprstr, __VA_ARGS__))
 
-    // This contains a workaround to the pedantic C99 requirement of having at
-    // least one argument to a variadic macro. The first argument is the
-    // boolean expression, the optional second argument (if provided) must be a
-    // literal format string, and any additional arguments are the format
-    // argument list.
-    //
-    // Unfortunately this means macros are expanded in the expression before it
-    // gets stringified. I haven't found a workaround to this.
-    //
-    // This adds two unused arguments to the format argument list when a
-    // format string is provided, so this would complicate the use of
-    // -Wformat and __attribute__((format)) on mpack_assert_fail_format() if we
-    // ever bothered to implement it.
-    #define mpack_assert(...) \
-            MPACK_EXPAND(((!(MPACK_EXTRACT_ARG0(__VA_ARGS__))) ? \
-                mpack_assert_fail_pos(__LINE__, __FILE__, MPACK_STRINGIFY_ARG0(__VA_ARGS__) , __VA_ARGS__ , "", NULL) : \
-                (void)0))
+// This contains a workaround to the pedantic C99 requirement of having at
+// least one argument to a variadic macro. The first argument is the
+// boolean expression, the optional second argument (if provided) must be a
+// literal format string, and any additional arguments are the format
+// argument list.
+//
+// Unfortunately this means macros are expanded in the expression before it
+// gets stringified. I haven't found a workaround to this.
+//
+// This adds two unused arguments to the format argument list when a
+// format string is provided, so this would complicate the use of
+// -Wformat and __attribute__((format)) on mpack_assert_fail_format() if we
+// ever bothered to implement it.
+#        define mpack_assert(...)                                              \
+            MPACK_EXPAND(((!(MPACK_EXTRACT_ARG0(__VA_ARGS__)))                 \
+                    ? mpack_assert_fail_pos(__LINE__, __FILE__,                \
+                        MPACK_STRINGIFY_ARG0(__VA_ARGS__), __VA_ARGS__, "",    \
+                        NULL)                                                  \
+                    : (void)0))
 
-    void mpack_break_hit(const char* message);
-    #if MPACK_STDIO
-        void mpack_break_hit_format(const char* format, ...);
-        #define mpack_break_hit_at(line, file, ...) \
-                MPACK_EXPAND(mpack_break_hit_format("mpack breakpoint hit at " file ":" #line "\n" __VA_ARGS__))
-    #else
-        #define mpack_break_hit_at(line, file, ...) \
-                mpack_break_hit("mpack breakpoint hit at " file ":" #line )
-    #endif
-    #define mpack_break_hit_pos(line, file, ...) MPACK_EXPAND(mpack_break_hit_at(line, file, __VA_ARGS__))
-    #define mpack_break(...) MPACK_EXPAND(mpack_break_hit_pos(__LINE__, __FILE__, __VA_ARGS__))
-#else
-    #define mpack_assert(...) \
-            (MPACK_EXPAND((!(MPACK_EXTRACT_ARG0(__VA_ARGS__))) ? \
-                (MPACK_UNREACHABLE, (void)0) : \
-                (void)0))
-    #define mpack_break(...) ((void)0)
-#endif
-
-
+void mpack_break_hit(const char *message);
+#        if MPACK_STDIO
+void mpack_break_hit_format(const char *format, ...);
+#            define mpack_break_hit_at(line, file, ...)                        \
+                MPACK_EXPAND(                                                  \
+                    mpack_break_hit_format("mpack breakpoint hit at " file     \
+                                           ":" #line "\n" __VA_ARGS__))
+#        else
+#            define mpack_break_hit_at(line, file, ...)                        \
+                mpack_break_hit("mpack breakpoint hit at " file ":" #line)
+#        endif
+#        define mpack_break_hit_pos(line, file, ...)                           \
+            MPACK_EXPAND(mpack_break_hit_at(line, file, __VA_ARGS__))
+#        define mpack_break(...)                                               \
+            MPACK_EXPAND(mpack_break_hit_pos(__LINE__, __FILE__, __VA_ARGS__))
+#    else
+#        define mpack_assert(...)                                              \
+            (MPACK_EXPAND((!(MPACK_EXTRACT_ARG0(__VA_ARGS__)))                 \
+                    ? (MPACK_UNREACHABLE, (void)0)                             \
+                    : (void)0))
+#        define mpack_break(...) ((void)0)
+#    endif
 
 /* Wrap some needed libc functions */
 
-#if MPACK_STDLIB
-    #define mpack_memcmp memcmp
-    #define mpack_memcpy memcpy
-    #define mpack_memmove memmove
-    #define mpack_memset memset
-    #ifndef mpack_strlen
-        #define mpack_strlen strlen
-    #endif
+#    if MPACK_STDLIB
+#        define mpack_memcmp memcmp
+#        define mpack_memcpy memcpy
+#        define mpack_memmove memmove
+#        define mpack_memset memset
+#        ifndef mpack_strlen
+#            define mpack_strlen strlen
+#        endif
 
-    #if defined(MPACK_UNIT_TESTS) && MPACK_INTERNAL && defined(__GNUC__)
-        // make sure we don't use the stdlib directly during development
-        #undef memcmp
-        #undef memcpy
-        #undef memmove
-        #undef memset
-        #undef strlen
-        #undef malloc
-        #undef free
-        #pragma GCC poison memcmp
-        #pragma GCC poison memcpy
-        #pragma GCC poison memmove
-        #pragma GCC poison memset
-        #pragma GCC poison strlen
-        #pragma GCC poison malloc
-        #pragma GCC poison free
-    #endif
+#        if defined(MPACK_UNIT_TESTS) && MPACK_INTERNAL && defined(__GNUC__)
+// make sure we don't use the stdlib directly during development
+#            undef memcmp
+#            undef memcpy
+#            undef memmove
+#            undef memset
+#            undef strlen
+#            undef malloc
+#            undef free
+#            pragma GCC poison memcmp
+#            pragma GCC poison memcpy
+#            pragma GCC poison memmove
+#            pragma GCC poison memset
+#            pragma GCC poison strlen
+#            pragma GCC poison malloc
+#            pragma GCC poison free
+#        endif
 
-#elif defined(__GNUC__) && !MPACK_NO_BUILTINS
-    // there's not always a builtin memmove for GCC,
-    // and we don't have a way to test for it
-    #define mpack_memcmp __builtin_memcmp
-    #define mpack_memcpy __builtin_memcpy
-    #define mpack_memset __builtin_memset
-    #define mpack_strlen __builtin_strlen
+#    elif defined(__GNUC__) && !MPACK_NO_BUILTINS
+// there's not always a builtin memmove for GCC,
+// and we don't have a way to test for it
+#        define mpack_memcmp __builtin_memcmp
+#        define mpack_memcpy __builtin_memcpy
+#        define mpack_memset __builtin_memset
+#        define mpack_strlen __builtin_strlen
 
-#elif defined(__clang__) && defined(__has_builtin) && !MPACK_NO_BUILTINS
-    #if __has_builtin(__builtin_memcmp)
-    #define mpack_memcmp __builtin_memcmp
-    #endif
-    #if __has_builtin(__builtin_memcpy)
-    #define mpack_memcpy __builtin_memcpy
-    #endif
-    #if __has_builtin(__builtin_memmove)
-    #define mpack_memmove __builtin_memmove
-    #endif
-    #if __has_builtin(__builtin_memset)
-    #define mpack_memset __builtin_memset
-    #endif
-    #if __has_builtin(__builtin_strlen)
-    #define mpack_strlen __builtin_strlen
-    #endif
-#endif
+#    elif defined(__clang__) && defined(__has_builtin) && !MPACK_NO_BUILTINS
+#        if __has_builtin(__builtin_memcmp)
+#            define mpack_memcmp __builtin_memcmp
+#        endif
+#        if __has_builtin(__builtin_memcpy)
+#            define mpack_memcpy __builtin_memcpy
+#        endif
+#        if __has_builtin(__builtin_memmove)
+#            define mpack_memmove __builtin_memmove
+#        endif
+#        if __has_builtin(__builtin_memset)
+#            define mpack_memset __builtin_memset
+#        endif
+#        if __has_builtin(__builtin_strlen)
+#            define mpack_strlen __builtin_strlen
+#        endif
+#    endif
 
-#ifndef mpack_memcmp
-int mpack_memcmp(const void* s1, const void* s2, size_t n);
-#endif
-#ifndef mpack_memcpy
-void* mpack_memcpy(void* MPACK_RESTRICT s1, const void* MPACK_RESTRICT s2, size_t n);
-#endif
-#ifndef mpack_memmove
-void* mpack_memmove(void* s1, const void* s2, size_t n);
-#endif
-#ifndef mpack_memset
-void* mpack_memset(void* s, int c, size_t n);
-#endif
-#ifndef mpack_strlen
-size_t mpack_strlen(const char* s);
-#endif
+#    ifndef mpack_memcmp
+int mpack_memcmp(const void *s1, const void *s2, size_t n);
+#    endif
+#    ifndef mpack_memcpy
+void *mpack_memcpy(
+    void *MPACK_RESTRICT s1, const void *MPACK_RESTRICT s2, size_t n);
+#    endif
+#    ifndef mpack_memmove
+void *mpack_memmove(void *s1, const void *s2, size_t n);
+#    endif
+#    ifndef mpack_memset
+void *mpack_memset(void *s, int c, size_t n);
+#    endif
+#    ifndef mpack_strlen
+size_t mpack_strlen(const char *s);
+#    endif
 
-#if MPACK_STDIO
-    #if defined(WIN32)
-        #define mpack_snprintf _snprintf
-    #else
-        #define mpack_snprintf snprintf
-    #endif
-#endif
-
-
+#    if MPACK_STDIO
+#        if defined(WIN32)
+#            define mpack_snprintf _snprintf
+#        else
+#            define mpack_snprintf snprintf
+#        endif
+#    endif
 
 /* Debug logging */
-#if 0
-    #include <stdio.h>
-    #define mpack_log(...) (MPACK_EXPAND(printf(__VA_ARGS__), fflush(stdout)))
-#else
-    #define mpack_log(...) ((void)0)
-#endif
-
-
+#    if 0
+#        include <stdio.h>
+#        define mpack_log(...)                                                 \
+            (MPACK_EXPAND(printf(__VA_ARGS__), fflush(stdout)))
+#    else
+#        define mpack_log(...) ((void)0)
+#    endif
 
 /* Make sure our configuration makes sense */
-#if defined(MPACK_MALLOC) && !defined(MPACK_FREE)
-    #error "MPACK_MALLOC requires MPACK_FREE."
-#endif
-#if !defined(MPACK_MALLOC) && defined(MPACK_FREE)
-    #error "MPACK_FREE requires MPACK_MALLOC."
-#endif
-#if MPACK_READ_TRACKING && !defined(MPACK_READER)
-    #error "MPACK_READ_TRACKING requires MPACK_READER."
-#endif
-#if MPACK_WRITE_TRACKING && !defined(MPACK_WRITER)
-    #error "MPACK_WRITE_TRACKING requires MPACK_WRITER."
-#endif
-#ifndef MPACK_MALLOC
-    #if MPACK_STDIO
-        #error "MPACK_STDIO requires preprocessor definitions for MPACK_MALLOC and MPACK_FREE."
-    #endif
-    #if MPACK_READ_TRACKING
-        #error "MPACK_READ_TRACKING requires preprocessor definitions for MPACK_MALLOC and MPACK_FREE."
-    #endif
-    #if MPACK_WRITE_TRACKING
-        #error "MPACK_WRITE_TRACKING requires preprocessor definitions for MPACK_MALLOC and MPACK_FREE."
-    #endif
-#endif
-
-
+#    if defined(MPACK_MALLOC) && !defined(MPACK_FREE)
+#        error "MPACK_MALLOC requires MPACK_FREE."
+#    endif
+#    if !defined(MPACK_MALLOC) && defined(MPACK_FREE)
+#        error "MPACK_FREE requires MPACK_MALLOC."
+#    endif
+#    if MPACK_READ_TRACKING && !defined(MPACK_READER)
+#        error "MPACK_READ_TRACKING requires MPACK_READER."
+#    endif
+#    if MPACK_WRITE_TRACKING && !defined(MPACK_WRITER)
+#        error "MPACK_WRITE_TRACKING requires MPACK_WRITER."
+#    endif
+#    ifndef MPACK_MALLOC
+#        if MPACK_STDIO
+#            error                                                             \
+                "MPACK_STDIO requires preprocessor definitions for MPACK_MALLOC and MPACK_FREE."
+#        endif
+#        if MPACK_READ_TRACKING
+#            error                                                             \
+                "MPACK_READ_TRACKING requires preprocessor definitions for MPACK_MALLOC and MPACK_FREE."
+#        endif
+#        if MPACK_WRITE_TRACKING
+#            error                                                             \
+                "MPACK_WRITE_TRACKING requires preprocessor definitions for MPACK_MALLOC and MPACK_FREE."
+#        endif
+#    endif
 
 /* Implement realloc if unavailable */
-#ifdef MPACK_MALLOC
-    #ifdef MPACK_REALLOC
-        MPACK_INLINE void* mpack_realloc(void* old_ptr, size_t used_size, size_t new_size) {
-            MPACK_UNUSED(used_size);
-            return MPACK_REALLOC(old_ptr, new_size);
-        }
-    #else
-        void* mpack_realloc(void* old_ptr, size_t used_size, size_t new_size);
-    #endif
-#endif
-
-
+#    ifdef MPACK_MALLOC
+#        ifdef MPACK_REALLOC
+MPACK_INLINE void *
+mpack_realloc(void *old_ptr, size_t used_size, size_t new_size)
+{
+    MPACK_UNUSED(used_size);
+    return MPACK_REALLOC(old_ptr, new_size);
+}
+#        else
+void *mpack_realloc(void *old_ptr, size_t used_size, size_t new_size);
+#        endif
+#    endif
 
 /**
  * @}
@@ -1218,7 +1198,6 @@ size_t mpack_strlen(const char* s);
 MPACK_HEADER_END
 
 #endif
-
 
 /* mpack/mpack-common.h.h */
 
@@ -1229,17 +1208,15 @@ MPACK_HEADER_END
  */
 
 #ifndef MPACK_COMMON_H
-#define MPACK_COMMON_H 1
+#    define MPACK_COMMON_H 1
 
 /* #include "mpack-platform.h" */
 
-#ifndef MPACK_PRINT_BYTE_COUNT
-#define MPACK_PRINT_BYTE_COUNT 12
-#endif
+#    ifndef MPACK_PRINT_BYTE_COUNT
+#        define MPACK_PRINT_BYTE_COUNT 12
+#    endif
 
 MPACK_HEADER_START
-
-
 
 /**
  * @defgroup common Tags and Common Elements
@@ -1252,29 +1229,30 @@ MPACK_HEADER_START
 
 /* Version information */
 
-#define MPACK_VERSION_MAJOR 1  /**< The major version number of MPack. */
-#define MPACK_VERSION_MINOR 0  /**< The minor version number of MPack. */
-#define MPACK_VERSION_PATCH 0  /**< The patch version number of MPack. */
+#    define MPACK_VERSION_MAJOR 1 /**< The major version number of MPack. */
+#    define MPACK_VERSION_MINOR 0 /**< The minor version number of MPack. */
+#    define MPACK_VERSION_PATCH 0 /**< The patch version number of MPack. */
 
 /** A number containing the version number of MPack for comparison purposes. */
-#define MPACK_VERSION ((MPACK_VERSION_MAJOR * 10000) + \
-        (MPACK_VERSION_MINOR * 100) + MPACK_VERSION_PATCH)
+#    define MPACK_VERSION                                                      \
+        ((MPACK_VERSION_MAJOR * 10000) + (MPACK_VERSION_MINOR * 100)           \
+            + MPACK_VERSION_PATCH)
 
 /** A macro to test for a minimum version of MPack. */
-#define MPACK_VERSION_AT_LEAST(major, minor, patch) \
-        (MPACK_VERSION >= (((major) * 10000) + ((minor) * 100) + (patch)))
+#    define MPACK_VERSION_AT_LEAST(major, minor, patch)                        \
+        (MPACK_VERSION >= (((major)*10000) + ((minor)*100) + (patch)))
 
 /** @cond */
-#if (MPACK_VERSION_PATCH > 0)
-#define MPACK_VERSION_STRING_BASE \
-        MPACK_STRINGIFY(MPACK_VERSION_MAJOR) "." \
-        MPACK_STRINGIFY(MPACK_VERSION_MINOR) "." \
-        MPACK_STRINGIFY(MPACK_VERSION_PATCH)
-#else
-#define MPACK_VERSION_STRING_BASE \
-        MPACK_STRINGIFY(MPACK_VERSION_MAJOR) "." \
-        MPACK_STRINGIFY(MPACK_VERSION_MINOR)
-#endif
+#    if (MPACK_VERSION_PATCH > 0)
+#        define MPACK_VERSION_STRING_BASE                                      \
+            MPACK_STRINGIFY(MPACK_VERSION_MAJOR)                               \
+            "." MPACK_STRINGIFY(MPACK_VERSION_MINOR) "." MPACK_STRINGIFY(      \
+                MPACK_VERSION_PATCH)
+#    else
+#        define MPACK_VERSION_STRING_BASE                                      \
+            MPACK_STRINGIFY(MPACK_VERSION_MAJOR)                               \
+            "." MPACK_STRINGIFY(MPACK_VERSION_MINOR)
+#    endif
 /** @endcond */
 
 /**
@@ -1283,23 +1261,24 @@ MPACK_HEADER_START
  *
  * A string containing the MPack version.
  */
-#if MPACK_RELEASE_VERSION
-#define MPACK_VERSION_STRING MPACK_VERSION_STRING_BASE
-#else
-#define MPACK_VERSION_STRING MPACK_VERSION_STRING_BASE "dev"
-#endif
+#    if MPACK_RELEASE_VERSION
+#        define MPACK_VERSION_STRING MPACK_VERSION_STRING_BASE
+#    else
+#        define MPACK_VERSION_STRING MPACK_VERSION_STRING_BASE "dev"
+#    endif
 
 /**
  * @def MPACK_LIBRARY_STRING
  * @hideinitializer
  *
- * A string describing MPack, containing the library name, version and debug mode.
+ * A string describing MPack, containing the library name, version and debug
+ * mode.
  */
-#if MPACK_DEBUG
-#define MPACK_LIBRARY_STRING "MPack " MPACK_VERSION_STRING "-debug"
-#else
-#define MPACK_LIBRARY_STRING "MPack " MPACK_VERSION_STRING
-#endif
+#    if MPACK_DEBUG
+#        define MPACK_LIBRARY_STRING "MPack " MPACK_VERSION_STRING "-debug"
+#    else
+#        define MPACK_LIBRARY_STRING "MPack " MPACK_VERSION_STRING
+#    endif
 
 /** @cond */
 /**
@@ -1307,10 +1286,10 @@ MPACK_HEADER_START
  *
  * The maximum encoded size of a tag in bytes.
  */
-#define MPACK_MAXIMUM_TAG_SIZE 9
+#    define MPACK_MAXIMUM_TAG_SIZE 9
 /** @endcond */
 
-#if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
 /**
  * @def MPACK_TIMESTAMP_NANOSECONDS_MAX
  *
@@ -1318,12 +1297,10 @@ MPACK_HEADER_START
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-#define MPACK_TIMESTAMP_NANOSECONDS_MAX 999999999
-#endif
+#        define MPACK_TIMESTAMP_NANOSECONDS_MAX 999999999
+#    endif
 
-
-
-#if MPACK_COMPATIBILITY
+#    if MPACK_COMPATIBILITY
 /**
  * Versions of the MessagePack format.
  *
@@ -1351,7 +1328,7 @@ typedef enum mpack_version_t {
     mpack_version_current = mpack_version_v5,
 
 } mpack_version_t;
-#endif
+#    endif
 
 /**
  * Error states for MPack objects.
@@ -1361,23 +1338,30 @@ typedef enum mpack_version_t {
  * the source is in an error state before using such values.
  */
 typedef enum mpack_error_t {
-    mpack_ok = 0,        /**< No error. */
-    mpack_error_io = 2,  /**< The reader or writer failed to fill or flush, or some other file or socket error occurred. */
+    mpack_ok = 0, /**< No error. */
+    mpack_error_io = 2, /**< The reader or writer failed to fill or flush, or
+                           some other file or socket error occurred. */
     mpack_error_invalid, /**< The data read is not valid MessagePack. */
-    mpack_error_unsupported, /**< The data read is not supported by this configuration of MPack. (See @ref MPACK_EXTENSIONS.) */
-    mpack_error_type,    /**< The type or value range did not match what was expected by the caller. */
-    mpack_error_too_big, /**< A read or write was bigger than the maximum size allowed for that operation. */
-    mpack_error_memory,  /**< An allocation failure occurred. */
-    mpack_error_bug,     /**< The MPack API was used incorrectly. (This will always assert in debug mode.) */
-    mpack_error_data,    /**< The contained data is not valid. */
-    mpack_error_eof,     /**< The reader failed to read because of file or socket EOF */
+    mpack_error_unsupported, /**< The data read is not supported by this
+                                configuration of MPack. (See @ref
+                                MPACK_EXTENSIONS.) */
+    mpack_error_type, /**< The type or value range did not match what was
+                         expected by the caller. */
+    mpack_error_too_big, /**< A read or write was bigger than the maximum size
+                            allowed for that operation. */
+    mpack_error_memory, /**< An allocation failure occurred. */
+    mpack_error_bug, /**< The MPack API was used incorrectly. (This will always
+                        assert in debug mode.) */
+    mpack_error_data, /**< The contained data is not valid. */
+    mpack_error_eof, /**< The reader failed to read because of file or socket
+                        EOF */
 } mpack_error_t;
 
 /**
  * Converts an MPack error to a string. This function returns an empty
  * string when MPACK_DEBUG is not set.
  */
-const char* mpack_error_to_string(mpack_error_t error);
+const char *mpack_error_to_string(mpack_error_t error);
 
 /**
  * Defines the type of a MessagePack tag.
@@ -1387,45 +1371,49 @@ const char* mpack_error_to_string(mpack_error_t error);
  * separately.
  */
 typedef enum mpack_type_t {
-    mpack_type_missing = 0, /**< Special type indicating a missing optional value. */
-    mpack_type_nil,         /**< A null value. */
-    mpack_type_bool,        /**< A boolean (true or false.) */
-    mpack_type_int,         /**< A 64-bit signed integer. */
-    mpack_type_uint,        /**< A 64-bit unsigned integer. */
-    mpack_type_float,       /**< A 32-bit IEEE 754 floating point number. */
-    mpack_type_double,      /**< A 64-bit IEEE 754 floating point number. */
-    mpack_type_str,         /**< A string. */
-    mpack_type_bin,         /**< A chunk of binary data. */
-    mpack_type_array,       /**< An array of MessagePack objects. */
-    mpack_type_map,         /**< An ordered map of key/value pairs of MessagePack objects. */
+    mpack_type_missing
+    = 0, /**< Special type indicating a missing optional value. */
+    mpack_type_nil, /**< A null value. */
+    mpack_type_bool, /**< A boolean (true or false.) */
+    mpack_type_int, /**< A 64-bit signed integer. */
+    mpack_type_uint, /**< A 64-bit unsigned integer. */
+    mpack_type_float, /**< A 32-bit IEEE 754 floating point number. */
+    mpack_type_double, /**< A 64-bit IEEE 754 floating point number. */
+    mpack_type_str, /**< A string. */
+    mpack_type_bin, /**< A chunk of binary data. */
+    mpack_type_array, /**< An array of MessagePack objects. */
+    mpack_type_map, /**< An ordered map of key/value pairs of MessagePack
+                       objects. */
 
-    #if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
     /**
      * A typed MessagePack extension object containing a chunk of binary data.
      *
      * @note This requires @ref MPACK_EXTENSIONS.
      */
     mpack_type_ext,
-    #endif
+#    endif
 } mpack_type_t;
 
 /**
  * Converts an MPack type to a string. This function returns an empty
  * string when MPACK_DEBUG is not set.
  */
-const char* mpack_type_to_string(mpack_type_t type);
+const char *mpack_type_to_string(mpack_type_t type);
 
-#if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
 /**
  * A timestamp.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
 typedef struct mpack_timestamp_t {
-    int64_t seconds; /*< The number of seconds (signed) since 1970-01-01T00:00:00Z. */
-    uint32_t nanoseconds; /*< The number of additional nanoseconds, between 0 and 999,999,999. */
+    int64_t seconds; /*< The number of seconds (signed) since
+                        1970-01-01T00:00:00Z. */
+    uint32_t nanoseconds; /*< The number of additional nanoseconds, between 0
+                             and 999,999,999. */
 } mpack_timestamp_t;
-#endif
+#    endif
 
 /**
  * An MPack tag is a MessagePack object header. It is a variant type
@@ -1446,17 +1434,18 @@ typedef struct mpack_tag_t mpack_tag_t;
 struct mpack_tag_t {
     mpack_type_t type; /*< The type of value. */
 
-    #if MPACK_EXTENSIONS
-    int8_t exttype; /*< The extension type if the type is @ref mpack_type_ext. */
-    #endif
+#    if MPACK_EXTENSIONS
+    int8_t
+        exttype; /*< The extension type if the type is @ref mpack_type_ext. */
+#    endif
 
     /* The value for non-compound types. */
     union {
         uint64_t u; /*< The value if the type is unsigned int. */
-        int64_t  i; /*< The value if the type is signed int. */
-        double   d; /*< The value if the type is double. */
-        float    f; /*< The value if the type is float. */
-        bool     b; /*< The value if the type is bool. */
+        int64_t i; /*< The value if the type is signed int. */
+        double d; /*< The value if the type is double. */
+        float f; /*< The value if the type is float. */
+        bool b; /*< The value if the type is bool. */
 
         /* The number of bytes if the type is str, bin or ext. */
         uint32_t l;
@@ -1481,21 +1470,31 @@ struct mpack_tag_t {
  * @warning This does not make the tag nil! The tag's type is invalid when
  * initialized this way. Use @ref mpack_tag_make_nil() to generate a nil tag.
  */
-#if MPACK_EXTENSIONS
-#define MPACK_TAG_ZERO {(mpack_type_t)0, 0, {0}}
-#else
-#define MPACK_TAG_ZERO {(mpack_type_t)0, {0}}
-#endif
+#    if MPACK_EXTENSIONS
+#        define MPACK_TAG_ZERO                                                 \
+            {                                                                  \
+                (mpack_type_t)0, 0, { 0 }                                      \
+            }
+#    else
+#        define MPACK_TAG_ZERO                                                 \
+            {                                                                  \
+                (mpack_type_t)0, { 0 }                                         \
+            }
+#    endif
 
 /** Generates a nil tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_nil(void) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_nil(void)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_nil;
     return ret;
 }
 
 /** Generates a bool tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_bool(bool value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_bool(bool value)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_bool;
     ret.v.b = value;
@@ -1503,7 +1502,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_bool(bool value) {
 }
 
 /** Generates a bool tag with value true. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_true(void) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_true(void)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_bool;
     ret.v.b = true;
@@ -1511,7 +1512,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_true(void) {
 }
 
 /** Generates a bool tag with value false. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_false(void) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_false(void)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_bool;
     ret.v.b = false;
@@ -1519,7 +1522,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_false(void) {
 }
 
 /** Generates a signed int tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_int(int64_t value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_int(int64_t value)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_int;
     ret.v.i = value;
@@ -1527,7 +1532,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_int(int64_t value) {
 }
 
 /** Generates an unsigned int tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_uint(uint64_t value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_uint(uint64_t value)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_uint;
     ret.v.u = value;
@@ -1535,7 +1542,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_uint(uint64_t value) {
 }
 
 /** Generates a float tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_float(float value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_float(float value)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_float;
     ret.v.f = value;
@@ -1543,7 +1552,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_float(float value) {
 }
 
 /** Generates a double tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_double(double value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_double(double value)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_double;
     ret.v.d = value;
@@ -1551,7 +1562,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_double(double value) {
 }
 
 /** Generates an array tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_array(uint32_t count) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_array(uint32_t count)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_array;
     ret.v.n = count;
@@ -1559,7 +1572,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_array(uint32_t count) {
 }
 
 /** Generates a map tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_map(uint32_t count) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_map(uint32_t count)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_map;
     ret.v.n = count;
@@ -1567,7 +1582,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_map(uint32_t count) {
 }
 
 /** Generates a str tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_str(uint32_t length) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_str(uint32_t length)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_str;
     ret.v.l = length;
@@ -1575,27 +1592,31 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_str(uint32_t length) {
 }
 
 /** Generates a bin tag. */
-MPACK_INLINE mpack_tag_t mpack_tag_make_bin(uint32_t length) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_bin(uint32_t length)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_bin;
     ret.v.l = length;
     return ret;
 }
 
-#if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
 /**
  * Generates an ext tag.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-MPACK_INLINE mpack_tag_t mpack_tag_make_ext(int8_t exttype, uint32_t length) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_make_ext(int8_t exttype, uint32_t length)
+{
     mpack_tag_t ret = MPACK_TAG_ZERO;
     ret.type = mpack_type_ext;
     ret.exttype = exttype;
     ret.v.l = length;
     return ret;
 }
-#endif
+#    endif
 
 /**
  * @}
@@ -1609,7 +1630,9 @@ MPACK_INLINE mpack_tag_t mpack_tag_make_ext(int8_t exttype, uint32_t length) {
 /**
  * Gets the type of a tag.
  */
-MPACK_INLINE mpack_type_t mpack_tag_type(mpack_tag_t* tag) {
+MPACK_INLINE mpack_type_t
+mpack_tag_type(mpack_tag_t *tag)
+{
     return tag->type;
 }
 
@@ -1620,7 +1643,9 @@ MPACK_INLINE mpack_type_t mpack_tag_type(mpack_tag_t* tag) {
  * This asserts that the type in the tag is @ref mpack_type_bool. (No check is
  * performed if MPACK_DEBUG is not set.)
  */
-MPACK_INLINE bool mpack_tag_bool_value(mpack_tag_t* tag) {
+MPACK_INLINE bool
+mpack_tag_bool_value(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_bool, "tag is not a bool!");
     return tag->v.b;
 }
@@ -1638,7 +1663,9 @@ MPACK_INLINE bool mpack_tag_bool_value(mpack_tag_t* tag) {
  *
  * @see mpack_type_int
  */
-MPACK_INLINE int64_t mpack_tag_int_value(mpack_tag_t* tag) {
+MPACK_INLINE int64_t
+mpack_tag_int_value(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_int, "tag is not an int!");
     return tag->v.i;
 }
@@ -1656,7 +1683,9 @@ MPACK_INLINE int64_t mpack_tag_int_value(mpack_tag_t* tag) {
  *
  * @see mpack_type_uint
  */
-MPACK_INLINE uint64_t mpack_tag_uint_value(mpack_tag_t* tag) {
+MPACK_INLINE uint64_t
+mpack_tag_uint_value(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_uint, "tag is not a uint!");
     return tag->v.u;
 }
@@ -1672,7 +1701,9 @@ MPACK_INLINE uint64_t mpack_tag_uint_value(mpack_tag_t* tag) {
  *
  * @see mpack_type_float
  */
-MPACK_INLINE float mpack_tag_float_value(mpack_tag_t* tag) {
+MPACK_INLINE float
+mpack_tag_float_value(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_float, "tag is not a float!");
     return tag->v.f;
 }
@@ -1688,7 +1719,9 @@ MPACK_INLINE float mpack_tag_float_value(mpack_tag_t* tag) {
  *
  * @see mpack_type_double
  */
-MPACK_INLINE double mpack_tag_double_value(mpack_tag_t* tag) {
+MPACK_INLINE double
+mpack_tag_double_value(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_double, "tag is not a double!");
     return tag->v.d;
 }
@@ -1701,7 +1734,9 @@ MPACK_INLINE double mpack_tag_double_value(mpack_tag_t* tag) {
  *
  * @see mpack_type_array
  */
-MPACK_INLINE uint32_t mpack_tag_array_count(mpack_tag_t* tag) {
+MPACK_INLINE uint32_t
+mpack_tag_array_count(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_array, "tag is not an array!");
     return tag->v.n;
 }
@@ -1714,7 +1749,9 @@ MPACK_INLINE uint32_t mpack_tag_array_count(mpack_tag_t* tag) {
  *
  * @see mpack_type_map
  */
-MPACK_INLINE uint32_t mpack_tag_map_count(mpack_tag_t* tag) {
+MPACK_INLINE uint32_t
+mpack_tag_map_count(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_map, "tag is not a map!");
     return tag->v.n;
 }
@@ -1727,7 +1764,9 @@ MPACK_INLINE uint32_t mpack_tag_map_count(mpack_tag_t* tag) {
  *
  * @see mpack_type_str
  */
-MPACK_INLINE uint32_t mpack_tag_str_length(mpack_tag_t* tag) {
+MPACK_INLINE uint32_t
+mpack_tag_str_length(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_str, "tag is not a str!");
     return tag->v.l;
 }
@@ -1740,12 +1779,14 @@ MPACK_INLINE uint32_t mpack_tag_str_length(mpack_tag_t* tag) {
  *
  * @see mpack_type_bin
  */
-MPACK_INLINE uint32_t mpack_tag_bin_length(mpack_tag_t* tag) {
+MPACK_INLINE uint32_t
+mpack_tag_bin_length(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_bin, "tag is not a bin!");
     return tag->v.l;
 }
 
-#if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
 /**
  * Gets the length in bytes of an ext-type tag.
  *
@@ -1756,7 +1797,9 @@ MPACK_INLINE uint32_t mpack_tag_bin_length(mpack_tag_t* tag) {
  *
  * @see mpack_type_ext
  */
-MPACK_INLINE uint32_t mpack_tag_ext_length(mpack_tag_t* tag) {
+MPACK_INLINE uint32_t
+mpack_tag_ext_length(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_ext, "tag is not an ext!");
     return tag->v.l;
 }
@@ -1771,11 +1814,13 @@ MPACK_INLINE uint32_t mpack_tag_ext_length(mpack_tag_t* tag) {
  *
  * @see mpack_type_ext
  */
-MPACK_INLINE int8_t mpack_tag_ext_exttype(mpack_tag_t* tag) {
+MPACK_INLINE int8_t
+mpack_tag_ext_exttype(mpack_tag_t *tag)
+{
     mpack_assert(tag->type == mpack_type_ext, "tag is not an ext!");
     return tag->exttype;
 }
-#endif
+#    endif
 
 /**
  * Gets the length in bytes of a str-, bin- or ext-type tag.
@@ -1788,14 +1833,17 @@ MPACK_INLINE int8_t mpack_tag_ext_exttype(mpack_tag_t* tag) {
  * @see mpack_type_bin
  * @see mpack_type_ext
  */
-MPACK_INLINE uint32_t mpack_tag_bytes(mpack_tag_t* tag) {
-    #if MPACK_EXTENSIONS
+MPACK_INLINE uint32_t
+mpack_tag_bytes(mpack_tag_t *tag)
+{
+#    if MPACK_EXTENSIONS
     mpack_assert(tag->type == mpack_type_str || tag->type == mpack_type_bin
-            || tag->type == mpack_type_ext, "tag is not a str, bin or ext!");
-    #else
+            || tag->type == mpack_type_ext,
+        "tag is not a str, bin or ext!");
+#    else
     mpack_assert(tag->type == mpack_type_str || tag->type == mpack_type_bin,
-            "tag is not a str or bin!");
-    #endif
+        "tag is not a str or bin!");
+#    endif
     return tag->v.l;
 }
 
@@ -1808,54 +1856,60 @@ MPACK_INLINE uint32_t mpack_tag_bytes(mpack_tag_t* tag) {
  * @{
  */
 
-#if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
 /**
  * The extension type for a timestamp.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-#define MPACK_EXTTYPE_TIMESTAMP ((int8_t)(-1))
-#endif
+#        define MPACK_EXTTYPE_TIMESTAMP ((int8_t)(-1))
+#    endif
 
 /**
  * Compares two tags with an arbitrary fixed ordering. Returns 0 if the tags are
  * equal, a negative integer if left comes before right, or a positive integer
  * otherwise.
  *
- * \warning The ordering is not guaranteed to be preserved across MPack versions; do
- * not rely on it in persistent data.
+ * \warning The ordering is not guaranteed to be preserved across MPack
+ * versions; do not rely on it in persistent data.
  *
- * \warning Floating point numbers are compared bit-for-bit, not using the language's
- * operator==. This means that NaNs with matching representation will compare equal.
- * This behaviour is up for debate; see comments in the definition of mpack_tag_cmp().
+ * \warning Floating point numbers are compared bit-for-bit, not using the
+ * language's operator==. This means that NaNs with matching representation will
+ * compare equal. This behaviour is up for debate; see comments in the
+ * definition of mpack_tag_cmp().
  *
  * See mpack_tag_equal() for more information on when tags are considered equal.
  */
 int mpack_tag_cmp(mpack_tag_t left, mpack_tag_t right);
 
 /**
- * Compares two tags for equality. Tags are considered equal if the types are compatible
- * and the values (for non-compound types) are equal.
+ * Compares two tags for equality. Tags are considered equal if the types are
+ * compatible and the values (for non-compound types) are equal.
  *
- * The field width of variable-width fields is ignored (and in fact is not stored
- * in a tag), and positive numbers in signed integers are considered equal to their
- * unsigned counterparts. So for example the value 1 stored as a positive fixint
- * is equal to the value 1 stored in a 64-bit unsigned integer field.
+ * The field width of variable-width fields is ignored (and in fact is not
+ * stored in a tag), and positive numbers in signed integers are considered
+ * equal to their unsigned counterparts. So for example the value 1 stored as a
+ * positive fixint is equal to the value 1 stored in a 64-bit unsigned integer
+ * field.
  *
  * The "extension type" of an extension object is considered part of the value
  * and must match exactly.
  *
- * \warning Floating point numbers are compared bit-for-bit, not using the language's
- * operator==. This means that NaNs with matching representation will compare equal.
- * This behaviour is up for debate; see comments in the definition of mpack_tag_cmp().
+ * \warning Floating point numbers are compared bit-for-bit, not using the
+ * language's operator==. This means that NaNs with matching representation will
+ * compare equal. This behaviour is up for debate; see comments in the
+ * definition of mpack_tag_cmp().
  */
-MPACK_INLINE bool mpack_tag_equal(mpack_tag_t left, mpack_tag_t right) {
+MPACK_INLINE bool
+mpack_tag_equal(mpack_tag_t left, mpack_tag_t right)
+{
     return mpack_tag_cmp(left, right) == 0;
 }
 
-#if MPACK_DEBUG && MPACK_STDIO
+#    if MPACK_DEBUG && MPACK_STDIO
 /**
- * Generates a json-like debug description of the given tag into the given buffer.
+ * Generates a json-like debug description of the given tag into the given
+ * buffer.
  *
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
@@ -1863,8 +1917,8 @@ MPACK_INLINE bool mpack_tag_equal(mpack_tag_t left, mpack_tag_t right) {
  * The prefix is used to print the first few hexadecimal bytes of a bin or ext
  * type. Pass NULL if not a bin or ext.
  */
-void mpack_tag_debug_pseudo_json(mpack_tag_t tag, char* buffer, size_t buffer_size,
-        const char* prefix, size_t prefix_size);
+void mpack_tag_debug_pseudo_json(mpack_tag_t tag, char *buffer,
+    size_t buffer_size, const char *prefix, size_t prefix_size);
 
 /**
  * Generates a debug string description of the given tag into the given buffer.
@@ -1872,7 +1926,8 @@ void mpack_tag_debug_pseudo_json(mpack_tag_t tag, char* buffer, size_t buffer_si
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-void mpack_tag_debug_describe(mpack_tag_t tag, char* buffer, size_t buffer_size);
+void mpack_tag_debug_describe(
+    mpack_tag_t tag, char *buffer, size_t buffer_size);
 
 /** @cond */
 
@@ -1881,31 +1936,34 @@ void mpack_tag_debug_describe(mpack_tag_t tag, char* buffer, size_t buffer_size)
  *
  * @see mpack_node_print_callback
  */
-typedef void (*mpack_print_callback_t)(void* context, const char* data, size_t count);
+typedef void (*mpack_print_callback_t)(
+    void *context, const char *data, size_t count);
 
 // helpers for printing debug output
 // i feel a bit like i'm re-implementing a buffered writer again...
 typedef struct mpack_print_t {
-    char* buffer;
+    char *buffer;
     size_t size;
     size_t count;
     mpack_print_callback_t callback;
-    void* context;
+    void *context;
 } mpack_print_t;
 
-void mpack_print_append(mpack_print_t* print, const char* data, size_t count);
+void mpack_print_append(mpack_print_t *print, const char *data, size_t count);
 
-MPACK_INLINE void mpack_print_append_cstr(mpack_print_t* print, const char* cstr) {
+MPACK_INLINE void
+mpack_print_append_cstr(mpack_print_t *print, const char *cstr)
+{
     mpack_print_append(print, cstr, mpack_strlen(cstr));
 }
 
-void mpack_print_flush(mpack_print_t* print);
+void mpack_print_flush(mpack_print_t *print);
 
-void mpack_print_file_callback(void* context, const char* data, size_t count);
+void mpack_print_file_callback(void *context, const char *data, size_t count);
 
 /** @endcond */
 
-#endif
+#    endif
 
 /**
  * @}
@@ -1927,71 +1985,97 @@ void mpack_print_file_callback(void* context, const char* data, size_t count);
  */
 
 /** \deprecated Renamed to mpack_tag_make_nil(). */
-MPACK_INLINE mpack_tag_t mpack_tag_nil(void) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_nil(void)
+{
     return mpack_tag_make_nil();
 }
 
 /** \deprecated Renamed to mpack_tag_make_bool(). */
-MPACK_INLINE mpack_tag_t mpack_tag_bool(bool value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_bool(bool value)
+{
     return mpack_tag_make_bool(value);
 }
 
 /** \deprecated Renamed to mpack_tag_make_true(). */
-MPACK_INLINE mpack_tag_t mpack_tag_true(void) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_true(void)
+{
     return mpack_tag_make_true();
 }
 
 /** \deprecated Renamed to mpack_tag_make_false(). */
-MPACK_INLINE mpack_tag_t mpack_tag_false(void) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_false(void)
+{
     return mpack_tag_make_false();
 }
 
 /** \deprecated Renamed to mpack_tag_make_int(). */
-MPACK_INLINE mpack_tag_t mpack_tag_int(int64_t value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_int(int64_t value)
+{
     return mpack_tag_make_int(value);
 }
 
 /** \deprecated Renamed to mpack_tag_make_uint(). */
-MPACK_INLINE mpack_tag_t mpack_tag_uint(uint64_t value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_uint(uint64_t value)
+{
     return mpack_tag_make_uint(value);
 }
 
 /** \deprecated Renamed to mpack_tag_make_float(). */
-MPACK_INLINE mpack_tag_t mpack_tag_float(float value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_float(float value)
+{
     return mpack_tag_make_float(value);
 }
 
 /** \deprecated Renamed to mpack_tag_make_double(). */
-MPACK_INLINE mpack_tag_t mpack_tag_double(double value) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_double(double value)
+{
     return mpack_tag_make_double(value);
 }
 
 /** \deprecated Renamed to mpack_tag_make_array(). */
-MPACK_INLINE mpack_tag_t mpack_tag_array(int32_t count) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_array(int32_t count)
+{
     return mpack_tag_make_array((uint32_t)count);
 }
 
 /** \deprecated Renamed to mpack_tag_make_map(). */
-MPACK_INLINE mpack_tag_t mpack_tag_map(int32_t count) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_map(int32_t count)
+{
     return mpack_tag_make_map((uint32_t)count);
 }
 
 /** \deprecated Renamed to mpack_tag_make_str(). */
-MPACK_INLINE mpack_tag_t mpack_tag_str(int32_t length) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_str(int32_t length)
+{
     return mpack_tag_make_str((uint32_t)length);
 }
 
 /** \deprecated Renamed to mpack_tag_make_bin(). */
-MPACK_INLINE mpack_tag_t mpack_tag_bin(int32_t length) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_bin(int32_t length)
+{
     return mpack_tag_make_bin((uint32_t)length);
 }
 
-#if MPACK_EXTENSIONS
+#    if MPACK_EXTENSIONS
 /** \deprecated Renamed to mpack_tag_make_ext(). */
-MPACK_INLINE mpack_tag_t mpack_tag_ext(int8_t exttype, int32_t length) {
+MPACK_INLINE mpack_tag_t
+mpack_tag_ext(int8_t exttype, int32_t length)
+{
     return mpack_tag_make_ext(exttype, (uint32_t)length);
 }
-#endif
+#    endif
 
 /**
  * @}
@@ -2008,109 +2092,154 @@ MPACK_INLINE mpack_tag_t mpack_tag_ext(int8_t exttype, int32_t length) {
  * use them for other purposes, but they are undocumented.
  */
 
-MPACK_INLINE uint8_t mpack_load_u8(const char* p) {
+MPACK_INLINE uint8_t
+mpack_load_u8(const char *p)
+{
     return (uint8_t)p[0];
 }
 
-MPACK_INLINE uint16_t mpack_load_u16(const char* p) {
-    #ifdef MPACK_NHSWAP16
+MPACK_INLINE uint16_t
+mpack_load_u16(const char *p)
+{
+#    ifdef MPACK_NHSWAP16
     uint16_t val;
     mpack_memcpy(&val, p, sizeof(val));
     return MPACK_NHSWAP16(val);
-    #else
-    return (uint16_t)((((uint16_t)(uint8_t)p[0]) << 8) |
-           ((uint16_t)(uint8_t)p[1]));
-    #endif
+#    else
+    return (uint16_t)(
+        (((uint16_t)(uint8_t)p[0]) << 8) | ((uint16_t)(uint8_t)p[1]));
+#    endif
 }
 
-MPACK_INLINE uint32_t mpack_load_u32(const char* p) {
-    #ifdef MPACK_NHSWAP32
+MPACK_INLINE uint32_t
+mpack_load_u32(const char *p)
+{
+#    ifdef MPACK_NHSWAP32
     uint32_t val;
     mpack_memcpy(&val, p, sizeof(val));
     return MPACK_NHSWAP32(val);
-    #else
-    return (((uint32_t)(uint8_t)p[0]) << 24) |
-           (((uint32_t)(uint8_t)p[1]) << 16) |
-           (((uint32_t)(uint8_t)p[2]) <<  8) |
-            ((uint32_t)(uint8_t)p[3]);
-    #endif
+#    else
+    return (((uint32_t)(uint8_t)p[0]) << 24) | (((uint32_t)(uint8_t)p[1]) << 16)
+        | (((uint32_t)(uint8_t)p[2]) << 8) | ((uint32_t)(uint8_t)p[3]);
+#    endif
 }
 
-MPACK_INLINE uint64_t mpack_load_u64(const char* p) {
-    #ifdef MPACK_NHSWAP64
+MPACK_INLINE uint64_t
+mpack_load_u64(const char *p)
+{
+#    ifdef MPACK_NHSWAP64
     uint64_t val;
     mpack_memcpy(&val, p, sizeof(val));
     return MPACK_NHSWAP64(val);
-    #else
-    return (((uint64_t)(uint8_t)p[0]) << 56) |
-           (((uint64_t)(uint8_t)p[1]) << 48) |
-           (((uint64_t)(uint8_t)p[2]) << 40) |
-           (((uint64_t)(uint8_t)p[3]) << 32) |
-           (((uint64_t)(uint8_t)p[4]) << 24) |
-           (((uint64_t)(uint8_t)p[5]) << 16) |
-           (((uint64_t)(uint8_t)p[6]) <<  8) |
-            ((uint64_t)(uint8_t)p[7]);
-    #endif
+#    else
+    return (((uint64_t)(uint8_t)p[0]) << 56) | (((uint64_t)(uint8_t)p[1]) << 48)
+        | (((uint64_t)(uint8_t)p[2]) << 40) | (((uint64_t)(uint8_t)p[3]) << 32)
+        | (((uint64_t)(uint8_t)p[4]) << 24) | (((uint64_t)(uint8_t)p[5]) << 16)
+        | (((uint64_t)(uint8_t)p[6]) << 8) | ((uint64_t)(uint8_t)p[7]);
+#    endif
 }
 
-MPACK_INLINE void mpack_store_u8(char* p, uint8_t val) {
-    uint8_t* u = (uint8_t*)p;
+MPACK_INLINE void
+mpack_store_u8(char *p, uint8_t val)
+{
+    uint8_t *u = (uint8_t *)p;
     u[0] = val;
 }
 
-MPACK_INLINE void mpack_store_u16(char* p, uint16_t val) {
-    #ifdef MPACK_NHSWAP16
+MPACK_INLINE void
+mpack_store_u16(char *p, uint16_t val)
+{
+#    ifdef MPACK_NHSWAP16
     val = MPACK_NHSWAP16(val);
     mpack_memcpy(p, &val, sizeof(val));
-    #else
-    uint8_t* u = (uint8_t*)p;
+#    else
+    uint8_t *u = (uint8_t *)p;
     u[0] = (uint8_t)((val >> 8) & 0xFF);
-    u[1] = (uint8_t)( val       & 0xFF);
-    #endif
+    u[1] = (uint8_t)(val & 0xFF);
+#    endif
 }
 
-MPACK_INLINE void mpack_store_u32(char* p, uint32_t val) {
-    #ifdef MPACK_NHSWAP32
+MPACK_INLINE void
+mpack_store_u32(char *p, uint32_t val)
+{
+#    ifdef MPACK_NHSWAP32
     val = MPACK_NHSWAP32(val);
     mpack_memcpy(p, &val, sizeof(val));
-    #else
-    uint8_t* u = (uint8_t*)p;
+#    else
+    uint8_t *u = (uint8_t *)p;
     u[0] = (uint8_t)((val >> 24) & 0xFF);
     u[1] = (uint8_t)((val >> 16) & 0xFF);
-    u[2] = (uint8_t)((val >>  8) & 0xFF);
-    u[3] = (uint8_t)( val        & 0xFF);
-    #endif
+    u[2] = (uint8_t)((val >> 8) & 0xFF);
+    u[3] = (uint8_t)(val & 0xFF);
+#    endif
 }
 
-MPACK_INLINE void mpack_store_u64(char* p, uint64_t val) {
-    #ifdef MPACK_NHSWAP64
+MPACK_INLINE void
+mpack_store_u64(char *p, uint64_t val)
+{
+#    ifdef MPACK_NHSWAP64
     val = MPACK_NHSWAP64(val);
     mpack_memcpy(p, &val, sizeof(val));
-    #else
-    uint8_t* u = (uint8_t*)p;
+#    else
+    uint8_t *u = (uint8_t *)p;
     u[0] = (uint8_t)((val >> 56) & 0xFF);
     u[1] = (uint8_t)((val >> 48) & 0xFF);
     u[2] = (uint8_t)((val >> 40) & 0xFF);
     u[3] = (uint8_t)((val >> 32) & 0xFF);
     u[4] = (uint8_t)((val >> 24) & 0xFF);
     u[5] = (uint8_t)((val >> 16) & 0xFF);
-    u[6] = (uint8_t)((val >>  8) & 0xFF);
-    u[7] = (uint8_t)( val        & 0xFF);
-    #endif
+    u[6] = (uint8_t)((val >> 8) & 0xFF);
+    u[7] = (uint8_t)(val & 0xFF);
+#    endif
 }
 
-MPACK_INLINE int8_t  mpack_load_i8 (const char* p) {return (int8_t) mpack_load_u8 (p);}
-MPACK_INLINE int16_t mpack_load_i16(const char* p) {return (int16_t)mpack_load_u16(p);}
-MPACK_INLINE int32_t mpack_load_i32(const char* p) {return (int32_t)mpack_load_u32(p);}
-MPACK_INLINE int64_t mpack_load_i64(const char* p) {return (int64_t)mpack_load_u64(p);}
-MPACK_INLINE void mpack_store_i8 (char* p, int8_t  val) {mpack_store_u8 (p, (uint8_t) val);}
-MPACK_INLINE void mpack_store_i16(char* p, int16_t val) {mpack_store_u16(p, (uint16_t)val);}
-MPACK_INLINE void mpack_store_i32(char* p, int32_t val) {mpack_store_u32(p, (uint32_t)val);}
-MPACK_INLINE void mpack_store_i64(char* p, int64_t val) {mpack_store_u64(p, (uint64_t)val);}
+MPACK_INLINE int8_t
+mpack_load_i8(const char *p)
+{
+    return (int8_t)mpack_load_u8(p);
+}
+MPACK_INLINE int16_t
+mpack_load_i16(const char *p)
+{
+    return (int16_t)mpack_load_u16(p);
+}
+MPACK_INLINE int32_t
+mpack_load_i32(const char *p)
+{
+    return (int32_t)mpack_load_u32(p);
+}
+MPACK_INLINE int64_t
+mpack_load_i64(const char *p)
+{
+    return (int64_t)mpack_load_u64(p);
+}
+MPACK_INLINE void
+mpack_store_i8(char *p, int8_t val)
+{
+    mpack_store_u8(p, (uint8_t)val);
+}
+MPACK_INLINE void
+mpack_store_i16(char *p, int16_t val)
+{
+    mpack_store_u16(p, (uint16_t)val);
+}
+MPACK_INLINE void
+mpack_store_i32(char *p, int32_t val)
+{
+    mpack_store_u32(p, (uint32_t)val);
+}
+MPACK_INLINE void
+mpack_store_i64(char *p, int64_t val)
+{
+    mpack_store_u64(p, (uint64_t)val);
+}
 
-MPACK_INLINE float mpack_load_float(const char* p) {
+MPACK_INLINE float
+mpack_load_float(const char *p)
+{
     MPACK_CHECK_FLOAT_ORDER();
-    MPACK_STATIC_ASSERT(sizeof(float) == sizeof(uint32_t), "float is wrong size??");
+    MPACK_STATIC_ASSERT(
+        sizeof(float) == sizeof(uint32_t), "float is wrong size??");
     union {
         float f;
         uint32_t u;
@@ -2119,9 +2248,12 @@ MPACK_INLINE float mpack_load_float(const char* p) {
     return v.f;
 }
 
-MPACK_INLINE double mpack_load_double(const char* p) {
+MPACK_INLINE double
+mpack_load_double(const char *p)
+{
     MPACK_CHECK_FLOAT_ORDER();
-    MPACK_STATIC_ASSERT(sizeof(double) == sizeof(uint64_t), "double is wrong size??");
+    MPACK_STATIC_ASSERT(
+        sizeof(double) == sizeof(uint64_t), "double is wrong size??");
     union {
         double d;
         uint64_t u;
@@ -2130,7 +2262,9 @@ MPACK_INLINE double mpack_load_double(const char* p) {
     return v.d;
 }
 
-MPACK_INLINE void mpack_store_float(char* p, float value) {
+MPACK_INLINE void
+mpack_store_float(char *p, float value)
+{
     MPACK_CHECK_FLOAT_ORDER();
     union {
         float f;
@@ -2140,7 +2274,9 @@ MPACK_INLINE void mpack_store_float(char* p, float value) {
     mpack_store_u32(p, v.u);
 }
 
-MPACK_INLINE void mpack_store_double(char* p, double value) {
+MPACK_INLINE void
+mpack_store_double(char *p, double value)
+{
     MPACK_CHECK_FLOAT_ORDER();
     union {
         double d;
@@ -2152,116 +2288,109 @@ MPACK_INLINE void mpack_store_double(char* p, double value) {
 
 /** @endcond */
 
-
-
 /** @cond */
 
 // Sizes in bytes for the various possible tags
-#define MPACK_TAG_SIZE_FIXUINT  1
-#define MPACK_TAG_SIZE_U8       2
-#define MPACK_TAG_SIZE_U16      3
-#define MPACK_TAG_SIZE_U32      5
-#define MPACK_TAG_SIZE_U64      9
-#define MPACK_TAG_SIZE_FIXINT   1
-#define MPACK_TAG_SIZE_I8       2
-#define MPACK_TAG_SIZE_I16      3
-#define MPACK_TAG_SIZE_I32      5
-#define MPACK_TAG_SIZE_I64      9
-#define MPACK_TAG_SIZE_FLOAT    5
-#define MPACK_TAG_SIZE_DOUBLE   9
-#define MPACK_TAG_SIZE_FIXARRAY 1
-#define MPACK_TAG_SIZE_ARRAY16  3
-#define MPACK_TAG_SIZE_ARRAY32  5
-#define MPACK_TAG_SIZE_FIXMAP   1
-#define MPACK_TAG_SIZE_MAP16    3
-#define MPACK_TAG_SIZE_MAP32    5
-#define MPACK_TAG_SIZE_FIXSTR   1
-#define MPACK_TAG_SIZE_STR8     2
-#define MPACK_TAG_SIZE_STR16    3
-#define MPACK_TAG_SIZE_STR32    5
-#define MPACK_TAG_SIZE_BIN8     2
-#define MPACK_TAG_SIZE_BIN16    3
-#define MPACK_TAG_SIZE_BIN32    5
-#define MPACK_TAG_SIZE_FIXEXT1  2
-#define MPACK_TAG_SIZE_FIXEXT2  2
-#define MPACK_TAG_SIZE_FIXEXT4  2
-#define MPACK_TAG_SIZE_FIXEXT8  2
-#define MPACK_TAG_SIZE_FIXEXT16 2
-#define MPACK_TAG_SIZE_EXT8     3
-#define MPACK_TAG_SIZE_EXT16    4
-#define MPACK_TAG_SIZE_EXT32    6
+#    define MPACK_TAG_SIZE_FIXUINT 1
+#    define MPACK_TAG_SIZE_U8 2
+#    define MPACK_TAG_SIZE_U16 3
+#    define MPACK_TAG_SIZE_U32 5
+#    define MPACK_TAG_SIZE_U64 9
+#    define MPACK_TAG_SIZE_FIXINT 1
+#    define MPACK_TAG_SIZE_I8 2
+#    define MPACK_TAG_SIZE_I16 3
+#    define MPACK_TAG_SIZE_I32 5
+#    define MPACK_TAG_SIZE_I64 9
+#    define MPACK_TAG_SIZE_FLOAT 5
+#    define MPACK_TAG_SIZE_DOUBLE 9
+#    define MPACK_TAG_SIZE_FIXARRAY 1
+#    define MPACK_TAG_SIZE_ARRAY16 3
+#    define MPACK_TAG_SIZE_ARRAY32 5
+#    define MPACK_TAG_SIZE_FIXMAP 1
+#    define MPACK_TAG_SIZE_MAP16 3
+#    define MPACK_TAG_SIZE_MAP32 5
+#    define MPACK_TAG_SIZE_FIXSTR 1
+#    define MPACK_TAG_SIZE_STR8 2
+#    define MPACK_TAG_SIZE_STR16 3
+#    define MPACK_TAG_SIZE_STR32 5
+#    define MPACK_TAG_SIZE_BIN8 2
+#    define MPACK_TAG_SIZE_BIN16 3
+#    define MPACK_TAG_SIZE_BIN32 5
+#    define MPACK_TAG_SIZE_FIXEXT1 2
+#    define MPACK_TAG_SIZE_FIXEXT2 2
+#    define MPACK_TAG_SIZE_FIXEXT4 2
+#    define MPACK_TAG_SIZE_FIXEXT8 2
+#    define MPACK_TAG_SIZE_FIXEXT16 2
+#    define MPACK_TAG_SIZE_EXT8 3
+#    define MPACK_TAG_SIZE_EXT16 4
+#    define MPACK_TAG_SIZE_EXT32 6
 
 // size in bytes for complete ext types
-#define MPACK_EXT_SIZE_TIMESTAMP4 (MPACK_TAG_SIZE_FIXEXT4 + 4)
-#define MPACK_EXT_SIZE_TIMESTAMP8 (MPACK_TAG_SIZE_FIXEXT8 + 8)
-#define MPACK_EXT_SIZE_TIMESTAMP12 (MPACK_TAG_SIZE_EXT8 + 12)
+#    define MPACK_EXT_SIZE_TIMESTAMP4 (MPACK_TAG_SIZE_FIXEXT4 + 4)
+#    define MPACK_EXT_SIZE_TIMESTAMP8 (MPACK_TAG_SIZE_FIXEXT8 + 8)
+#    define MPACK_EXT_SIZE_TIMESTAMP12 (MPACK_TAG_SIZE_EXT8 + 12)
 
 /** @endcond */
 
-
-
-#if MPACK_READ_TRACKING || MPACK_WRITE_TRACKING
+#    if MPACK_READ_TRACKING || MPACK_WRITE_TRACKING
 /* Tracks the write state of compound elements (maps, arrays, */
 /* strings, binary blobs and extension types) */
 /** @cond */
 
 typedef struct mpack_track_element_t {
     mpack_type_t type;
-    uint64_t left; // we need 64-bit because (2 * INT32_MAX) elements can be stored in a map
+    uint64_t left; // we need 64-bit because (2 * INT32_MAX) elements can be
+                   // stored in a map
 } mpack_track_element_t;
 
 typedef struct mpack_track_t {
     size_t count;
     size_t capacity;
-    mpack_track_element_t* elements;
+    mpack_track_element_t *elements;
 } mpack_track_t;
 
-#if MPACK_INTERNAL
-mpack_error_t mpack_track_init(mpack_track_t* track);
-mpack_error_t mpack_track_grow(mpack_track_t* track);
-mpack_error_t mpack_track_push(mpack_track_t* track, mpack_type_t type, uint64_t count);
-mpack_error_t mpack_track_pop(mpack_track_t* track, mpack_type_t type);
-mpack_error_t mpack_track_element(mpack_track_t* track, bool read);
-mpack_error_t mpack_track_peek_element(mpack_track_t* track, bool read);
-mpack_error_t mpack_track_bytes(mpack_track_t* track, bool read, uint64_t count);
-mpack_error_t mpack_track_str_bytes_all(mpack_track_t* track, bool read, uint64_t count);
-mpack_error_t mpack_track_check_empty(mpack_track_t* track);
-mpack_error_t mpack_track_destroy(mpack_track_t* track, bool cancel);
-#endif
+#        if MPACK_INTERNAL
+mpack_error_t mpack_track_init(mpack_track_t *track);
+mpack_error_t mpack_track_grow(mpack_track_t *track);
+mpack_error_t mpack_track_push(
+    mpack_track_t *track, mpack_type_t type, uint64_t count);
+mpack_error_t mpack_track_pop(mpack_track_t *track, mpack_type_t type);
+mpack_error_t mpack_track_element(mpack_track_t *track, bool read);
+mpack_error_t mpack_track_peek_element(mpack_track_t *track, bool read);
+mpack_error_t mpack_track_bytes(
+    mpack_track_t *track, bool read, uint64_t count);
+mpack_error_t mpack_track_str_bytes_all(
+    mpack_track_t *track, bool read, uint64_t count);
+mpack_error_t mpack_track_check_empty(mpack_track_t *track);
+mpack_error_t mpack_track_destroy(mpack_track_t *track, bool cancel);
+#        endif
 
 /** @endcond */
-#endif
+#    endif
 
-
-
-#if MPACK_INTERNAL
+#    if MPACK_INTERNAL
 /** @cond */
-
-
 
 /* Miscellaneous string functions */
 
 /**
  * Returns true if the given UTF-8 string is valid.
  */
-bool mpack_utf8_check(const char* str, size_t bytes);
+bool mpack_utf8_check(const char *str, size_t bytes);
 
 /**
- * Returns true if the given UTF-8 string is valid and contains no null characters.
+ * Returns true if the given UTF-8 string is valid and contains no null
+ * characters.
  */
-bool mpack_utf8_check_no_null(const char* str, size_t bytes);
+bool mpack_utf8_check_no_null(const char *str, size_t bytes);
 
 /**
  * Returns true if the given string has no null bytes.
  */
-bool mpack_str_check_no_null(const char* str, size_t bytes);
-
-
+bool mpack_str_check_no_null(const char *str, size_t bytes);
 
 /** @endcond */
-#endif
-
-
+#    endif
 
 /**
  * @}
@@ -2275,7 +2404,6 @@ MPACK_HEADER_END
 
 #endif
 
-
 /* mpack/mpack-writer.h.h */
 
 /**
@@ -2285,22 +2413,23 @@ MPACK_HEADER_END
  */
 
 #ifndef MPACK_WRITER_H
-#define MPACK_WRITER_H 1
+#    define MPACK_WRITER_H 1
 
 /* #include "mpack-common.h" */
 
 MPACK_HEADER_START
 
-#if MPACK_WRITER
+#    if MPACK_WRITER
 
-#if MPACK_WRITE_TRACKING
+#        if MPACK_WRITE_TRACKING
 struct mpack_track_t;
-#endif
+#        endif
 
 /**
  * @defgroup writer Write API
  *
- * The MPack Write API encodes structured data of a fixed (hardcoded) schema to MessagePack.
+ * The MPack Write API encodes structured data of a fixed (hardcoded) schema to
+ * MessagePack.
  *
  * @{
  */
@@ -2310,7 +2439,7 @@ struct mpack_track_t;
  *
  * The minimum buffer size for a writer with a flush function.
  */
-#define MPACK_WRITER_MINIMUM_BUFFER_SIZE 32
+#        define MPACK_WRITER_MINIMUM_BUFFER_SIZE 32
 
 /**
  * A buffered MessagePack encoder.
@@ -2330,7 +2459,8 @@ typedef struct mpack_writer_t mpack_writer_t;
  *
  * The specified context for callbacks is at writer->context.
  */
-typedef void (*mpack_writer_flush_t)(mpack_writer_t* writer, const char* buffer, size_t count);
+typedef void (*mpack_writer_flush_t)(
+    mpack_writer_t *writer, const char *buffer, size_t count);
 
 /**
  * An error handler function to be called when an error is flagged on
@@ -2356,64 +2486,77 @@ typedef void (*mpack_writer_flush_t)(mpack_writer_t* writer, const char* buffer,
  * that the writer is destroyed since any future accesses to it cause
  * undefined behavior.
  */
-typedef void (*mpack_writer_error_t)(mpack_writer_t* writer, mpack_error_t error);
+typedef void (*mpack_writer_error_t)(
+    mpack_writer_t *writer, mpack_error_t error);
 
 /**
  * A teardown function to be called when the writer is destroyed.
  */
-typedef void (*mpack_writer_teardown_t)(mpack_writer_t* writer);
+typedef void (*mpack_writer_teardown_t)(mpack_writer_t *writer);
 
 /* Hide internals from documentation */
 /** @cond */
 
 struct mpack_writer_t {
-    #if MPACK_COMPATIBILITY
-    mpack_version_t version;          /* Version of the MessagePack spec to write */
-    #endif
-    mpack_writer_flush_t flush;       /* Function to write bytes to the output stream */
-    mpack_writer_error_t error_fn;    /* Function to call on error */
-    mpack_writer_teardown_t teardown; /* Function to teardown the context on destroy */
-    void* context;                    /* Context for writer callbacks */
+#        if MPACK_COMPATIBILITY
+    mpack_version_t version; /* Version of the MessagePack spec to write */
+#        endif
+    mpack_writer_flush_t
+        flush; /* Function to write bytes to the output stream */
+    mpack_writer_error_t error_fn; /* Function to call on error */
+    mpack_writer_teardown_t
+        teardown; /* Function to teardown the context on destroy */
+    void *context; /* Context for writer callbacks */
 
-    char* buffer;         /* Byte buffer */
-    char* current;        /* Current position within the buffer */
-    char* end;            /* The end of the buffer */
-    mpack_error_t error;  /* Error state */
+    char *buffer; /* Byte buffer */
+    char *current; /* Current position within the buffer */
+    char *end; /* The end of the buffer */
+    mpack_error_t error; /* Error state */
 
-    #if MPACK_WRITE_TRACKING
+#        if MPACK_WRITE_TRACKING
     mpack_track_t track; /* Stack of map/array/str/bin/ext writes */
-    #endif
+#        endif
 
-    #ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
     /* Reserved. You can use this space to allocate a custom
      * context in order to reduce heap allocations. */
-    void* reserved[2];
-    #endif
+    void *reserved[2];
+#        endif
 };
 
-#if MPACK_WRITE_TRACKING
-void mpack_writer_track_push(mpack_writer_t* writer, mpack_type_t type, uint64_t count);
-void mpack_writer_track_pop(mpack_writer_t* writer, mpack_type_t type);
-void mpack_writer_track_element(mpack_writer_t* writer);
-void mpack_writer_track_bytes(mpack_writer_t* writer, size_t count);
-#else
-MPACK_INLINE void mpack_writer_track_push(mpack_writer_t* writer, mpack_type_t type, uint64_t count) {
+#        if MPACK_WRITE_TRACKING
+void mpack_writer_track_push(
+    mpack_writer_t *writer, mpack_type_t type, uint64_t count);
+void mpack_writer_track_pop(mpack_writer_t *writer, mpack_type_t type);
+void mpack_writer_track_element(mpack_writer_t *writer);
+void mpack_writer_track_bytes(mpack_writer_t *writer, size_t count);
+#        else
+MPACK_INLINE void
+mpack_writer_track_push(
+    mpack_writer_t *writer, mpack_type_t type, uint64_t count)
+{
     MPACK_UNUSED(writer);
     MPACK_UNUSED(type);
     MPACK_UNUSED(count);
 }
-MPACK_INLINE void mpack_writer_track_pop(mpack_writer_t* writer, mpack_type_t type) {
+MPACK_INLINE void
+mpack_writer_track_pop(mpack_writer_t *writer, mpack_type_t type)
+{
     MPACK_UNUSED(writer);
     MPACK_UNUSED(type);
 }
-MPACK_INLINE void mpack_writer_track_element(mpack_writer_t* writer) {
+MPACK_INLINE void
+mpack_writer_track_element(mpack_writer_t *writer)
+{
     MPACK_UNUSED(writer);
 }
-MPACK_INLINE void mpack_writer_track_bytes(mpack_writer_t* writer, size_t count) {
+MPACK_INLINE void
+mpack_writer_track_bytes(mpack_writer_t *writer, size_t count)
+{
     MPACK_UNUSED(writer);
     MPACK_UNUSED(count);
 }
-#endif
+#        endif
 
 /** @endcond */
 
@@ -2435,9 +2578,9 @@ MPACK_INLINE void mpack_writer_track_bytes(mpack_writer_t* writer, size_t count)
  * @param buffer The buffer into which to write MessagePack data.
  * @param size The size of the buffer.
  */
-void mpack_writer_init(mpack_writer_t* writer, char* buffer, size_t size);
+void mpack_writer_init(mpack_writer_t *writer, char *buffer, size_t size);
 
-#ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
 /**
  * Initializes an MPack writer using a growable buffer.
  *
@@ -2455,30 +2598,33 @@ void mpack_writer_init(mpack_writer_t* writer, char* buffer, size_t size);
  * @param data Where to place the allocated data.
  * @param size Where to write the size of the data.
  */
-void mpack_writer_init_growable(mpack_writer_t* writer, char** data, size_t* size);
-#endif
+void mpack_writer_init_growable(
+    mpack_writer_t *writer, char **data, size_t *size);
+#        endif
 
 /**
  * Initializes an MPack writer directly into an error state. Use this if you
  * are writing a wrapper to mpack_writer_init() which can fail its setup.
  */
-void mpack_writer_init_error(mpack_writer_t* writer, mpack_error_t error);
+void mpack_writer_init_error(mpack_writer_t *writer, mpack_error_t error);
 
-#if MPACK_STDIO
+#        if MPACK_STDIO
 /**
  * Initializes an MPack writer that writes to a file.
  *
  * @throws mpack_error_memory if allocation fails
  * @throws mpack_error_io if the file cannot be opened
  */
-void mpack_writer_init_filename(mpack_writer_t* writer, const char* filename);
+void mpack_writer_init_filename(mpack_writer_t *writer, const char *filename);
 
 /**
  * Deprecated.
  *
  * \deprecated Renamed to mpack_writer_init_filename().
  */
-MPACK_INLINE void mpack_writer_init_file(mpack_writer_t* writer, const char* filename) {
+MPACK_INLINE void
+mpack_writer_init_file(mpack_writer_t *writer, const char *filename)
+{
     mpack_writer_init_filename(writer, filename);
 }
 
@@ -2497,17 +2643,19 @@ MPACK_INLINE void mpack_writer_init_file(mpack_writer_t* writer, const char* fil
  *
  * @see mpack_writer_flush_message
  */
-void mpack_writer_init_stdfile(mpack_writer_t* writer, FILE* stdfile, bool close_when_done);
-#endif
+void mpack_writer_init_stdfile(
+    mpack_writer_t *writer, FILE *stdfile, bool close_when_done);
+#        endif
 
 /** @cond */
 
-#define mpack_writer_init_stack_line_ex(line, writer) \
-    char mpack_buf_##line[MPACK_STACK_SIZE]; \
-    mpack_writer_init(writer, mpack_buf_##line, sizeof(mpack_buf_##line))
+#        define mpack_writer_init_stack_line_ex(line, writer)                  \
+            char mpack_buf_##line[MPACK_STACK_SIZE];                           \
+            mpack_writer_init(                                                 \
+                writer, mpack_buf_##line, sizeof(mpack_buf_##line))
 
-#define mpack_writer_init_stack_line(line, writer) \
-    mpack_writer_init_stack_line_ex(line, writer)
+#        define mpack_writer_init_stack_line(line, writer)                     \
+            mpack_writer_init_stack_line_ex(line, writer)
 
 /*
  * Initializes an MPack writer using stack space as a buffer. A flush function
@@ -2516,8 +2664,8 @@ void mpack_writer_init_stdfile(mpack_writer_t* writer, FILE* stdfile, bool close
  * This is currently undocumented since it's not entirely useful on its own.
  */
 
-#define mpack_writer_init_stack(writer) \
-    mpack_writer_init_stack_line(__LINE__, (writer))
+#        define mpack_writer_init_stack(writer)                                \
+            mpack_writer_init_stack_line(__LINE__, (writer))
 
 /** @endcond */
 
@@ -2547,7 +2695,7 @@ void mpack_writer_init_stdfile(mpack_writer_t* writer, FILE* stdfile, bool close
  * @see mpack_writer_flag_error
  * @see mpack_error_data
  */
-mpack_error_t mpack_writer_destroy(mpack_writer_t* writer);
+mpack_error_t mpack_writer_destroy(mpack_writer_t *writer);
 
 /**
  * @}
@@ -2558,7 +2706,7 @@ mpack_error_t mpack_writer_destroy(mpack_writer_t* writer);
  * @{
  */
 
-#if MPACK_COMPATIBILITY
+#        if MPACK_COMPATIBILITY
 /**
  * Sets the version of the MessagePack spec that will be generated.
  *
@@ -2567,10 +2715,12 @@ mpack_error_t mpack_writer_destroy(mpack_writer_t* writer);
  *
  * @note This requires @ref MPACK_COMPATIBILITY.
  */
-MPACK_INLINE void mpack_writer_set_version(mpack_writer_t* writer, mpack_version_t version) {
+MPACK_INLINE void
+mpack_writer_set_version(mpack_writer_t *writer, mpack_version_t version)
+{
     writer->version = version;
 }
-#endif
+#        endif
 
 /**
  * Sets the custom pointer to pass to the writer callbacks, such as flush
@@ -2581,7 +2731,9 @@ MPACK_INLINE void mpack_writer_set_version(mpack_writer_t* writer, mpack_version
  *
  * @see mpack_writer_context()
  */
-MPACK_INLINE void mpack_writer_set_context(mpack_writer_t* writer, void* context) {
+MPACK_INLINE void
+mpack_writer_set_context(mpack_writer_t *writer, void *context)
+{
     writer->context = context;
 }
 
@@ -2591,7 +2743,9 @@ MPACK_INLINE void mpack_writer_set_context(mpack_writer_t* writer, void* context
  * @see mpack_writer_set_context
  * @see mpack_writer_set_flush
  */
-MPACK_INLINE void* mpack_writer_context(mpack_writer_t* writer) {
+MPACK_INLINE void *
+mpack_writer_context(mpack_writer_t *writer)
+{
     return writer->context;
 }
 
@@ -2609,7 +2763,7 @@ MPACK_INLINE void* mpack_writer_context(mpack_writer_t* writer) {
  *
  * @see mpack_writer_context()
  */
-void mpack_writer_set_flush(mpack_writer_t* writer, mpack_writer_flush_t flush);
+void mpack_writer_set_flush(mpack_writer_t *writer, mpack_writer_flush_t flush);
 
 /**
  * Sets the error function to call when an error is flagged on the writer.
@@ -2624,7 +2778,10 @@ void mpack_writer_set_flush(mpack_writer_t* writer, mpack_writer_flush_t flush);
  * @param writer The MPack writer.
  * @param error_fn The function to call when an error is flagged on the writer.
  */
-MPACK_INLINE void mpack_writer_set_error_handler(mpack_writer_t* writer, mpack_writer_error_t error_fn) {
+MPACK_INLINE void
+mpack_writer_set_error_handler(
+    mpack_writer_t *writer, mpack_writer_error_t error_fn)
+{
     writer->error_fn = error_fn;
 }
 
@@ -2637,7 +2794,10 @@ MPACK_INLINE void mpack_writer_set_error_handler(mpack_writer_t* writer, mpack_w
  * @param writer The MPack writer.
  * @param teardown The function to call when the writer is destroyed.
  */
-MPACK_INLINE void mpack_writer_set_teardown(mpack_writer_t* writer, mpack_writer_teardown_t teardown) {
+MPACK_INLINE void
+mpack_writer_set_teardown(
+    mpack_writer_t *writer, mpack_writer_teardown_t teardown)
+{
     writer->teardown = teardown;
 }
 
@@ -2668,14 +2828,16 @@ MPACK_INLINE void mpack_writer_set_teardown(mpack_writer_t* writer, mpack_writer
  *
  * This will assert if no flush function is assigned to the writer.
  */
-void mpack_writer_flush_message(mpack_writer_t* writer);
+void mpack_writer_flush_message(mpack_writer_t *writer);
 
 /**
  * Returns the number of bytes currently stored in the buffer. This
  * may be less than the total number of bytes written if bytes have
  * been flushed to an underlying stream.
  */
-MPACK_INLINE size_t mpack_writer_buffer_used(mpack_writer_t* writer) {
+MPACK_INLINE size_t
+mpack_writer_buffer_used(mpack_writer_t *writer)
+{
     return (size_t)(writer->current - writer->buffer);
 }
 
@@ -2683,7 +2845,9 @@ MPACK_INLINE size_t mpack_writer_buffer_used(mpack_writer_t* writer) {
  * Returns the amount of space left in the buffer. This may be reset
  * after a write if bytes are flushed to an underlying stream.
  */
-MPACK_INLINE size_t mpack_writer_buffer_left(mpack_writer_t* writer) {
+MPACK_INLINE size_t
+mpack_writer_buffer_left(mpack_writer_t *writer)
+{
     return (size_t)(writer->end - writer->current);
 }
 
@@ -2691,7 +2855,9 @@ MPACK_INLINE size_t mpack_writer_buffer_left(mpack_writer_t* writer) {
  * Returns the (current) size of the buffer. This may change after a write if
  * the flush callback changes the buffer.
  */
-MPACK_INLINE size_t mpack_writer_buffer_size(mpack_writer_t* writer) {
+MPACK_INLINE size_t
+mpack_writer_buffer_size(mpack_writer_t *writer)
+{
     return (size_t)(writer->end - writer->buffer);
 }
 
@@ -2711,7 +2877,7 @@ MPACK_INLINE size_t mpack_writer_buffer_size(mpack_writer_t* writer) {
  * @see mpack_writer_destroy
  * @see mpack_error_data
  */
-void mpack_writer_flag_error(mpack_writer_t* writer, mpack_error_t error);
+void mpack_writer_flag_error(mpack_writer_t *writer, mpack_error_t error);
 
 /**
  * Queries the error state of the MPack writer.
@@ -2719,7 +2885,9 @@ void mpack_writer_flag_error(mpack_writer_t* writer, mpack_error_t error);
  * If a writer is in an error state, you should discard all data since the
  * last time the error flag was checked. The error flag cannot be cleared.
  */
-MPACK_INLINE mpack_error_t mpack_writer_error(mpack_writer_t* writer) {
+MPACK_INLINE mpack_error_t
+mpack_writer_error(mpack_writer_t *writer)
+{
     return writer->error;
 }
 
@@ -2739,7 +2907,7 @@ MPACK_INLINE mpack_error_t mpack_writer_error(mpack_writer_t* writer) {
  * @see mpack_finish_ext()
  * @see mpack_finish_type()
  */
-void mpack_write_tag(mpack_writer_t* writer, mpack_tag_t tag);
+void mpack_write_tag(mpack_writer_t *writer, mpack_tag_t tag);
 
 /**
  * @}
@@ -2751,36 +2919,43 @@ void mpack_write_tag(mpack_writer_t* writer, mpack_tag_t tag);
  */
 
 /** Writes an 8-bit integer in the most efficient packing available. */
-void mpack_write_i8(mpack_writer_t* writer, int8_t value);
+void mpack_write_i8(mpack_writer_t *writer, int8_t value);
 
 /** Writes a 16-bit integer in the most efficient packing available. */
-void mpack_write_i16(mpack_writer_t* writer, int16_t value);
+void mpack_write_i16(mpack_writer_t *writer, int16_t value);
 
 /** Writes a 32-bit integer in the most efficient packing available. */
-void mpack_write_i32(mpack_writer_t* writer, int32_t value);
+void mpack_write_i32(mpack_writer_t *writer, int32_t value);
 
 /** Writes a 64-bit integer in the most efficient packing available. */
-void mpack_write_i64(mpack_writer_t* writer, int64_t value);
+void mpack_write_i64(mpack_writer_t *writer, int64_t value);
 
 /** Writes an integer in the most efficient packing available. */
-MPACK_INLINE void mpack_write_int(mpack_writer_t* writer, int64_t value) {
+MPACK_INLINE void
+mpack_write_int(mpack_writer_t *writer, int64_t value)
+{
     mpack_write_i64(writer, value);
 }
 
 /** Writes an 8-bit unsigned integer in the most efficient packing available. */
-void mpack_write_u8(mpack_writer_t* writer, uint8_t value);
+void mpack_write_u8(mpack_writer_t *writer, uint8_t value);
 
-/** Writes an 16-bit unsigned integer in the most efficient packing available. */
-void mpack_write_u16(mpack_writer_t* writer, uint16_t value);
+/** Writes an 16-bit unsigned integer in the most efficient packing available.
+ */
+void mpack_write_u16(mpack_writer_t *writer, uint16_t value);
 
-/** Writes an 32-bit unsigned integer in the most efficient packing available. */
-void mpack_write_u32(mpack_writer_t* writer, uint32_t value);
+/** Writes an 32-bit unsigned integer in the most efficient packing available.
+ */
+void mpack_write_u32(mpack_writer_t *writer, uint32_t value);
 
-/** Writes an 64-bit unsigned integer in the most efficient packing available. */
-void mpack_write_u64(mpack_writer_t* writer, uint64_t value);
+/** Writes an 64-bit unsigned integer in the most efficient packing available.
+ */
+void mpack_write_u64(mpack_writer_t *writer, uint64_t value);
 
 /** Writes an unsigned integer in the most efficient packing available. */
-MPACK_INLINE void mpack_write_uint(mpack_writer_t* writer, uint64_t value) {
+MPACK_INLINE void
+mpack_write_uint(mpack_writer_t *writer, uint64_t value)
+{
     mpack_write_u64(writer, value);
 }
 
@@ -2794,27 +2969,28 @@ MPACK_INLINE void mpack_write_uint(mpack_writer_t* writer, uint64_t value) {
  */
 
 /** Writes a float. */
-void mpack_write_float(mpack_writer_t* writer, float value);
+void mpack_write_float(mpack_writer_t *writer, float value);
 
 /** Writes a double. */
-void mpack_write_double(mpack_writer_t* writer, double value);
+void mpack_write_double(mpack_writer_t *writer, double value);
 
 /** Writes a boolean. */
-void mpack_write_bool(mpack_writer_t* writer, bool value);
+void mpack_write_bool(mpack_writer_t *writer, bool value);
 
 /** Writes a boolean with value true. */
-void mpack_write_true(mpack_writer_t* writer);
+void mpack_write_true(mpack_writer_t *writer);
 
 /** Writes a boolean with value false. */
-void mpack_write_false(mpack_writer_t* writer);
+void mpack_write_false(mpack_writer_t *writer);
 
 /** Writes a nil. */
-void mpack_write_nil(mpack_writer_t* writer);
+void mpack_write_nil(mpack_writer_t *writer);
 
 /** Write a pre-encoded messagepack object */
-void mpack_write_object_bytes(mpack_writer_t* writer, const char* data, size_t bytes);
+void mpack_write_object_bytes(
+    mpack_writer_t *writer, const char *data, size_t bytes);
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Writes a timestamp.
  *
@@ -2822,9 +2998,11 @@ void mpack_write_object_bytes(mpack_writer_t* writer, const char* data, size_t b
  *
  * @param writer The writer
  * @param seconds The (signed) number of seconds since 1970-01-01T00:00:00Z.
- * @param nanoseconds The additional number of nanoseconds from 0 to 999,999,999 inclusive.
+ * @param nanoseconds The additional number of nanoseconds from 0 to 999,999,999
+ * inclusive.
  */
-void mpack_write_timestamp(mpack_writer_t* writer, int64_t seconds, uint32_t nanoseconds);
+void mpack_write_timestamp(
+    mpack_writer_t *writer, int64_t seconds, uint32_t nanoseconds);
 
 /**
  * Writes a timestamp with the given number of seconds (and zero nanoseconds).
@@ -2834,7 +3012,9 @@ void mpack_write_timestamp(mpack_writer_t* writer, int64_t seconds, uint32_t nan
  * @param writer The writer
  * @param seconds The (signed) number of seconds since 1970-01-01T00:00:00Z.
  */
-MPACK_INLINE void mpack_write_timestamp_seconds(mpack_writer_t* writer, int64_t seconds) {
+MPACK_INLINE void
+mpack_write_timestamp_seconds(mpack_writer_t *writer, int64_t seconds)
+{
     mpack_write_timestamp(writer, seconds, 0);
 }
 
@@ -2843,10 +3023,13 @@ MPACK_INLINE void mpack_write_timestamp_seconds(mpack_writer_t* writer, int64_t 
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-MPACK_INLINE void mpack_write_timestamp_struct(mpack_writer_t* writer, mpack_timestamp_t timestamp) {
+MPACK_INLINE void
+mpack_write_timestamp_struct(
+    mpack_writer_t *writer, mpack_timestamp_t timestamp)
+{
     mpack_write_timestamp(writer, timestamp.seconds, timestamp.nanoseconds);
 }
-#endif
+#        endif
 
 /**
  * @}
@@ -2865,7 +3048,7 @@ MPACK_INLINE void mpack_write_timestamp_struct(mpack_writer_t* writer, mpack_tim
  *
  * @see mpack_finish_array()
  */
-void mpack_start_array(mpack_writer_t* writer, uint32_t count);
+void mpack_start_array(mpack_writer_t *writer, uint32_t count);
 
 /**
  * Opens a map.
@@ -2879,7 +3062,7 @@ void mpack_start_array(mpack_writer_t* writer, uint32_t count);
  *
  * @see mpack_finish_map()
  */
-void mpack_start_map(mpack_writer_t* writer, uint32_t count);
+void mpack_start_map(mpack_writer_t *writer, uint32_t count);
 
 /**
  * Finishes writing an array.
@@ -2887,11 +3070,14 @@ void mpack_start_map(mpack_writer_t* writer, uint32_t count);
  * This should be called only after a corresponding call to mpack_start_array()
  * and after the array contents are written.
  *
- * This will track writes to ensure that the correct number of elements are written.
+ * This will track writes to ensure that the correct number of elements are
+ * written.
  *
  * @see mpack_start_array()
  */
-MPACK_INLINE void mpack_finish_array(mpack_writer_t* writer) {
+MPACK_INLINE void
+mpack_finish_array(mpack_writer_t *writer)
+{
     mpack_writer_track_pop(writer, mpack_type_array);
 }
 
@@ -2901,11 +3087,14 @@ MPACK_INLINE void mpack_finish_array(mpack_writer_t* writer) {
  * This should be called only after a corresponding call to mpack_start_map()
  * and after the map contents are written.
  *
- * This will track writes to ensure that the correct number of elements are written.
+ * This will track writes to ensure that the correct number of elements are
+ * written.
  *
  * @see mpack_start_map()
  */
-MPACK_INLINE void mpack_finish_map(mpack_writer_t* writer) {
+MPACK_INLINE void
+mpack_finish_map(mpack_writer_t *writer)
+{
     mpack_writer_track_pop(writer, mpack_type_map);
 }
 
@@ -2931,7 +3120,7 @@ MPACK_INLINE void mpack_finish_map(mpack_writer_t* writer) {
  * You should not call mpack_finish_str() after calling this; this
  * performs both start and finish.
  */
-void mpack_write_str(mpack_writer_t* writer, const char* str, uint32_t length);
+void mpack_write_str(mpack_writer_t *writer, const char *str, uint32_t length);
 
 /**
  * Writes a string, ensuring that it is valid UTF-8.
@@ -2944,7 +3133,7 @@ void mpack_write_str(mpack_writer_t* writer, const char* str, uint32_t length);
  *
  * @throws mpack_error_invalid if the string is not valid UTF-8
  */
-void mpack_write_utf8(mpack_writer_t* writer, const char* str, uint32_t length);
+void mpack_write_utf8(mpack_writer_t *writer, const char *str, uint32_t length);
 
 /**
  * Writes a null-terminated string. (The null-terminator is not written.)
@@ -2957,7 +3146,7 @@ void mpack_write_utf8(mpack_writer_t* writer, const char* str, uint32_t length);
  * You should not call mpack_finish_str() after calling this; this
  * performs both start and finish.
  */
-void mpack_write_cstr(mpack_writer_t* writer, const char* cstr);
+void mpack_write_cstr(mpack_writer_t *writer, const char *cstr);
 
 /**
  * Writes a null-terminated string, or a nil node if the given cstr pointer
@@ -2971,7 +3160,7 @@ void mpack_write_cstr(mpack_writer_t* writer, const char* cstr);
  * You should not call mpack_finish_str() after calling this; this
  * performs both start and finish.
  */
-void mpack_write_cstr_or_nil(mpack_writer_t* writer, const char* cstr);
+void mpack_write_cstr_or_nil(mpack_writer_t *writer, const char *cstr);
 
 /**
  * Writes a null-terminated string, ensuring that it is valid UTF-8. (The
@@ -2985,7 +3174,7 @@ void mpack_write_cstr_or_nil(mpack_writer_t* writer, const char* cstr);
  *
  * @throws mpack_error_invalid if the string is not valid UTF-8
  */
-void mpack_write_utf8_cstr(mpack_writer_t* writer, const char* cstr);
+void mpack_write_utf8_cstr(mpack_writer_t *writer, const char *cstr);
 
 /**
  * Writes a null-terminated string ensuring that it is valid UTF-8, or
@@ -3000,7 +3189,7 @@ void mpack_write_utf8_cstr(mpack_writer_t* writer, const char* cstr);
  *
  * @throws mpack_error_invalid if the string is not valid UTF-8
  */
-void mpack_write_utf8_cstr_or_nil(mpack_writer_t* writer, const char* cstr);
+void mpack_write_utf8_cstr_or_nil(mpack_writer_t *writer, const char *cstr);
 
 /**
  * Writes a binary blob.
@@ -3010,24 +3199,25 @@ void mpack_write_utf8_cstr_or_nil(mpack_writer_t* writer, const char* cstr);
  * You should not call mpack_finish_bin() after calling this; this
  * performs both start and finish.
  */
-void mpack_write_bin(mpack_writer_t* writer, const char* data, uint32_t count);
+void mpack_write_bin(mpack_writer_t *writer, const char *data, uint32_t count);
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Writes an extension type.
  *
  * To stream an extension blob in chunks, use mpack_start_ext() instead.
  *
- * Extension types [0, 127] are available for application-specific types. Extension
- * types [-128, -1] are reserved for future extensions of MessagePack.
+ * Extension types [0, 127] are available for application-specific types.
+ * Extension types [-128, -1] are reserved for future extensions of MessagePack.
  *
  * You should not call mpack_finish_ext() after calling this; this
  * performs both start and finish.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-void mpack_write_ext(mpack_writer_t* writer, int8_t exttype, const char* data, uint32_t count);
-#endif
+void mpack_write_ext(
+    mpack_writer_t *writer, int8_t exttype, const char *data, uint32_t count);
+#        endif
 
 /**
  * @}
@@ -3049,28 +3239,28 @@ void mpack_write_ext(mpack_writer_t* writer, int8_t exttype, const char* data, u
  * MPack does not care about the underlying encoding, but UTF-8 is highly
  * recommended, especially for compatibility with JSON.
  */
-void mpack_start_str(mpack_writer_t* writer, uint32_t count);
+void mpack_start_str(mpack_writer_t *writer, uint32_t count);
 
 /**
  * Opens a binary blob. `count` bytes should be written with calls to
  * mpack_write_bytes(), and mpack_finish_bin() should be called
  * when done.
  */
-void mpack_start_bin(mpack_writer_t* writer, uint32_t count);
+void mpack_start_bin(mpack_writer_t *writer, uint32_t count);
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Opens an extension type. `count` bytes should be written with calls
  * to mpack_write_bytes(), and mpack_finish_ext() should be called
  * when done.
  *
- * Extension types [0, 127] are available for application-specific types. Extension
- * types [-128, -1] are reserved for future extensions of MessagePack.
+ * Extension types [0, 127] are available for application-specific types.
+ * Extension types [-128, -1] are reserved for future extensions of MessagePack.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-void mpack_start_ext(mpack_writer_t* writer, int8_t exttype, uint32_t count);
-#endif
+void mpack_start_ext(mpack_writer_t *writer, int8_t exttype, uint32_t count);
+#        endif
 
 /**
  * Writes a portion of bytes for a string, binary blob or extension type which
@@ -3094,7 +3284,7 @@ void mpack_start_ext(mpack_writer_t* writer, int8_t exttype, uint32_t count);
  * @see mpack_finish_ext()
  * @see mpack_finish_type()
  */
-void mpack_write_bytes(mpack_writer_t* writer, const char* data, size_t count);
+void mpack_write_bytes(mpack_writer_t *writer, const char *data, size_t count);
 
 /**
  * Finishes writing a string.
@@ -3102,12 +3292,15 @@ void mpack_write_bytes(mpack_writer_t* writer, const char* data, size_t count);
  * This should be called only after a corresponding call to mpack_start_str()
  * and after the string bytes are written with mpack_write_bytes().
  *
- * This will track writes to ensure that the correct number of elements are written.
+ * This will track writes to ensure that the correct number of elements are
+ * written.
  *
  * @see mpack_start_str()
  * @see mpack_write_bytes()
  */
-MPACK_INLINE void mpack_finish_str(mpack_writer_t* writer) {
+MPACK_INLINE void
+mpack_finish_str(mpack_writer_t *writer)
+{
     mpack_writer_track_pop(writer, mpack_type_str);
 }
 
@@ -3117,33 +3310,39 @@ MPACK_INLINE void mpack_finish_str(mpack_writer_t* writer) {
  * This should be called only after a corresponding call to mpack_start_bin()
  * and after the binary bytes are written with mpack_write_bytes().
  *
- * This will track writes to ensure that the correct number of bytes are written.
+ * This will track writes to ensure that the correct number of bytes are
+ * written.
  *
  * @see mpack_start_bin()
  * @see mpack_write_bytes()
  */
-MPACK_INLINE void mpack_finish_bin(mpack_writer_t* writer) {
+MPACK_INLINE void
+mpack_finish_bin(mpack_writer_t *writer)
+{
     mpack_writer_track_pop(writer, mpack_type_bin);
 }
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Finishes writing an extended type binary data blob.
  *
  * This should be called only after a corresponding call to mpack_start_bin()
  * and after the binary bytes are written with mpack_write_bytes().
  *
- * This will track writes to ensure that the correct number of bytes are written.
+ * This will track writes to ensure that the correct number of bytes are
+ * written.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  *
  * @see mpack_start_ext()
  * @see mpack_write_bytes()
  */
-MPACK_INLINE void mpack_finish_ext(mpack_writer_t* writer) {
+MPACK_INLINE void
+mpack_finish_ext(mpack_writer_t *writer)
+{
     mpack_writer_track_pop(writer, mpack_type_ext);
 }
-#endif
+#        endif
 
 /**
  * Finishes writing the given compound type.
@@ -3154,7 +3353,9 @@ MPACK_INLINE void mpack_finish_ext(mpack_writer_t* writer) {
  * This can be called with the appropriate type instead the corresponding
  * mpack_finish_*() function if you want to finish a dynamic type.
  */
-MPACK_INLINE void mpack_finish_type(mpack_writer_t* writer, mpack_type_t type) {
+MPACK_INLINE void
+mpack_finish_type(mpack_writer_t *writer, mpack_type_t type)
+{
     mpack_writer_track_pop(writer, type);
 }
 
@@ -3162,7 +3363,7 @@ MPACK_INLINE void mpack_finish_type(mpack_writer_t* writer, mpack_type_t type) {
  * @}
  */
 
-#if MPACK_WRITER && MPACK_HAS_GENERIC && !defined(__cplusplus)
+#        if MPACK_WRITER && MPACK_HAS_GENERIC && !defined(__cplusplus)
 
 /**
  * @name Type-Generic Writers
@@ -3184,8 +3385,8 @@ MPACK_INLINE void mpack_finish_type(mpack_writer_t* writer, mpack_type_t type) {
  * all of type `int`, not `bool` or `void*`! They will emit unexpected
  * types when passed uncast, so be careful when using them.
  */
-#define mpack_write(writer, value) \
-    _Generic(((void)0, value),                      \
+#            define mpack_write(writer, value)                                 \
+                _Generic(((void)0, value),                      \
               int8_t: mpack_write_i8,               \
              int16_t: mpack_write_i16,              \
              int32_t: mpack_write_i32,              \
@@ -3217,26 +3418,27 @@ MPACK_INLINE void mpack_finish_type(mpack_writer_t* writer, mpack_type_t type) {
  * @param key A null-terminated C string.
  * @param value A primitive type supported by mpack_write().
  */
-#define mpack_write_kv(writer, key, value) do {     \
-    mpack_write_cstr(writer, key);                  \
-    mpack_write(writer, value);                     \
-} while (0)
+#            define mpack_write_kv(writer, key, value)                         \
+                do {                                                           \
+                    mpack_write_cstr(writer, key);                             \
+                    mpack_write(writer, value);                                \
+                } while (0)
 
 /**
  * @}
  */
 
-#endif
+#        endif
 
 /**
  * @}
  */
 
-#endif
+#    endif
 
 MPACK_HEADER_END
 
-#if defined(__cplusplus) || defined(MPACK_DOXYGEN)
+#    if defined(__cplusplus) || defined(MPACK_DOXYGEN)
 
 /*
  * C++ generic writers for primitive values
@@ -3245,130 +3447,182 @@ MPACK_HEADER_END
  * extern "C". They'll be moved to a C++-specific header soon.
  */
 
-#ifdef MPACK_DOXYGEN
-#undef mpack_write
-#undef mpack_write_kv
-#endif
+#        ifdef MPACK_DOXYGEN
+#            undef mpack_write
+#            undef mpack_write_kv
+#        endif
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int8_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, int8_t value)
+{
     mpack_write_i8(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int16_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, int16_t value)
+{
     mpack_write_i16(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int32_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, int32_t value)
+{
     mpack_write_i32(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, int64_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, int64_t value)
+{
     mpack_write_i64(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint8_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, uint8_t value)
+{
     mpack_write_u8(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint16_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, uint16_t value)
+{
     mpack_write_u16(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint32_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, uint32_t value)
+{
     mpack_write_u32(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, uint64_t value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, uint64_t value)
+{
     mpack_write_u64(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, bool value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, bool value)
+{
     mpack_write_bool(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, float value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, float value)
+{
     mpack_write_float(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, double value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, double value)
+{
     mpack_write_double(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, char *value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, char *value)
+{
     mpack_write_cstr_or_nil(writer, value);
 }
 
-MPACK_INLINE void mpack_write(mpack_writer_t* writer, const char *value) {
+MPACK_INLINE void
+mpack_write(mpack_writer_t *writer, const char *value)
+{
     mpack_write_cstr_or_nil(writer, value);
 }
 
 /* C++ generic write for key-value pairs */
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int8_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, int8_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_i8(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int16_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, int16_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_i16(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int32_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, int32_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_i32(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, int64_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, int64_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_i64(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint8_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, uint8_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_u8(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint16_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, uint16_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_u16(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint32_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, uint32_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_u32(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, uint64_t value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, uint64_t value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_u64(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, bool value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, bool value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_bool(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, float value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, float value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_float(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, double value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, double value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_double(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, char *value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, char *value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_cstr_or_nil(writer, value);
 }
 
-MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, const char *value) {
+MPACK_INLINE void
+mpack_write_kv(mpack_writer_t *writer, const char *key, const char *value)
+{
     mpack_write_cstr(writer, key);
     mpack_write_cstr_or_nil(writer, value);
 }
-#endif /* __cplusplus */
+#    endif /* __cplusplus */
 
 #endif
 
@@ -3381,21 +3635,21 @@ MPACK_INLINE void mpack_write_kv(mpack_writer_t* writer, const char *key, const 
  */
 
 #ifndef MPACK_READER_H
-#define MPACK_READER_H 1
+#    define MPACK_READER_H 1
 
 /* #include "mpack-common.h" */
 
 MPACK_HEADER_START
 
-#if MPACK_READER
+#    if MPACK_READER
 
-#if MPACK_READ_TRACKING
+#        if MPACK_READ_TRACKING
 struct mpack_track_t;
-#endif
+#        endif
 
 // The denominator to determine whether a read is a small
 // fraction of the buffer size.
-#define MPACK_READER_SMALL_FRACTION_DENOMINATOR 32
+#        define MPACK_READER_SMALL_FRACTION_DENOMINATOR 32
 
 /**
  * @defgroup reader Reader API
@@ -3420,7 +3674,7 @@ struct mpack_track_t;
  *
  * The minimum buffer size for a reader with a fill function.
  */
-#define MPACK_READER_MINIMUM_BUFFER_SIZE 32
+#        define MPACK_READER_MINIMUM_BUFFER_SIZE 32
 
 /**
  * A buffered MessagePack decoder.
@@ -3454,7 +3708,8 @@ typedef struct mpack_reader_t mpack_reader_t;
  *
  * @see mpack_reader_context()
  */
-typedef size_t (*mpack_reader_fill_t)(mpack_reader_t* reader, char* buffer, size_t count);
+typedef size_t (*mpack_reader_fill_t)(
+    mpack_reader_t *reader, char *buffer, size_t count);
 
 /**
  * The MPack reader's skip function. It should discard the given number
@@ -3464,7 +3719,7 @@ typedef size_t (*mpack_reader_fill_t)(mpack_reader_t* reader, char* buffer, size
  *
  * @see mpack_reader_context()
  */
-typedef void (*mpack_reader_skip_t)(mpack_reader_t* reader, size_t count);
+typedef void (*mpack_reader_skip_t)(mpack_reader_t *reader, size_t count);
 
 /**
  * An error handler function to be called when an error is flagged on
@@ -3490,34 +3745,37 @@ typedef void (*mpack_reader_skip_t)(mpack_reader_t* reader, size_t count);
  * that the reader is destroyed since any future accesses to it cause
  * undefined behavior.
  */
-typedef void (*mpack_reader_error_t)(mpack_reader_t* reader, mpack_error_t error);
+typedef void (*mpack_reader_error_t)(
+    mpack_reader_t *reader, mpack_error_t error);
 
 /**
  * A teardown function to be called when the reader is destroyed.
  */
-typedef void (*mpack_reader_teardown_t)(mpack_reader_t* reader);
+typedef void (*mpack_reader_teardown_t)(mpack_reader_t *reader);
 
 /* Hide internals from documentation */
 /** @cond */
 
 struct mpack_reader_t {
-    void* context;                    /* Context for reader callbacks */
-    mpack_reader_fill_t fill;         /* Function to read bytes into the buffer */
-    mpack_reader_error_t error_fn;    /* Function to call on error */
-    mpack_reader_teardown_t teardown; /* Function to teardown the context on destroy */
-    mpack_reader_skip_t skip;         /* Function to skip bytes from the source */
+    void *context; /* Context for reader callbacks */
+    mpack_reader_fill_t fill; /* Function to read bytes into the buffer */
+    mpack_reader_error_t error_fn; /* Function to call on error */
+    mpack_reader_teardown_t
+        teardown; /* Function to teardown the context on destroy */
+    mpack_reader_skip_t skip; /* Function to skip bytes from the source */
 
-    char* buffer;       /* Writeable byte buffer */
-    size_t size;        /* Size of the buffer */
+    char *buffer; /* Writeable byte buffer */
+    size_t size; /* Size of the buffer */
 
-    const char* data;   /* Current data pointer (in the buffer, if it is used) */
-    const char* end;    /* The end of available data (in the buffer, if it is used) */
+    const char *data; /* Current data pointer (in the buffer, if it is used) */
+    const char
+        *end; /* The end of available data (in the buffer, if it is used) */
 
-    mpack_error_t error;  /* Error state */
+    mpack_error_t error; /* Error state */
 
-    #if MPACK_READ_TRACKING
+#        if MPACK_READ_TRACKING
     mpack_track_t track; /* Stack of map/array/str/bin/ext reads */
-    #endif
+#        endif
 };
 
 /** @endcond */
@@ -3537,38 +3795,42 @@ struct mpack_reader_t {
  * @param size The size of the buffer.
  * @param count The number of bytes already in the buffer.
  */
-void mpack_reader_init(mpack_reader_t* reader, char* buffer, size_t size, size_t count);
+void mpack_reader_init(
+    mpack_reader_t *reader, char *buffer, size_t size, size_t count);
 
 /**
  * Initializes an MPack reader directly into an error state. Use this if you
  * are writing a wrapper to mpack_reader_init() which can fail its setup.
  */
-void mpack_reader_init_error(mpack_reader_t* reader, mpack_error_t error);
+void mpack_reader_init_error(mpack_reader_t *reader, mpack_error_t error);
 
 /**
- * Initializes an MPack reader to parse a pre-loaded contiguous chunk of data. The
- * reader does not assume ownership of the data.
+ * Initializes an MPack reader to parse a pre-loaded contiguous chunk of data.
+ * The reader does not assume ownership of the data.
  *
  * @param reader The MPack reader.
  * @param data The data to parse.
  * @param count The number of bytes pointed to by data.
  */
-void mpack_reader_init_data(mpack_reader_t* reader, const char* data, size_t count);
+void mpack_reader_init_data(
+    mpack_reader_t *reader, const char *data, size_t count);
 
-#if MPACK_STDIO
+#        if MPACK_STDIO
 /**
  * Initializes an MPack reader that reads from a file.
  *
  * The file will be automatically opened and closed by the reader.
  */
-void mpack_reader_init_filename(mpack_reader_t* reader, const char* filename);
+void mpack_reader_init_filename(mpack_reader_t *reader, const char *filename);
 
 /**
  * Deprecated.
  *
  * \deprecated Renamed to mpack_reader_init_filename().
  */
-MPACK_INLINE void mpack_reader_init_file(mpack_reader_t* reader, const char* filename) {
+MPACK_INLINE void
+mpack_reader_init_file(mpack_reader_t *reader, const char *filename)
+{
     mpack_reader_init_filename(reader, filename);
 }
 
@@ -3586,8 +3848,9 @@ MPACK_INLINE void mpack_reader_init_file(mpack_reader_t* reader, const char* fil
  * and it may read more data than it parsed. See mpack_reader_remaining() to
  * access the extra data.
  */
-void mpack_reader_init_stdfile(mpack_reader_t* reader, FILE* stdfile, bool close_when_done);
-#endif
+void mpack_reader_init_stdfile(
+    mpack_reader_t *reader, FILE *stdfile, bool close_when_done);
+#        endif
 
 /**
  * @def mpack_reader_init_stack(reader)
@@ -3600,16 +3863,17 @@ void mpack_reader_init_stdfile(mpack_reader_t* reader, FILE* stdfile, bool close
  */
 
 /** @cond */
-#define mpack_reader_init_stack_line_ex(line, reader) \
-    char mpack_buf_##line[MPACK_STACK_SIZE]; \
-    mpack_reader_init((reader), mpack_buf_##line, sizeof(mpack_buf_##line), 0)
+#        define mpack_reader_init_stack_line_ex(line, reader)                  \
+            char mpack_buf_##line[MPACK_STACK_SIZE];                           \
+            mpack_reader_init(                                                 \
+                (reader), mpack_buf_##line, sizeof(mpack_buf_##line), 0)
 
-#define mpack_reader_init_stack_line(line, reader) \
-    mpack_reader_init_stack_line_ex(line, reader)
+#        define mpack_reader_init_stack_line(line, reader)                     \
+            mpack_reader_init_stack_line_ex(line, reader)
 /** @endcond */
 
-#define mpack_reader_init_stack(reader) \
-    mpack_reader_init_stack_line(__LINE__, (reader))
+#        define mpack_reader_init_stack(reader)                                \
+            mpack_reader_init_stack_line(__LINE__, (reader))
 
 /**
  * Cleans up the MPack reader, ensuring that all compound elements
@@ -3625,7 +3889,7 @@ void mpack_reader_init_stdfile(mpack_reader_t* reader, FILE* stdfile, bool close
  * @see mpack_reader_flag_error()
  * @see mpack_error_data
  */
-mpack_error_t mpack_reader_destroy(mpack_reader_t* reader);
+mpack_error_t mpack_reader_destroy(mpack_reader_t *reader);
 
 /**
  * @}
@@ -3645,7 +3909,9 @@ mpack_error_t mpack_reader_destroy(mpack_reader_t* reader);
  *
  * @see mpack_reader_context()
  */
-MPACK_INLINE void mpack_reader_set_context(mpack_reader_t* reader, void* context) {
+MPACK_INLINE void
+mpack_reader_set_context(mpack_reader_t *reader, void *context)
+{
     reader->context = context;
 }
 
@@ -3656,7 +3922,9 @@ MPACK_INLINE void mpack_reader_set_context(mpack_reader_t* reader, void* context
  * @see mpack_reader_set_fill
  * @see mpack_reader_set_skip
  */
-MPACK_INLINE void* mpack_reader_context(mpack_reader_t* reader) {
+MPACK_INLINE void *
+mpack_reader_context(mpack_reader_t *reader)
+{
     return reader->context;
 }
 
@@ -3677,7 +3945,7 @@ MPACK_INLINE void* mpack_reader_context(mpack_reader_t* reader) {
  * @param reader The MPack reader.
  * @param fill The function to fetch additional data into the buffer.
  */
-void mpack_reader_set_fill(mpack_reader_t* reader, mpack_reader_fill_t fill);
+void mpack_reader_set_fill(mpack_reader_t *reader, mpack_reader_fill_t fill);
 
 /**
  * Sets the skip function to discard bytes from the source stream.
@@ -3695,7 +3963,7 @@ void mpack_reader_set_fill(mpack_reader_t* reader, mpack_reader_fill_t fill);
  * @param reader The MPack reader.
  * @param skip The function to discard bytes from the source stream.
  */
-void mpack_reader_set_skip(mpack_reader_t* reader, mpack_reader_skip_t skip);
+void mpack_reader_set_skip(mpack_reader_t *reader, mpack_reader_skip_t skip);
 
 /**
  * Sets the error function to call when an error is flagged on the reader.
@@ -3710,7 +3978,10 @@ void mpack_reader_set_skip(mpack_reader_t* reader, mpack_reader_skip_t skip);
  * @param reader The MPack reader.
  * @param error_fn The function to call when an error is flagged on the reader.
  */
-MPACK_INLINE void mpack_reader_set_error_handler(mpack_reader_t* reader, mpack_reader_error_t error_fn) {
+MPACK_INLINE void
+mpack_reader_set_error_handler(
+    mpack_reader_t *reader, mpack_reader_error_t error_fn)
+{
     reader->error_fn = error_fn;
 }
 
@@ -3723,7 +3994,10 @@ MPACK_INLINE void mpack_reader_set_error_handler(mpack_reader_t* reader, mpack_r
  * @param reader The MPack reader.
  * @param teardown The function to call when the reader is destroyed.
  */
-MPACK_INLINE void mpack_reader_set_teardown(mpack_reader_t* reader, mpack_reader_teardown_t teardown) {
+MPACK_INLINE void
+mpack_reader_set_teardown(
+    mpack_reader_t *reader, mpack_reader_teardown_t teardown)
+{
     reader->teardown = teardown;
 }
 
@@ -3742,7 +4016,9 @@ MPACK_INLINE void mpack_reader_set_teardown(mpack_reader_t* reader, mpack_reader
  * If a reader is in an error state, you should discard all data since the
  * last time the error flag was checked. The error flag cannot be cleared.
  */
-MPACK_INLINE mpack_error_t mpack_reader_error(mpack_reader_t* reader) {
+MPACK_INLINE mpack_error_t
+mpack_reader_error(mpack_reader_t *reader)
+{
     return reader->error;
 }
 
@@ -3756,11 +4032,11 @@ MPACK_INLINE mpack_error_t mpack_reader_error(mpack_reader_t* reader) {
  * If the reader is already in an error state, this call is ignored and no
  * error callback is called.
  */
-void mpack_reader_flag_error(mpack_reader_t* reader, mpack_error_t error);
+void mpack_reader_flag_error(mpack_reader_t *reader, mpack_error_t error);
 
 /**
- * Places the reader in the given error state if the given error is not mpack_ok,
- * returning the resulting error state of the reader.
+ * Places the reader in the given error state if the given error is not
+ * mpack_ok, returning the resulting error state of the reader.
  *
  * This allows you to externally flag errors, for example if you are validating
  * data as you read it.
@@ -3768,7 +4044,9 @@ void mpack_reader_flag_error(mpack_reader_t* reader, mpack_error_t error);
  * If the given error is mpack_ok or if the reader is already in an error state,
  * this call is ignored and the actual error state of the reader is returned.
  */
-MPACK_INLINE mpack_error_t mpack_reader_flag_if_error(mpack_reader_t* reader, mpack_error_t error) {
+MPACK_INLINE mpack_error_t
+mpack_reader_flag_if_error(mpack_reader_t *reader, mpack_error_t error)
+{
     if (error != mpack_ok)
         mpack_reader_flag_error(reader, error);
     return mpack_reader_error(reader);
@@ -3792,7 +4070,7 @@ MPACK_INLINE mpack_error_t mpack_reader_flag_if_error(mpack_reader_t* reader, mp
  * @param data [out] A pointer to the remaining data, or NULL.
  * @return The number of bytes remaining in the buffer.
  */
-size_t mpack_reader_remaining(mpack_reader_t* reader, const char** data);
+size_t mpack_reader_remaining(mpack_reader_t *reader, const char **data);
 
 /**
  * Reads a MessagePack object header (an MPack tag.)
@@ -3808,7 +4086,7 @@ size_t mpack_reader_remaining(mpack_reader_t* reader, const char** data);
  * @note Maps in JSON are unordered, so it is recommended not to expect
  * a specific ordering for your map values in case your data is converted
  * to/from JSON.
- * 
+ *
  * @see mpack_read_bytes()
  * @see mpack_done_array()
  * @see mpack_done_map()
@@ -3816,7 +4094,7 @@ size_t mpack_reader_remaining(mpack_reader_t* reader, const char** data);
  * @see mpack_done_bin()
  * @see mpack_done_ext()
  */
-mpack_tag_t mpack_read_tag(mpack_reader_t* reader);
+mpack_tag_t mpack_read_tag(mpack_reader_t *reader);
 
 /**
  * Parses the next MessagePack object header (an MPack tag) without
@@ -3833,7 +4111,7 @@ mpack_tag_t mpack_read_tag(mpack_reader_t* reader);
  * @see mpack_read_tag()
  * @see mpack_discard()
  */
-mpack_tag_t mpack_peek_tag(mpack_reader_t* reader);
+mpack_tag_t mpack_peek_tag(mpack_reader_t *reader);
 
 /**
  * @}
@@ -3848,7 +4126,7 @@ mpack_tag_t mpack_peek_tag(mpack_reader_t* reader);
  * Skips bytes from the underlying stream. This is used only to
  * skip the contents of a string, binary blob or extension object.
  */
-void mpack_skip_bytes(mpack_reader_t* reader, size_t count);
+void mpack_skip_bytes(mpack_reader_t *reader, size_t count);
 
 /**
  * Reads bytes from a string, binary blob or extension object, copying
@@ -3868,7 +4146,7 @@ void mpack_skip_bytes(mpack_reader_t* reader, size_t count);
  * @param p The buffer in which to copy the bytes
  * @param count The number of bytes to read
  */
-void mpack_read_bytes(mpack_reader_t* reader, char* p, size_t count);
+void mpack_read_bytes(mpack_reader_t *reader, char *p, size_t count);
 
 /**
  * Reads bytes from a string, ensures that the string is valid UTF-8,
@@ -3893,7 +4171,7 @@ void mpack_read_bytes(mpack_reader_t* reader, char* p, size_t count);
  *
  * @throws mpack_error_type if the string contains invalid UTF-8.
  */
-void mpack_read_utf8(mpack_reader_t* reader, char* p, size_t byte_count);
+void mpack_read_utf8(mpack_reader_t *reader, char *p, size_t byte_count);
 
 /**
  * Reads bytes from a string, ensures that the string contains no NUL
@@ -3914,14 +4192,16 @@ void mpack_read_utf8(mpack_reader_t* reader, char* p, size_t byte_count);
  * Alternatively you could use mpack_peek_tag() and call
  * mpack_expect_cstr() if it's a string.
  *
- * @throws mpack_error_too_big if the string plus null-terminator is larger than the given buffer size
+ * @throws mpack_error_too_big if the string plus null-terminator is larger than
+ * the given buffer size
  * @throws mpack_error_type if the string contains a null byte.
  *
  * @see mpack_peek_tag()
  * @see mpack_expect_cstr()
  * @see mpack_expect_utf8_cstr()
  */
-void mpack_read_cstr(mpack_reader_t* reader, char* buf, size_t buffer_size, size_t byte_count);
+void mpack_read_cstr(
+    mpack_reader_t *reader, char *buf, size_t buffer_size, size_t byte_count);
 
 /**
  * Reads bytes from a string, ensures that the string is valid UTF-8
@@ -3947,20 +4227,23 @@ void mpack_read_cstr(mpack_reader_t* reader, char* buf, size_t buffer_size, size
  * Alternatively you could use mpack_peek_tag() and call
  * mpack_expect_utf8_cstr() if it's a string.
  *
- * @throws mpack_error_too_big if the string plus null-terminator is larger than the given buffer size
+ * @throws mpack_error_too_big if the string plus null-terminator is larger than
+ * the given buffer size
  * @throws mpack_error_type if the string contains invalid UTF-8 or a null byte.
  *
  * @see mpack_peek_tag()
  * @see mpack_expect_utf8_cstr()
  */
-void mpack_read_utf8_cstr(mpack_reader_t* reader, char* buf, size_t buffer_size, size_t byte_count);
+void mpack_read_utf8_cstr(
+    mpack_reader_t *reader, char *buf, size_t buffer_size, size_t byte_count);
 
-#ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
 /** @cond */
 // This can optionally add a null-terminator, but it does not check
 // whether the data contains null bytes. This must be done separately
 // in a cstring read function (possibly as part of a UTF-8 check.)
-char* mpack_read_bytes_alloc_impl(mpack_reader_t* reader, size_t count, bool null_terminated);
+char *mpack_read_bytes_alloc_impl(
+    mpack_reader_t *reader, size_t count, bool null_terminated);
 /** @endcond */
 
 /**
@@ -3972,10 +4255,12 @@ char* mpack_read_bytes_alloc_impl(mpack_reader_t* reader, size_t count, bool nul
  *
  * Returns NULL if any error occurs, or if count is zero.
  */
-MPACK_INLINE char* mpack_read_bytes_alloc(mpack_reader_t* reader, size_t count) {
+MPACK_INLINE char *
+mpack_read_bytes_alloc(mpack_reader_t *reader, size_t count)
+{
     return mpack_read_bytes_alloc_impl(reader, count, false);
 }
-#endif
+#        endif
 
 /**
  * Reads bytes from a string, binary blob or extension object in-place in
@@ -3994,8 +4279,8 @@ MPACK_INLINE char* mpack_read_bytes_alloc(mpack_reader_t* reader, size_t count) 
  * The reader will move data around in the buffer if needed to ensure that
  * the pointer can always be returned, so this should only be used if
  * count is very small compared to the buffer size. If you need to check
- * whether a small size is reasonable (for example you intend to handle small and
- * large sizes differently), you can call mpack_should_read_bytes_inplace().
+ * whether a small size is reasonable (for example you intend to handle small
+ * and large sizes differently), you can call mpack_should_read_bytes_inplace().
  *
  * This can be called multiple times for a single str, bin or ext
  * to read the data in chunks. The total data read must add up
@@ -4003,11 +4288,12 @@ MPACK_INLINE char* mpack_read_bytes_alloc(mpack_reader_t* reader, size_t count) 
  *
  * NULL is returned if the reader is in an error state.
  *
- * @throws mpack_error_too_big if the requested size is larger than the buffer size
+ * @throws mpack_error_too_big if the requested size is larger than the buffer
+ * size
  *
  * @see mpack_should_read_bytes_inplace()
  */
-const char* mpack_read_bytes_inplace(mpack_reader_t* reader, size_t count);
+const char *mpack_read_bytes_inplace(mpack_reader_t *reader, size_t count);
 
 /**
  * Reads bytes from a string in-place in the buffer and ensures they are
@@ -4026,8 +4312,8 @@ const char* mpack_read_bytes_inplace(mpack_reader_t* reader, size_t count);
  * The reader will move data around in the buffer if needed to ensure that
  * the pointer can always be returned, so this should only be used if
  * count is very small compared to the buffer size. If you need to check
- * whether a small size is reasonable (for example you intend to handle small and
- * large sizes differently), you can call mpack_should_read_bytes_inplace().
+ * whether a small size is reasonable (for example you intend to handle small
+ * and large sizes differently), you can call mpack_should_read_bytes_inplace().
  *
  * This does not accept any UTF-8 variant such as Modified UTF-8, CESU-8 or
  * WTF-8. Only pure UTF-8 is allowed.
@@ -4039,11 +4325,12 @@ const char* mpack_read_bytes_inplace(mpack_reader_t* reader, size_t count);
  * NULL is returned if the reader is in an error state.
  *
  * @throws mpack_error_type if the string contains invalid UTF-8
- * @throws mpack_error_too_big if the requested size is larger than the buffer size
+ * @throws mpack_error_too_big if the requested size is larger than the buffer
+ * size
  *
  * @see mpack_should_read_bytes_inplace()
  */
-const char* mpack_read_utf8_inplace(mpack_reader_t* reader, size_t count);
+const char *mpack_read_utf8_inplace(mpack_reader_t *reader, size_t count);
 
 /**
  * Returns true if it's a good idea to read the given number of bytes
@@ -4059,11 +4346,14 @@ const char* mpack_read_utf8_inplace(mpack_reader_t* reader, size_t count);
  *
  * @see mpack_read_bytes_inplace()
  */
-MPACK_INLINE bool mpack_should_read_bytes_inplace(mpack_reader_t* reader, size_t count) {
-    return (reader->size == 0 || count <= reader->size / MPACK_READER_SMALL_FRACTION_DENOMINATOR);
+MPACK_INLINE bool
+mpack_should_read_bytes_inplace(mpack_reader_t *reader, size_t count)
+{
+    return (reader->size == 0
+        || count <= reader->size / MPACK_READER_SMALL_FRACTION_DENOMINATOR);
 }
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Reads a timestamp contained in an ext object of the given size, closing the
  * ext type.
@@ -4080,8 +4370,8 @@ MPACK_INLINE bool mpack_should_read_bytes_inplace(mpack_reader_t* reader, size_t
  * @throws mpack_error_invalid if the size is not one of the supported
  * timestamp sizes, or if the nanoseconds are out of range.
  */
-mpack_timestamp_t mpack_read_timestamp(mpack_reader_t* reader, size_t size);
-#endif
+mpack_timestamp_t mpack_read_timestamp(mpack_reader_t *reader, size_t size);
+#        endif
 
 /**
  * @}
@@ -4092,27 +4382,31 @@ mpack_timestamp_t mpack_read_timestamp(mpack_reader_t* reader, size_t size);
  * @{
  */
 
-#if MPACK_READ_TRACKING
+#        if MPACK_READ_TRACKING
 /**
  * Finishes reading the given type.
  *
  * This will track reads to ensure that the correct number of elements
  * or bytes are read.
  */
-void mpack_done_type(mpack_reader_t* reader, mpack_type_t type);
-#else
-MPACK_INLINE void mpack_done_type(mpack_reader_t* reader, mpack_type_t type) {
+void mpack_done_type(mpack_reader_t *reader, mpack_type_t type);
+#        else
+MPACK_INLINE void
+mpack_done_type(mpack_reader_t *reader, mpack_type_t type)
+{
     MPACK_UNUSED(reader);
     MPACK_UNUSED(type);
 }
-#endif
+#        endif
 
 /**
  * Finishes reading an array.
  *
  * This will track reads to ensure that the correct number of elements are read.
  */
-MPACK_INLINE void mpack_done_array(mpack_reader_t* reader) {
+MPACK_INLINE void
+mpack_done_array(mpack_reader_t *reader)
+{
     mpack_done_type(reader, mpack_type_array);
 }
 
@@ -4123,7 +4417,9 @@ MPACK_INLINE void mpack_done_array(mpack_reader_t* reader) {
  *
  * This will track reads to ensure that the correct number of elements are read.
  */
-MPACK_INLINE void mpack_done_map(mpack_reader_t* reader) {
+MPACK_INLINE void
+mpack_done_map(mpack_reader_t *reader)
+{
     mpack_done_type(reader, mpack_type_map);
 }
 
@@ -4134,7 +4430,9 @@ MPACK_INLINE void mpack_done_map(mpack_reader_t* reader) {
  *
  * This will track reads to ensure that the correct number of bytes are read.
  */
-MPACK_INLINE void mpack_done_str(mpack_reader_t* reader) {
+MPACK_INLINE void
+mpack_done_str(mpack_reader_t *reader)
+{
     mpack_done_type(reader, mpack_type_str);
 }
 
@@ -4145,11 +4443,13 @@ MPACK_INLINE void mpack_done_str(mpack_reader_t* reader) {
  *
  * This will track reads to ensure that the correct number of bytes are read.
  */
-MPACK_INLINE void mpack_done_bin(mpack_reader_t* reader) {
+MPACK_INLINE void
+mpack_done_bin(mpack_reader_t *reader)
+{
     mpack_done_type(reader, mpack_type_bin);
 }
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * @fn mpack_done_ext(mpack_reader_t* reader)
  *
@@ -4159,16 +4459,18 @@ MPACK_INLINE void mpack_done_bin(mpack_reader_t* reader) {
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-MPACK_INLINE void mpack_done_ext(mpack_reader_t* reader) {
+MPACK_INLINE void
+mpack_done_ext(mpack_reader_t *reader)
+{
     mpack_done_type(reader, mpack_type_ext);
 }
-#endif
+#        endif
 
 /**
  * Reads and discards the next object. This will read and discard all
  * contained data as well if it is a compound type.
  */
-void mpack_discard(mpack_reader_t* reader);
+void mpack_discard(mpack_reader_t *reader);
 
 /**
  * @}
@@ -4176,7 +4478,7 @@ void mpack_discard(mpack_reader_t* reader);
 
 /** @cond */
 
-#if MPACK_DEBUG && MPACK_STDIO
+#        if MPACK_DEBUG && MPACK_STDIO
 /**
  * @name Debugging Functions
  * @{
@@ -4191,7 +4493,8 @@ void mpack_discard(mpack_reader_t* reader);
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-void mpack_print_data_to_buffer(const char* data, size_t data_size, char* buffer, size_t buffer_size);
+void mpack_print_data_to_buffer(
+    const char *data, size_t data_size, char *buffer, size_t buffer_size);
 
 /*
  * Converts a node to pseudo-JSON for debugging purposes, calling the given
@@ -4202,19 +4505,22 @@ void mpack_print_data_to_buffer(const char* data, size_t data_size, char* buffer
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-void mpack_print_data_to_callback(const char* data, size_t size, mpack_print_callback_t callback, void* context);
+void mpack_print_data_to_callback(const char *data, size_t size,
+    mpack_print_callback_t callback, void *context);
 
 /*
  * Converts a blob of MessagePack to pseudo-JSON for debugging purposes
  * and pretty-prints it to the given file.
  */
-void mpack_print_data_to_file(const char* data, size_t len, FILE* file);
+void mpack_print_data_to_file(const char *data, size_t len, FILE *file);
 
 /*
  * Converts a blob of MessagePack to pseudo-JSON for debugging purposes
  * and pretty-prints it to stdout.
  */
-MPACK_INLINE void mpack_print_data_to_stdout(const char* data, size_t len) {
+MPACK_INLINE void
+mpack_print_data_to_stdout(const char *data, size_t len)
+{
     mpack_print_data_to_file(data, len, stdout);
 }
 
@@ -4223,21 +4529,24 @@ MPACK_INLINE void mpack_print_data_to_stdout(const char* data, size_t len) {
  * debugging purposes, calling the given callback as many times as is necessary
  * to output the character data.
  */
-void mpack_print_stdfile_to_callback(FILE* file, mpack_print_callback_t callback, void* context);
+void mpack_print_stdfile_to_callback(
+    FILE *file, mpack_print_callback_t callback, void *context);
 
 /*
  * Deprecated.
  *
  * \deprecated Renamed to mpack_print_data_to_stdout().
  */
-MPACK_INLINE void mpack_print(const char* data, size_t len) {
+MPACK_INLINE void
+mpack_print(const char *data, size_t len)
+{
     mpack_print_data_to_stdout(data, len);
 }
 
 /**
  * @}
  */
-#endif
+#        endif
 
 /** @endcond */
 
@@ -4245,32 +4554,36 @@ MPACK_INLINE void mpack_print(const char* data, size_t len) {
  * @}
  */
 
+#        if MPACK_INTERNAL
 
-
-#if MPACK_INTERNAL
-
-bool mpack_reader_ensure_straddle(mpack_reader_t* reader, size_t count);
+bool mpack_reader_ensure_straddle(mpack_reader_t *reader, size_t count);
 
 /*
  * Ensures there are at least @c count bytes left in the
  * data, raising an error and returning false if more
  * data cannot be made available.
  */
-MPACK_INLINE bool mpack_reader_ensure(mpack_reader_t* reader, size_t count) {
+MPACK_INLINE bool
+mpack_reader_ensure(mpack_reader_t *reader, size_t count)
+{
     mpack_assert(count != 0, "cannot ensure zero bytes!");
-    mpack_assert(reader->error == mpack_ok, "reader cannot be in an error state!");
+    mpack_assert(
+        reader->error == mpack_ok, "reader cannot be in an error state!");
 
     if (count <= (size_t)(reader->end - reader->data))
         return true;
     return mpack_reader_ensure_straddle(reader, count);
 }
 
-void mpack_read_native_straddle(mpack_reader_t* reader, char* p, size_t count);
+void mpack_read_native_straddle(mpack_reader_t *reader, char *p, size_t count);
 
 // Reads count bytes into p, deferring to mpack_read_native_straddle() if more
 // bytes are needed than are available in the buffer.
-MPACK_INLINE void mpack_read_native(mpack_reader_t* reader, char* p, size_t count) {
-    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL", (int)count);
+MPACK_INLINE void
+mpack_read_native(mpack_reader_t *reader, char *p, size_t count)
+{
+    mpack_assert(count == 0 || p != NULL, "data pointer for %i bytes is NULL",
+        (int)count);
 
     if (count > (size_t)(reader->end - reader->data)) {
         mpack_read_native_straddle(reader, p, count);
@@ -4280,41 +4593,54 @@ MPACK_INLINE void mpack_read_native(mpack_reader_t* reader, char* p, size_t coun
     }
 }
 
-#if MPACK_READ_TRACKING
-#define MPACK_READER_TRACK(reader, error_expr) \
-    (((reader)->error == mpack_ok) ? mpack_reader_flag_if_error((reader), (error_expr)) : (reader)->error)
-#else
-#define MPACK_READER_TRACK(reader, error_expr) (MPACK_UNUSED(reader), mpack_ok)
-#endif
+#            if MPACK_READ_TRACKING
+#                define MPACK_READER_TRACK(reader, error_expr)                 \
+                    (((reader)->error == mpack_ok)                             \
+                            ? mpack_reader_flag_if_error(                      \
+                                (reader), (error_expr))                        \
+                            : (reader)->error)
+#            else
+#                define MPACK_READER_TRACK(reader, error_expr)                 \
+                    (MPACK_UNUSED(reader), mpack_ok)
+#            endif
 
-MPACK_INLINE mpack_error_t mpack_reader_track_element(mpack_reader_t* reader) {
-    return MPACK_READER_TRACK(reader, mpack_track_element(&reader->track, true));
+MPACK_INLINE mpack_error_t
+mpack_reader_track_element(mpack_reader_t *reader)
+{
+    return MPACK_READER_TRACK(
+        reader, mpack_track_element(&reader->track, true));
 }
 
-MPACK_INLINE mpack_error_t mpack_reader_track_peek_element(mpack_reader_t* reader) {
-    return MPACK_READER_TRACK(reader, mpack_track_peek_element(&reader->track, true));
+MPACK_INLINE mpack_error_t
+mpack_reader_track_peek_element(mpack_reader_t *reader)
+{
+    return MPACK_READER_TRACK(
+        reader, mpack_track_peek_element(&reader->track, true));
 }
 
-MPACK_INLINE mpack_error_t mpack_reader_track_bytes(mpack_reader_t* reader, uint64_t count) {
+MPACK_INLINE mpack_error_t
+mpack_reader_track_bytes(mpack_reader_t *reader, uint64_t count)
+{
     MPACK_UNUSED(count);
-    return MPACK_READER_TRACK(reader, mpack_track_bytes(&reader->track, true, count));
+    return MPACK_READER_TRACK(
+        reader, mpack_track_bytes(&reader->track, true, count));
 }
 
-MPACK_INLINE mpack_error_t mpack_reader_track_str_bytes_all(mpack_reader_t* reader, uint64_t count) {
+MPACK_INLINE mpack_error_t
+mpack_reader_track_str_bytes_all(mpack_reader_t *reader, uint64_t count)
+{
     MPACK_UNUSED(count);
-    return MPACK_READER_TRACK(reader, mpack_track_str_bytes_all(&reader->track, true, count));
+    return MPACK_READER_TRACK(
+        reader, mpack_track_str_bytes_all(&reader->track, true, count));
 }
 
-#endif
+#        endif
 
-
-
-#endif
+#    endif
 
 MPACK_HEADER_END
 
 #endif
-
 
 /* mpack/mpack-expect.h.h */
 
@@ -4325,17 +4651,17 @@ MPACK_HEADER_END
  */
 
 #ifndef MPACK_EXPECT_H
-#define MPACK_EXPECT_H 1
+#    define MPACK_EXPECT_H 1
 
 /* #include "mpack-reader.h" */
 
 MPACK_HEADER_START
 
-#if MPACK_EXPECT
+#    if MPACK_EXPECT
 
-#if !MPACK_READER
-#error "MPACK_EXPECT requires MPACK_READER."
-#endif
+#        if !MPACK_READER
+#            error "MPACK_EXPECT requires MPACK_READER."
+#        endif
 
 /**
  * @defgroup expect Expect API
@@ -4372,7 +4698,7 @@ MPACK_HEADER_START
  *
  * Returns zero if an error occurs.
  */
-uint8_t mpack_expect_u8(mpack_reader_t* reader);
+uint8_t mpack_expect_u8(mpack_reader_t *reader);
 
 /**
  * Reads a 16-bit unsigned integer.
@@ -4382,7 +4708,7 @@ uint8_t mpack_expect_u8(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-uint16_t mpack_expect_u16(mpack_reader_t* reader);
+uint16_t mpack_expect_u16(mpack_reader_t *reader);
 
 /**
  * Reads a 32-bit unsigned integer.
@@ -4392,7 +4718,7 @@ uint16_t mpack_expect_u16(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-uint32_t mpack_expect_u32(mpack_reader_t* reader);
+uint32_t mpack_expect_u32(mpack_reader_t *reader);
 
 /**
  * Reads a 64-bit unsigned integer.
@@ -4402,7 +4728,7 @@ uint32_t mpack_expect_u32(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-uint64_t mpack_expect_u64(mpack_reader_t* reader);
+uint64_t mpack_expect_u64(mpack_reader_t *reader);
 
 /**
  * Reads an 8-bit signed integer.
@@ -4412,7 +4738,7 @@ uint64_t mpack_expect_u64(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-int8_t mpack_expect_i8(mpack_reader_t* reader);
+int8_t mpack_expect_i8(mpack_reader_t *reader);
 
 /**
  * Reads a 16-bit signed integer.
@@ -4422,7 +4748,7 @@ int8_t mpack_expect_i8(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-int16_t mpack_expect_i16(mpack_reader_t* reader);
+int16_t mpack_expect_i16(mpack_reader_t *reader);
 
 /**
  * Reads a 32-bit signed integer.
@@ -4432,7 +4758,7 @@ int16_t mpack_expect_i16(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-int32_t mpack_expect_i32(mpack_reader_t* reader);
+int32_t mpack_expect_i32(mpack_reader_t *reader);
 
 /**
  * Reads a 64-bit signed integer.
@@ -4442,45 +4768,47 @@ int32_t mpack_expect_i32(mpack_reader_t* reader);
  *
  * Returns zero if an error occurs.
  */
-int64_t mpack_expect_i64(mpack_reader_t* reader);
+int64_t mpack_expect_i64(mpack_reader_t *reader);
 
 /**
- * Reads a number, returning the value as a float. The underlying value can be an
- * integer, float or double; the value is converted to a float.
+ * Reads a number, returning the value as a float. The underlying value can be
+ * an integer, float or double; the value is converted to a float.
  *
  * @note Reading a double or a large integer with this function can incur a
  * loss of precision.
  *
- * @throws mpack_error_type if the underlying value is not a float, double or integer.
+ * @throws mpack_error_type if the underlying value is not a float, double or
+ * integer.
  */
-float mpack_expect_float(mpack_reader_t* reader);
+float mpack_expect_float(mpack_reader_t *reader);
 
 /**
- * Reads a number, returning the value as a double. The underlying value can be an
- * integer, float or double; the value is converted to a double.
+ * Reads a number, returning the value as a double. The underlying value can be
+ * an integer, float or double; the value is converted to a double.
  *
  * @note Reading a very large integer with this function can incur a
  * loss of precision.
  *
- * @throws mpack_error_type if the underlying value is not a float, double or integer.
+ * @throws mpack_error_type if the underlying value is not a float, double or
+ * integer.
  */
-double mpack_expect_double(mpack_reader_t* reader);
+double mpack_expect_double(mpack_reader_t *reader);
 
 /**
- * Reads a float. The underlying value must be a float, not a double or an integer.
- * This ensures no loss of precision can occur.
+ * Reads a float. The underlying value must be a float, not a double or an
+ * integer. This ensures no loss of precision can occur.
  *
  * @throws mpack_error_type if the underlying value is not a float.
  */
-float mpack_expect_float_strict(mpack_reader_t* reader);
+float mpack_expect_float_strict(mpack_reader_t *reader);
 
 /**
- * Reads a double. The underlying value must be a float or double, not an integer.
- * This ensures no loss of precision can occur.
+ * Reads a double. The underlying value must be a float or double, not an
+ * integer. This ensures no loss of precision can occur.
  *
  * @throws mpack_error_type if the underlying value is not a float or double.
  */
-double mpack_expect_double_strict(mpack_reader_t* reader);
+double mpack_expect_double_strict(mpack_reader_t *reader);
 
 /**
  * @}
@@ -4492,44 +4820,52 @@ double mpack_expect_double_strict(mpack_reader_t* reader);
  */
 
 /**
- * Reads an 8-bit unsigned integer, ensuring that it falls within the given range.
+ * Reads an 8-bit unsigned integer, ensuring that it falls within the given
+ * range.
  *
  * The underlying type may be an integer type of any size and signedness,
  * as long as the value can be represented in an 8-bit unsigned int.
  *
  * Returns min_value if an error occurs.
  */
-uint8_t mpack_expect_u8_range(mpack_reader_t* reader, uint8_t min_value, uint8_t max_value);
+uint8_t mpack_expect_u8_range(
+    mpack_reader_t *reader, uint8_t min_value, uint8_t max_value);
 
 /**
- * Reads a 16-bit unsigned integer, ensuring that it falls within the given range.
+ * Reads a 16-bit unsigned integer, ensuring that it falls within the given
+ * range.
  *
  * The underlying type may be an integer type of any size and signedness,
  * as long as the value can be represented in a 16-bit unsigned int.
  *
  * Returns min_value if an error occurs.
  */
-uint16_t mpack_expect_u16_range(mpack_reader_t* reader, uint16_t min_value, uint16_t max_value);
+uint16_t mpack_expect_u16_range(
+    mpack_reader_t *reader, uint16_t min_value, uint16_t max_value);
 
 /**
- * Reads a 32-bit unsigned integer, ensuring that it falls within the given range.
+ * Reads a 32-bit unsigned integer, ensuring that it falls within the given
+ * range.
  *
  * The underlying type may be an integer type of any size and signedness,
  * as long as the value can be represented in a 32-bit unsigned int.
  *
  * Returns min_value if an error occurs.
  */
-uint32_t mpack_expect_u32_range(mpack_reader_t* reader, uint32_t min_value, uint32_t max_value);
+uint32_t mpack_expect_u32_range(
+    mpack_reader_t *reader, uint32_t min_value, uint32_t max_value);
 
 /**
- * Reads a 64-bit unsigned integer, ensuring that it falls within the given range.
+ * Reads a 64-bit unsigned integer, ensuring that it falls within the given
+ * range.
  *
  * The underlying type may be an integer type of any size and signedness,
  * as long as the value can be represented in a 64-bit unsigned int.
  *
  * Returns min_value if an error occurs.
  */
-uint64_t mpack_expect_u64_range(mpack_reader_t* reader, uint64_t min_value, uint64_t max_value);
+uint64_t mpack_expect_u64_range(
+    mpack_reader_t *reader, uint64_t min_value, uint64_t max_value);
 
 /**
  * Reads an unsigned integer, ensuring that it falls within the given range.
@@ -4539,11 +4875,15 @@ uint64_t mpack_expect_u64_range(mpack_reader_t* reader, uint64_t min_value, uint
  *
  * Returns min_value if an error occurs.
  */
-MPACK_INLINE unsigned int mpack_expect_uint_range(mpack_reader_t* reader, unsigned int min_value, unsigned int max_value) {
+MPACK_INLINE unsigned int
+mpack_expect_uint_range(
+    mpack_reader_t *reader, unsigned int min_value, unsigned int max_value)
+{
     // This should be true at compile-time, so this just wraps the 32-bit
     // function. We fallback to 64-bit if for some reason sizeof(int) isn't 4.
     if (sizeof(unsigned int) == 4)
-        return (unsigned int)mpack_expect_u32_range(reader, (uint32_t)min_value, (uint32_t)max_value);
+        return (unsigned int)mpack_expect_u32_range(
+            reader, (uint32_t)min_value, (uint32_t)max_value);
     return (unsigned int)mpack_expect_u64_range(reader, min_value, max_value);
 }
 
@@ -4555,7 +4895,9 @@ MPACK_INLINE unsigned int mpack_expect_uint_range(mpack_reader_t* reader, unsign
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE uint8_t mpack_expect_u8_max(mpack_reader_t* reader, uint8_t max_value) {
+MPACK_INLINE uint8_t
+mpack_expect_u8_max(mpack_reader_t *reader, uint8_t max_value)
+{
     return mpack_expect_u8_range(reader, 0, max_value);
 }
 
@@ -4567,7 +4909,9 @@ MPACK_INLINE uint8_t mpack_expect_u8_max(mpack_reader_t* reader, uint8_t max_val
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE uint16_t mpack_expect_u16_max(mpack_reader_t* reader, uint16_t max_value) {
+MPACK_INLINE uint16_t
+mpack_expect_u16_max(mpack_reader_t *reader, uint16_t max_value)
+{
     return mpack_expect_u16_range(reader, 0, max_value);
 }
 
@@ -4579,7 +4923,9 @@ MPACK_INLINE uint16_t mpack_expect_u16_max(mpack_reader_t* reader, uint16_t max_
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE uint32_t mpack_expect_u32_max(mpack_reader_t* reader, uint32_t max_value) {
+MPACK_INLINE uint32_t
+mpack_expect_u32_max(mpack_reader_t *reader, uint32_t max_value)
+{
     return mpack_expect_u32_range(reader, 0, max_value);
 }
 
@@ -4591,7 +4937,9 @@ MPACK_INLINE uint32_t mpack_expect_u32_max(mpack_reader_t* reader, uint32_t max_
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE uint64_t mpack_expect_u64_max(mpack_reader_t* reader, uint64_t max_value) {
+MPACK_INLINE uint64_t
+mpack_expect_u64_max(mpack_reader_t *reader, uint64_t max_value)
+{
     return mpack_expect_u64_range(reader, 0, max_value);
 }
 
@@ -4603,7 +4951,9 @@ MPACK_INLINE uint64_t mpack_expect_u64_max(mpack_reader_t* reader, uint64_t max_
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE unsigned int mpack_expect_uint_max(mpack_reader_t* reader, unsigned int max_value) {
+MPACK_INLINE unsigned int
+mpack_expect_uint_max(mpack_reader_t *reader, unsigned int max_value)
+{
     return mpack_expect_uint_range(reader, 0, max_value);
 }
 
@@ -4615,7 +4965,8 @@ MPACK_INLINE unsigned int mpack_expect_uint_max(mpack_reader_t* reader, unsigned
  *
  * Returns min_value if an error occurs.
  */
-int8_t mpack_expect_i8_range(mpack_reader_t* reader, int8_t min_value, int8_t max_value);
+int8_t mpack_expect_i8_range(
+    mpack_reader_t *reader, int8_t min_value, int8_t max_value);
 
 /**
  * Reads a 16-bit signed integer, ensuring that it falls within the given range.
@@ -4625,7 +4976,8 @@ int8_t mpack_expect_i8_range(mpack_reader_t* reader, int8_t min_value, int8_t ma
  *
  * Returns min_value if an error occurs.
  */
-int16_t mpack_expect_i16_range(mpack_reader_t* reader, int16_t min_value, int16_t max_value);
+int16_t mpack_expect_i16_range(
+    mpack_reader_t *reader, int16_t min_value, int16_t max_value);
 
 /**
  * Reads a 32-bit signed integer, ensuring that it falls within the given range.
@@ -4635,7 +4987,8 @@ int16_t mpack_expect_i16_range(mpack_reader_t* reader, int16_t min_value, int16_
  *
  * Returns min_value if an error occurs.
  */
-int32_t mpack_expect_i32_range(mpack_reader_t* reader, int32_t min_value, int32_t max_value);
+int32_t mpack_expect_i32_range(
+    mpack_reader_t *reader, int32_t min_value, int32_t max_value);
 
 /**
  * Reads a 64-bit signed integer, ensuring that it falls within the given range.
@@ -4645,7 +4998,8 @@ int32_t mpack_expect_i32_range(mpack_reader_t* reader, int32_t min_value, int32_
  *
  * Returns min_value if an error occurs.
  */
-int64_t mpack_expect_i64_range(mpack_reader_t* reader, int64_t min_value, int64_t max_value);
+int64_t mpack_expect_i64_range(
+    mpack_reader_t *reader, int64_t min_value, int64_t max_value);
 
 /**
  * Reads a signed integer, ensuring that it falls within the given range.
@@ -4655,11 +5009,14 @@ int64_t mpack_expect_i64_range(mpack_reader_t* reader, int64_t min_value, int64_
  *
  * Returns min_value if an error occurs.
  */
-MPACK_INLINE int mpack_expect_int_range(mpack_reader_t* reader, int min_value, int max_value) {
+MPACK_INLINE int
+mpack_expect_int_range(mpack_reader_t *reader, int min_value, int max_value)
+{
     // This should be true at compile-time, so this just wraps the 32-bit
     // function. We fallback to 64-bit if for some reason sizeof(int) isn't 4.
     if (sizeof(int) == 4)
-        return (int)mpack_expect_i32_range(reader, (int32_t)min_value, (int32_t)max_value);
+        return (int)mpack_expect_i32_range(
+            reader, (int32_t)min_value, (int32_t)max_value);
     return (int)mpack_expect_i64_range(reader, min_value, max_value);
 }
 
@@ -4672,7 +5029,9 @@ MPACK_INLINE int mpack_expect_int_range(mpack_reader_t* reader, int min_value, i
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE int8_t mpack_expect_i8_max(mpack_reader_t* reader, int8_t max_value) {
+MPACK_INLINE int8_t
+mpack_expect_i8_max(mpack_reader_t *reader, int8_t max_value)
+{
     return mpack_expect_i8_range(reader, 0, max_value);
 }
 
@@ -4685,7 +5044,9 @@ MPACK_INLINE int8_t mpack_expect_i8_max(mpack_reader_t* reader, int8_t max_value
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE int16_t mpack_expect_i16_max(mpack_reader_t* reader, int16_t max_value) {
+MPACK_INLINE int16_t
+mpack_expect_i16_max(mpack_reader_t *reader, int16_t max_value)
+{
     return mpack_expect_i16_range(reader, 0, max_value);
 }
 
@@ -4698,7 +5059,9 @@ MPACK_INLINE int16_t mpack_expect_i16_max(mpack_reader_t* reader, int16_t max_va
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE int32_t mpack_expect_i32_max(mpack_reader_t* reader, int32_t max_value) {
+MPACK_INLINE int32_t
+mpack_expect_i32_max(mpack_reader_t *reader, int32_t max_value)
+{
     return mpack_expect_i32_range(reader, 0, max_value);
 }
 
@@ -4711,7 +5074,9 @@ MPACK_INLINE int32_t mpack_expect_i32_max(mpack_reader_t* reader, int32_t max_va
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE int64_t mpack_expect_i64_max(mpack_reader_t* reader, int64_t max_value) {
+MPACK_INLINE int64_t
+mpack_expect_i64_max(mpack_reader_t *reader, int64_t max_value)
+{
     return mpack_expect_i64_range(reader, 0, max_value);
 }
 
@@ -4723,7 +5088,9 @@ MPACK_INLINE int64_t mpack_expect_i64_max(mpack_reader_t* reader, int64_t max_va
  *
  * Returns 0 if an error occurs.
  */
-MPACK_INLINE int mpack_expect_int_max(mpack_reader_t* reader, int max_value) {
+MPACK_INLINE int
+mpack_expect_int_max(mpack_reader_t *reader, int max_value)
+{
     return mpack_expect_int_range(reader, 0, max_value);
 }
 
@@ -4735,9 +5102,11 @@ MPACK_INLINE int mpack_expect_int_max(mpack_reader_t* reader, int max_value) {
  * @note Reading a double or a large integer with this function can incur a
  * loss of precision.
  *
- * @throws mpack_error_type if the underlying value is not a float, double or integer.
+ * @throws mpack_error_type if the underlying value is not a float, double or
+ * integer.
  */
-float mpack_expect_float_range(mpack_reader_t* reader, float min_value, float max_value);
+float mpack_expect_float_range(
+    mpack_reader_t *reader, float min_value, float max_value);
 
 /**
  * Reads a number, ensuring that it falls within the given range and returning
@@ -4747,15 +5116,15 @@ float mpack_expect_float_range(mpack_reader_t* reader, float min_value, float ma
  * @note Reading a very large integer with this function can incur a
  * loss of precision.
  *
- * @throws mpack_error_type if the underlying value is not a float, double or integer.
+ * @throws mpack_error_type if the underlying value is not a float, double or
+ * integer.
  */
-double mpack_expect_double_range(mpack_reader_t* reader, double min_value, double max_value);
+double mpack_expect_double_range(
+    mpack_reader_t *reader, double min_value, double max_value);
 
 /**
  * @}
  */
-
-
 
 // These are additional Basic Number functions that wrap inline range functions.
 
@@ -4772,15 +5141,17 @@ double mpack_expect_double_range(mpack_reader_t* reader, double min_value, doubl
  *
  * Returns zero if an error occurs.
  */
-MPACK_INLINE unsigned int mpack_expect_uint(mpack_reader_t* reader) {
+MPACK_INLINE unsigned int
+mpack_expect_uint(mpack_reader_t *reader)
+{
 
-    // This should be true at compile-time, so this just wraps the 32-bit function.
+    // This should be true at compile-time, so this just wraps the 32-bit
+    // function.
     if (sizeof(unsigned int) == 4)
         return (unsigned int)mpack_expect_u32(reader);
 
     // Otherwise we wrap the max function to ensure it fits.
     return (unsigned int)mpack_expect_u64_max(reader, UINT_MAX);
-
 }
 
 /**
@@ -4791,22 +5162,22 @@ MPACK_INLINE unsigned int mpack_expect_uint(mpack_reader_t* reader) {
  *
  * Returns zero if an error occurs.
  */
-MPACK_INLINE int mpack_expect_int(mpack_reader_t* reader) {
+MPACK_INLINE int
+mpack_expect_int(mpack_reader_t *reader)
+{
 
-    // This should be true at compile-time, so this just wraps the 32-bit function.
+    // This should be true at compile-time, so this just wraps the 32-bit
+    // function.
     if (sizeof(int) == 4)
         return (int)mpack_expect_i32(reader);
 
     // Otherwise we wrap the range function to ensure it fits.
     return (int)mpack_expect_i64_range(reader, INT_MIN, INT_MAX);
-
 }
 
 /**
  * @}
  */
-
-
 
 /**
  * @name Matching Number Functions
@@ -4819,7 +5190,7 @@ MPACK_INLINE int mpack_expect_int(mpack_reader_t* reader) {
  * mpack_error_type is raised if the value is not representable as an unsigned
  * integer or if it does not exactly match the given value.
  */
-void mpack_expect_uint_match(mpack_reader_t* reader, uint64_t value);
+void mpack_expect_uint_match(mpack_reader_t *reader, uint64_t value);
 
 /**
  * Reads a signed integer, ensuring that it exactly matches the given value.
@@ -4827,7 +5198,7 @@ void mpack_expect_uint_match(mpack_reader_t* reader, uint64_t value);
  * mpack_error_type is raised if the value is not representable as a signed
  * integer or if it does not exactly match the given value.
  */
-void mpack_expect_int_match(mpack_reader_t* reader, int64_t value);
+void mpack_expect_int_match(mpack_reader_t *reader, int64_t value);
 
 /**
  * @name Other Basic Types
@@ -4837,24 +5208,25 @@ void mpack_expect_int_match(mpack_reader_t* reader, int64_t value);
 /**
  * Reads a nil, raising @ref mpack_error_type if the value is not nil.
  */
-void mpack_expect_nil(mpack_reader_t* reader);
+void mpack_expect_nil(mpack_reader_t *reader);
 
 /**
  * Reads a boolean.
  *
- * @note Integers will raise mpack_error_type; the value must be strictly a boolean.
+ * @note Integers will raise mpack_error_type; the value must be strictly a
+ * boolean.
  */
-bool mpack_expect_bool(mpack_reader_t* reader);
+bool mpack_expect_bool(mpack_reader_t *reader);
 
 /**
  * Reads a boolean, raising @ref mpack_error_type if its value is not @c true.
  */
-void mpack_expect_true(mpack_reader_t* reader);
+void mpack_expect_true(mpack_reader_t *reader);
 
 /**
  * Reads a boolean, raising @ref mpack_error_type if its value is not @c false.
  */
-void mpack_expect_false(mpack_reader_t* reader);
+void mpack_expect_false(mpack_reader_t *reader);
 
 /**
  * @}
@@ -4865,21 +5237,21 @@ void mpack_expect_false(mpack_reader_t* reader);
  * @{
  */
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Reads a timestamp.
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-mpack_timestamp_t mpack_expect_timestamp(mpack_reader_t* reader);
+mpack_timestamp_t mpack_expect_timestamp(mpack_reader_t *reader);
 
 /**
  * Reads a timestamp in seconds, truncating the nanoseconds (if any).
  *
  * @note This requires @ref MPACK_EXTENSIONS.
  */
-int64_t mpack_expect_timestamp_truncate(mpack_reader_t* reader);
-#endif
+int64_t mpack_expect_timestamp_truncate(mpack_reader_t *reader);
+#        endif
 
 /**
  * @}
@@ -4912,11 +5284,11 @@ int64_t mpack_expect_timestamp_truncate(mpack_reader_t* reader);
  *
  * @throws mpack_error_type if the value is not a map.
  */
-uint32_t mpack_expect_map(mpack_reader_t* reader);
+uint32_t mpack_expect_map(mpack_reader_t *reader);
 
 /**
- * Reads the start of a map with a number of elements in the given range, returning
- * its element count.
+ * Reads the start of a map with a number of elements in the given range,
+ * returning its element count.
  *
  * A number of values follow equal to twice the element count of the map,
  * alternating between keys and values. @ref mpack_done_map() must be called
@@ -4931,7 +5303,8 @@ uint32_t mpack_expect_map(mpack_reader_t* reader);
  * @throws mpack_error_type if the value is not a map or if its size does
  * not fall within the given range.
  */
-uint32_t mpack_expect_map_range(mpack_reader_t* reader, uint32_t min_count, uint32_t max_count);
+uint32_t mpack_expect_map_range(
+    mpack_reader_t *reader, uint32_t min_count, uint32_t max_count);
 
 /**
  * Reads the start of a map with a number of elements at most @a max_count,
@@ -4950,7 +5323,9 @@ uint32_t mpack_expect_map_range(mpack_reader_t* reader, uint32_t min_count, uint
  * @throws mpack_error_type if the value is not a map or if its size is
  * greater than max_count.
  */
-MPACK_INLINE uint32_t mpack_expect_map_max(mpack_reader_t* reader, uint32_t max_count) {
+MPACK_INLINE uint32_t
+mpack_expect_map_max(mpack_reader_t *reader, uint32_t max_count)
+{
     return mpack_expect_map_range(reader, 0, max_count);
 }
 
@@ -4968,7 +5343,7 @@ MPACK_INLINE uint32_t mpack_expect_map_max(mpack_reader_t* reader, uint32_t max_
  * @throws mpack_error_type if the value is not a map or if its size
  * does not match the given count.
  */
-void mpack_expect_map_match(mpack_reader_t* reader, uint32_t count);
+void mpack_expect_map_match(mpack_reader_t *reader, uint32_t count);
 
 /**
  * Reads a nil node or the start of a map, returning whether a map was
@@ -4988,14 +5363,14 @@ void mpack_expect_map_match(mpack_reader_t* reader, uint32_t count);
  * through the map's contents, you must check for errors on each iteration
  * of the loop. Otherwise an attacker could craft a message declaring a map
  * of a billion elements which would throw your parsing code into an
- * infinite loop! You should strongly consider using mpack_expect_map_max_or_nil()
- * with a safe maximum size instead.
+ * infinite loop! You should strongly consider using
+ * mpack_expect_map_max_or_nil() with a safe maximum size instead.
  *
  * @returns @c true if a map was read successfully; @c false if nil was read
  *     or an error occured.
  * @throws mpack_error_type if the value is not a nil or map.
  */
-bool mpack_expect_map_or_nil(mpack_reader_t* reader, uint32_t* count);
+bool mpack_expect_map_or_nil(mpack_reader_t *reader, uint32_t *count);
 
 /**
  * Reads a nil node or the start of a map with a number of elements at most
@@ -5008,14 +5383,16 @@ bool mpack_expect_map_or_nil(mpack_reader_t* reader, uint32_t* count);
  *
  * @note Maps in JSON are unordered, so it is recommended not to expect
  * a specific ordering for your map values in case your data is converted
- * to/from JSON. Consider using mpack_expect_key_cstr() or mpack_expect_key_uint()
- * to switch on the key; see @ref docs/expect.md for examples.
+ * to/from JSON. Consider using mpack_expect_key_cstr() or
+ * mpack_expect_key_uint() to switch on the key; see @ref docs/expect.md for
+ * examples.
  *
  * @returns @c true if a map was read successfully; @c false if nil was read
  *     or an error occured.
  * @throws mpack_error_type if the value is not a nil or map.
  */
-bool mpack_expect_map_max_or_nil(mpack_reader_t* reader, uint32_t max_count, uint32_t* count);
+bool mpack_expect_map_max_or_nil(
+    mpack_reader_t *reader, uint32_t max_count, uint32_t *count);
 
 /**
  * Reads the start of an array, returning its element count.
@@ -5032,7 +5409,7 @@ bool mpack_expect_map_max_or_nil(mpack_reader_t* reader, uint32_t max_count, uin
  * infinite loop! You should strongly consider using mpack_expect_array_max()
  * with a safe maximum size instead.
  */
-uint32_t mpack_expect_array(mpack_reader_t* reader);
+uint32_t mpack_expect_array(mpack_reader_t *reader);
 
 /**
  * Reads the start of an array with a number of elements in the given range,
@@ -5046,7 +5423,8 @@ uint32_t mpack_expect_array(mpack_reader_t* reader);
  * @throws mpack_error_type if the value is not an array or if its size does
  * not fall within the given range.
  */
-uint32_t mpack_expect_array_range(mpack_reader_t* reader, uint32_t min_count, uint32_t max_count);
+uint32_t mpack_expect_array_range(
+    mpack_reader_t *reader, uint32_t min_count, uint32_t max_count);
 
 /**
  * Reads the start of an array with a number of elements at most @a max_count,
@@ -5060,7 +5438,9 @@ uint32_t mpack_expect_array_range(mpack_reader_t* reader, uint32_t min_count, ui
  * @throws mpack_error_type if the value is not an array or if its size is
  * greater than max_count.
  */
-MPACK_INLINE uint32_t mpack_expect_array_max(mpack_reader_t* reader, uint32_t max_count) {
+MPACK_INLINE uint32_t
+mpack_expect_array_max(mpack_reader_t *reader, uint32_t max_count)
+{
     return mpack_expect_array_range(reader, 0, max_count);
 }
 
@@ -5073,7 +5453,7 @@ MPACK_INLINE uint32_t mpack_expect_array_max(mpack_reader_t* reader, uint32_t ma
  * @throws mpack_error_type if the value is not an array or if its size does
  * not match the given count.
  */
-void mpack_expect_array_match(mpack_reader_t* reader, uint32_t count);
+void mpack_expect_array_match(mpack_reader_t *reader, uint32_t count);
 
 /**
  * Reads a nil node or the start of an array, returning whether an array was
@@ -5089,14 +5469,14 @@ void mpack_expect_array_match(mpack_reader_t* reader, uint32_t count);
  * through the array's contents, you must check for errors on each iteration
  * of the loop. Otherwise an attacker could craft a message declaring an array
  * of a billion elements which would throw your parsing code into an
- * infinite loop! You should strongly consider using mpack_expect_array_max_or_nil()
- * with a safe maximum size instead.
+ * infinite loop! You should strongly consider using
+ * mpack_expect_array_max_or_nil() with a safe maximum size instead.
  *
  * @returns @c true if an array was read successfully; @c false if nil was read
  *     or an error occured.
  * @throws mpack_error_type if the value is not a nil or array.
  */
-bool mpack_expect_array_or_nil(mpack_reader_t* reader, uint32_t* count);
+bool mpack_expect_array_or_nil(mpack_reader_t *reader, uint32_t *count);
 
 /**
  * Reads a nil node or the start of an array with a number of elements at most
@@ -5111,9 +5491,10 @@ bool mpack_expect_array_or_nil(mpack_reader_t* reader, uint32_t* count);
  *     or an error occured.
  * @throws mpack_error_type if the value is not a nil or array.
  */
-bool mpack_expect_array_max_or_nil(mpack_reader_t* reader, uint32_t max_count, uint32_t* count);
+bool mpack_expect_array_max_or_nil(
+    mpack_reader_t *reader, uint32_t max_count, uint32_t *count);
 
-#ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
 /**
  * @hideinitializer
  *
@@ -5135,15 +5516,17 @@ bool mpack_expect_array_max_or_nil(mpack_reader_t* reader, uint32_t max_count, u
  * @throws mpack_error_type if the value is not an array or if its size is
  * greater than max_count.
  */
-#define mpack_expect_array_alloc(reader, Type, max_count, out_count) \
-    ((Type*)mpack_expect_array_alloc_impl(reader, sizeof(Type), max_count, out_count, false))
+#            define mpack_expect_array_alloc(                                  \
+                reader, Type, max_count, out_count)                            \
+                ((Type *)mpack_expect_array_alloc_impl(                        \
+                    reader, sizeof(Type), max_count, out_count, false))
 
 /**
  * @hideinitializer
  *
  * Reads a nil node or the start of an array and allocates storage for it,
- * placing its size in out_count. A number of objects follow equal to the element
- * count of the array if a non-empty array was read.
+ * placing its size in out_count. A number of objects follow equal to the
+ * element count of the array if a non-empty array was read.
  *
  * If an error occurs, NULL is returned and the reader is placed in an
  * error state.
@@ -5163,21 +5546,22 @@ bool mpack_expect_array_max_or_nil(mpack_reader_t* reader, uint32_t max_count, u
  * @throws mpack_error_type if the value is not an array or if its size is
  * greater than max_count.
  */
-#define mpack_expect_array_or_nil_alloc(reader, Type, max_count, out_count) \
-    ((Type*)mpack_expect_array_alloc_impl(reader, sizeof(Type), max_count, out_count, true))
-#endif
+#            define mpack_expect_array_or_nil_alloc(                           \
+                reader, Type, max_count, out_count)                            \
+                ((Type *)mpack_expect_array_alloc_impl(                        \
+                    reader, sizeof(Type), max_count, out_count, true))
+#        endif
 
 /**
  * @}
  */
 
 /** @cond */
-#ifdef MPACK_MALLOC
-void* mpack_expect_array_alloc_impl(mpack_reader_t* reader,
-        size_t element_size, uint32_t max_count, uint32_t* out_count, bool allow_nil);
-#endif
+#        ifdef MPACK_MALLOC
+void *mpack_expect_array_alloc_impl(mpack_reader_t *reader, size_t element_size,
+    uint32_t max_count, uint32_t *out_count, bool allow_nil);
+#        endif
 /** @endcond */
-
 
 /**
  * @name String Functions
@@ -5195,7 +5579,7 @@ void* mpack_expect_array_alloc_impl(mpack_reader_t* reader,
  *
  * mpack_error_type is raised if the value is not a string.
  */
-uint32_t mpack_expect_str(mpack_reader_t* reader);
+uint32_t mpack_expect_str(mpack_reader_t *reader);
 
 /**
  * Reads a string of at most the given size, writing it into the
@@ -5206,7 +5590,7 @@ uint32_t mpack_expect_str(mpack_reader_t* reader);
  *
  * NUL bytes are allowed in the string, and no encoding checks are done.
  */
-size_t mpack_expect_str_buf(mpack_reader_t* reader, char* buf, size_t bufsize);
+size_t mpack_expect_str_buf(mpack_reader_t *reader, char *buf, size_t bufsize);
 
 /**
  * Reads a string into the given buffer, ensuring it is a valid UTF-8 string
@@ -5221,9 +5605,10 @@ size_t mpack_expect_str_buf(mpack_reader_t* reader, char* buf, size_t bufsize);
  * NUL bytes are allowed in the string (as they are in UTF-8.)
  *
  * Raises mpack_error_too_big if there is not enough room for the string.
- * Raises mpack_error_type if the value is not a string or is not a valid UTF-8 string.
+ * Raises mpack_error_type if the value is not a string or is not a valid UTF-8
+ * string.
  */
-size_t mpack_expect_utf8(mpack_reader_t* reader, char* buf, size_t bufsize);
+size_t mpack_expect_utf8(mpack_reader_t *reader, char *buf, size_t bufsize);
 
 /**
  * Reads the start of a string, raising an error if its length is not
@@ -5234,9 +5619,12 @@ size_t mpack_expect_utf8(mpack_reader_t* reader, char* buf, size_t bufsize);
  * once all bytes have been read.
  *
  * @throws mpack_error_type If the value is not a string.
- * @throws mpack_error_too_big If the string's length in bytes is larger than the given maximum size.
+ * @throws mpack_error_too_big If the string's length in bytes is larger than
+ * the given maximum size.
  */
-MPACK_INLINE uint32_t mpack_expect_str_max(mpack_reader_t* reader, uint32_t maxsize) {
+MPACK_INLINE uint32_t
+mpack_expect_str_max(mpack_reader_t *reader, uint32_t maxsize)
+{
     uint32_t length = mpack_expect_str(reader);
     if (length > maxsize) {
         mpack_reader_flag_error(reader, mpack_error_too_big);
@@ -5256,7 +5644,9 @@ MPACK_INLINE uint32_t mpack_expect_str_max(mpack_reader_t* reader, uint32_t maxs
  * mpack_error_type is raised if the value is not a string or if its
  * length does not match.
  */
-MPACK_INLINE void mpack_expect_str_length(mpack_reader_t* reader, uint32_t count) {
+MPACK_INLINE void
+mpack_expect_str_length(mpack_reader_t *reader, uint32_t count)
+{
     if (mpack_expect_str(reader) != count)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
@@ -5267,16 +5657,18 @@ MPACK_INLINE void mpack_expect_str_length(mpack_reader_t* reader, uint32_t count
  * Remember that maps are unordered in JSON. Don't use this for map keys
  * unless the map has only a single key!
  */
-void mpack_expect_str_match(mpack_reader_t* reader, const char* str, size_t length);
+void mpack_expect_str_match(
+    mpack_reader_t *reader, const char *str, size_t length);
 
 /**
  * Reads a string into the given buffer, ensures it has no null bytes,
  * and adds a null-terminator at the end.
  *
- * Raises mpack_error_too_big if there is not enough room for the string and null-terminator.
- * Raises mpack_error_type if the value is not a string or contains a null byte.
+ * Raises mpack_error_too_big if there is not enough room for the string and
+ * null-terminator. Raises mpack_error_type if the value is not a string or
+ * contains a null byte.
  */
-void mpack_expect_cstr(mpack_reader_t* reader, char* buf, size_t size);
+void mpack_expect_cstr(mpack_reader_t *reader, char *buf, size_t size);
 
 /**
  * Reads a string into the given buffer, ensures it is a valid UTF-8 string
@@ -5286,12 +5678,13 @@ void mpack_expect_cstr(mpack_reader_t* reader, char* buf, size_t size);
  * WTF-8. Only pure UTF-8 is allowed, but without the NUL character, since
  * it cannot be represented in a null-terminated string.
  *
- * Raises mpack_error_too_big if there is not enough room for the string and null-terminator.
- * Raises mpack_error_type if the value is not a string or is not a valid UTF-8 string.
+ * Raises mpack_error_too_big if there is not enough room for the string and
+ * null-terminator. Raises mpack_error_type if the value is not a string or is
+ * not a valid UTF-8 string.
  */
-void mpack_expect_utf8_cstr(mpack_reader_t* reader, char* buf, size_t size);
+void mpack_expect_utf8_cstr(mpack_reader_t *reader, char *buf, size_t size);
 
-#ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
 /**
  * Reads a string with the given total maximum size (including space for a
  * null-terminator), allocates storage for it, ensures it has no null-bytes,
@@ -5301,10 +5694,12 @@ void mpack_expect_utf8_cstr(mpack_reader_t* reader, char* buf, size_t size);
  * The allocated string must be freed with MPACK_FREE() (or simply free()
  * if MPack's allocator hasn't been customized.)
  *
- * @throws mpack_error_too_big If the string plus null-terminator is larger than the given maxsize.
- * @throws mpack_error_type If the value is not a string or contains a null byte.
+ * @throws mpack_error_too_big If the string plus null-terminator is larger than
+ * the given maxsize.
+ * @throws mpack_error_type If the value is not a string or contains a null
+ * byte.
  */
-char* mpack_expect_cstr_alloc(mpack_reader_t* reader, size_t maxsize);
+char *mpack_expect_cstr_alloc(mpack_reader_t *reader, size_t maxsize);
 
 /**
  * Reads a string with the given total maximum size (including space for a
@@ -5328,8 +5723,8 @@ char* mpack_expect_cstr_alloc(mpack_reader_t* reader, size_t maxsize);
  * @throws mpack_error_type If the value is not a string or contains
  *     invalid UTF-8 or a null byte.
  */
-char* mpack_expect_utf8_cstr_alloc(mpack_reader_t* reader, size_t maxsize);
-#endif
+char *mpack_expect_utf8_cstr_alloc(mpack_reader_t *reader, size_t maxsize);
+#        endif
 
 /**
  * Reads a string, ensuring it exactly matches the given null-terminated
@@ -5338,7 +5733,9 @@ char* mpack_expect_utf8_cstr_alloc(mpack_reader_t* reader, size_t maxsize);
  * Remember that maps are unordered in JSON. Don't use this for map keys
  * unless the map has only a single key!
  */
-MPACK_INLINE void mpack_expect_cstr_match(mpack_reader_t* reader, const char* cstr) {
+MPACK_INLINE void
+mpack_expect_cstr_match(mpack_reader_t *reader, const char *cstr)
+{
     mpack_assert(cstr != NULL, "cstr pointer is NULL");
     mpack_expect_str_match(reader, cstr, mpack_strlen(cstr));
 }
@@ -5361,7 +5758,7 @@ MPACK_INLINE void mpack_expect_cstr_match(mpack_reader_t* reader, const char* cs
  *
  * mpack_error_type is raised if the value is not a binary blob.
  */
-uint32_t mpack_expect_bin(mpack_reader_t* reader);
+uint32_t mpack_expect_bin(mpack_reader_t *reader);
 
 /**
  * Reads the start of a binary blob, raising an error if its length is not
@@ -5374,7 +5771,9 @@ uint32_t mpack_expect_bin(mpack_reader_t* reader);
  * mpack_error_type is raised if the value is not a binary blob or if its
  * length does not match.
  */
-MPACK_INLINE uint32_t mpack_expect_bin_max(mpack_reader_t* reader, uint32_t maxsize) {
+MPACK_INLINE uint32_t
+mpack_expect_bin_max(mpack_reader_t *reader, uint32_t maxsize)
+{
     uint32_t length = mpack_expect_bin(reader);
     if (length > maxsize) {
         mpack_reader_flag_error(reader, mpack_error_type);
@@ -5394,7 +5793,9 @@ MPACK_INLINE uint32_t mpack_expect_bin_max(mpack_reader_t* reader, uint32_t maxs
  * mpack_error_type is raised if the value is not a binary blob or if its
  * length does not match.
  */
-MPACK_INLINE void mpack_expect_bin_size(mpack_reader_t* reader, uint32_t count) {
+MPACK_INLINE void
+mpack_expect_bin_size(mpack_reader_t *reader, uint32_t count)
+{
     if (mpack_expect_bin(reader) != count)
         mpack_reader_flag_error(reader, mpack_error_type);
 }
@@ -5406,12 +5807,14 @@ MPACK_INLINE void mpack_expect_bin_size(mpack_reader_t* reader, uint32_t count) 
  * binary (since in MessagePack 1.0, strings and binary data were combined
  * under the "raw" type which became string in 1.1.)
  */
-size_t mpack_expect_bin_buf(mpack_reader_t* reader, char* buf, size_t size);
+size_t mpack_expect_bin_buf(mpack_reader_t *reader, char *buf, size_t size);
 
 /**
- * Reads a binary blob with the given total maximum size, allocating storage for it.
+ * Reads a binary blob with the given total maximum size, allocating storage for
+ * it.
  */
-char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* size);
+char *mpack_expect_bin_alloc(
+    mpack_reader_t *reader, size_t maxsize, size_t *size);
 
 /**
  * @}
@@ -5422,7 +5825,7 @@ char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* siz
  * @{
  */
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Reads the start of an extension blob, returning its size in bytes and
  * placing the type into @p type.
@@ -5447,7 +5850,7 @@ char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* siz
  * types in the future, and previously valid data containing reserved types may
  * become invalid in the future.
  */
-uint32_t mpack_expect_ext(mpack_reader_t* reader, int8_t* type);
+uint32_t mpack_expect_ext(mpack_reader_t *reader, int8_t *type);
 
 /**
  * Reads the start of an extension blob, raising an error if its length is not
@@ -5475,7 +5878,9 @@ uint32_t mpack_expect_ext(mpack_reader_t* reader, int8_t* type);
  *
  * @see mpack_expect_ext()
  */
-MPACK_INLINE uint32_t mpack_expect_ext_max(mpack_reader_t* reader, int8_t* type, uint32_t maxsize) {
+MPACK_INLINE uint32_t
+mpack_expect_ext_max(mpack_reader_t *reader, int8_t *type, uint32_t maxsize)
+{
     uint32_t length = mpack_expect_ext(reader, type);
     if (length > maxsize) {
         mpack_reader_flag_error(reader, mpack_error_type);
@@ -5510,7 +5915,9 @@ MPACK_INLINE uint32_t mpack_expect_ext_max(mpack_reader_t* reader, int8_t* type,
  *
  * @see mpack_expect_ext()
  */
-MPACK_INLINE void mpack_expect_ext_size(mpack_reader_t* reader, int8_t* type, uint32_t count) {
+MPACK_INLINE void
+mpack_expect_ext_size(mpack_reader_t *reader, int8_t *type, uint32_t count)
+{
     if (mpack_expect_ext(reader, type) != count) {
         *type = 0;
         mpack_reader_flag_error(reader, mpack_error_type);
@@ -5539,10 +5946,11 @@ MPACK_INLINE void mpack_expect_ext_size(mpack_reader_t* reader, int8_t* type, ui
  *
  * @see mpack_expect_ext()
  */
-size_t mpack_expect_ext_buf(mpack_reader_t* reader, int8_t* type, char* buf, size_t size);
-#endif
+size_t mpack_expect_ext_buf(
+    mpack_reader_t *reader, int8_t *type, char *buf, size_t size);
+#        endif
 
-#if MPACK_EXTENSIONS && defined(MPACK_MALLOC)
+#        if MPACK_EXTENSIONS && defined(MPACK_MALLOC)
 /**
  * Reads an extension blob with the given total maximum size, allocating
  * storage for it, and placing the type into @p type.
@@ -5565,8 +5973,9 @@ size_t mpack_expect_ext_buf(mpack_reader_t* reader, int8_t* type, char* buf, siz
  *
  * @see mpack_expect_ext()
  */
-char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsize, size_t* size);
-#endif
+char *mpack_expect_ext_alloc(
+    mpack_reader_t *reader, int8_t *type, size_t maxsize, size_t *size);
+#        endif
 
 /**
  * @}
@@ -5594,7 +6003,7 @@ char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsiz
  * @see mpack_done_bin()
  * @see mpack_done_ext()
  */
-void mpack_expect_tag(mpack_reader_t* reader, mpack_tag_t tag);
+void mpack_expect_tag(mpack_reader_t *reader, mpack_tag_t tag);
 
 /**
  * Expects a string matching one of the strings in the given array,
@@ -5621,14 +6030,16 @@ void mpack_expect_tag(mpack_reader_t* reader, mpack_tag_t tag);
  *
  * See @ref docs/expect.md for more examples.
  *
- * The maximum string length is the size of the buffer (strings are read in-place.)
+ * The maximum string length is the size of the buffer (strings are read
+ * in-place.)
  *
  * @param reader The reader
  * @param strings An array of expected strings of length count
  * @param count The number of strings
  * @return The index of the matched string, or @a count in case of error
  */
-size_t mpack_expect_enum(mpack_reader_t* reader, const char* strings[], size_t count);
+size_t mpack_expect_enum(
+    mpack_reader_t *reader, const char *strings[], size_t count);
 
 /**
  * Expects a string matching one of the strings in the given array
@@ -5654,7 +6065,8 @@ size_t mpack_expect_enum(mpack_reader_t* reader, const char* strings[], size_t c
  *
  * See @ref docs/expect.md for more examples.
  *
- * The maximum string length is the size of the buffer (strings are read in-place.)
+ * The maximum string length is the size of the buffer (strings are read
+ * in-place.)
  *
  * @param reader The reader
  * @param strings An array of expected strings of length count
@@ -5663,7 +6075,8 @@ size_t mpack_expect_enum(mpack_reader_t* reader, const char* strings[], size_t c
  * @return The index of the matched string, or @a count if it does not
  * match or an error occurs
  */
-size_t mpack_expect_enum_optional(mpack_reader_t* reader, const char* strings[], size_t count);
+size_t mpack_expect_enum_optional(
+    mpack_reader_t *reader, const char *strings[], size_t count);
 
 /**
  * Expects an unsigned integer map key between 0 and count-1, marking it
@@ -5690,7 +6103,8 @@ size_t mpack_expect_enum_optional(mpack_reader_t* reader, const char* strings[],
  *
  * @see @ref docs/expect.md
  */
-size_t mpack_expect_key_uint(mpack_reader_t* reader, bool found[], size_t count);
+size_t mpack_expect_key_uint(
+    mpack_reader_t *reader, bool found[], size_t count);
 
 /**
  * Expects a string map key matching one of the strings in the given key list,
@@ -5707,7 +6121,8 @@ size_t mpack_expect_key_uint(mpack_reader_t* reader, bool found[], size_t count)
  *
  * If the key is unrecognized, count is returned and no error is flagged. If
  * you want an error on unrecognized keys, flag an error in the default case
- * in your switch; otherwise you must call mpack_discard() to discard its content.
+ * in your switch; otherwise you must call mpack_discard() to discard its
+ * content.
  *
  * The maximum key length is the size of the buffer (keys are read in-place.)
  *
@@ -5718,8 +6133,8 @@ size_t mpack_expect_key_uint(mpack_reader_t* reader, bool found[], size_t count)
  *
  * @see @ref docs/expect.md
  */
-size_t mpack_expect_key_cstr(mpack_reader_t* reader, const char* keys[],
-        bool found[], size_t count);
+size_t mpack_expect_key_cstr(
+    mpack_reader_t *reader, const char *keys[], bool found[], size_t count);
 
 /**
  * @}
@@ -5729,13 +6144,11 @@ size_t mpack_expect_key_cstr(mpack_reader_t* reader, const char* keys[],
  * @}
  */
 
-#endif
+#    endif
 
 MPACK_HEADER_END
 
 #endif
-
-
 
 /* mpack/mpack-node.h.h */
 
@@ -5746,13 +6159,13 @@ MPACK_HEADER_END
  */
 
 #ifndef MPACK_NODE_H
-#define MPACK_NODE_H 1
+#    define MPACK_NODE_H 1
 
 /* #include "mpack-reader.h" */
 
 MPACK_HEADER_START
 
-#if MPACK_NODE
+#    if MPACK_NODE
 
 /**
  * @defgroup node Node API
@@ -5824,7 +6237,7 @@ typedef struct mpack_tree_t mpack_tree_t;
  * that the tree is destroyed since any future accesses to it cause
  * undefined behavior.
  */
-typedef void (*mpack_tree_error_t)(mpack_tree_t* tree, mpack_error_t error);
+typedef void (*mpack_tree_error_t)(mpack_tree_t *tree, mpack_error_t error);
 
 /**
  * The MPack tree's read function. It should fill the buffer with as many bytes
@@ -5847,21 +6260,20 @@ typedef void (*mpack_tree_error_t)(mpack_tree_t* tree, mpack_error_t error);
  * When you return 0, mpack_tree_try_parse() will return false without flagging
  * an error.
  */
-typedef size_t (*mpack_tree_read_t)(mpack_tree_t* tree, char* buffer, size_t count);
+typedef size_t (*mpack_tree_read_t)(
+    mpack_tree_t *tree, char *buffer, size_t count);
 
 /**
  * A teardown function to be called when the tree is destroyed.
  */
-typedef void (*mpack_tree_teardown_t)(mpack_tree_t* tree);
-
-
+typedef void (*mpack_tree_teardown_t)(mpack_tree_t *tree);
 
 /* Hide internals from documentation */
 /** @cond */
 
 struct mpack_node_t {
-    mpack_node_data_t* data;
-    mpack_tree_t* tree;
+    mpack_node_data_t *data;
+    mpack_tree_t *tree;
 };
 
 struct mpack_node_data_t {
@@ -5874,20 +6286,19 @@ struct mpack_node_data_t {
      */
     uint32_t len;
 
-    union
-    {
-        bool     b; /* The value if the type is bool. */
-        float    f; /* The value if the type is float. */
-        double   d; /* The value if the type is double. */
-        int64_t  i; /* The value if the type is signed int. */
+    union {
+        bool b; /* The value if the type is bool. */
+        float f; /* The value if the type is float. */
+        double d; /* The value if the type is double. */
+        int64_t i; /* The value if the type is signed int. */
         uint64_t u; /* The value if the type is unsigned int. */
         size_t offset; /* The byte offset for str, bin and ext */
-        mpack_node_data_t* children; /* The children for map or array */
+        mpack_node_data_t *children; /* The children for map or array */
     } value;
 };
 
 typedef struct mpack_tree_page_t {
-    struct mpack_tree_page_t* next;
+    struct mpack_tree_page_t *next;
     mpack_node_data_t nodes[1]; // variable size
 } mpack_tree_page_t;
 
@@ -5898,7 +6309,7 @@ typedef enum mpack_tree_parse_state_t {
 } mpack_tree_parse_state_t;
 
 typedef struct mpack_level_t {
-    mpack_node_data_t* child;
+    mpack_node_data_t *child;
     size_t left; // children left in level
 } mpack_level_t;
 
@@ -5910,8 +6321,9 @@ typedef struct mpack_tree_parser_t {
     //
     // When a map or array is parsed, we ensure at least one byte for each child
     // exists and subtract them right away. This ensures that if ever a map or
-    // array declares more elements than could possibly be contained in the data,
-    // we will error out immediately rather than allocating storage for them.
+    // array declares more elements than could possibly be contained in the
+    // data, we will error out immediately rather than allocating storage for
+    // them.
     //
     // For example malicious data that repeats 0xDE 0xFF 0xFF (start of a map
     // with 65536 key-value pairs) would otherwise cause us to run out of
@@ -5925,92 +6337,101 @@ typedef struct mpack_tree_parser_t {
     // over bytes in the data.
     size_t possible_nodes_left;
 
-    mpack_node_data_t* nodes; // next node in current page/pool
+    mpack_node_data_t *nodes; // next node in current page/pool
     size_t nodes_left; // nodes left in current page/pool
 
     size_t current_node_reserved;
     size_t level;
 
-    #ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
     // It's much faster to allocate the initial parsing stack inline within the
     // parser. We replace it with a heap allocation if we need to grow it.
-    mpack_level_t* stack;
+    mpack_level_t *stack;
     size_t stack_capacity;
     bool stack_owned;
     mpack_level_t stack_local[MPACK_NODE_INITIAL_DEPTH];
-    #else
+#        else
     // Without malloc(), we have to reserve a parsing stack the maximum allowed
     // parsing depth.
     mpack_level_t stack[MPACK_NODE_MAX_DEPTH_WITHOUT_MALLOC];
-    #endif
+#        endif
 } mpack_tree_parser_t;
 
 struct mpack_tree_t {
-    mpack_tree_error_t error_fn;    /* Function to call on error */
-    mpack_tree_read_t read_fn;      /* Function to call to read more data */
-    mpack_tree_teardown_t teardown; /* Function to teardown the context on destroy */
-    void* context;                  /* Context for tree callbacks */
+    mpack_tree_error_t error_fn; /* Function to call on error */
+    mpack_tree_read_t read_fn; /* Function to call to read more data */
+    mpack_tree_teardown_t
+        teardown; /* Function to teardown the context on destroy */
+    void *context; /* Context for tree callbacks */
 
-    mpack_node_data_t nil_node;     /* a nil node to be returned in case of error */
-    mpack_node_data_t missing_node; /* a missing node to be returned in optional lookups */
+    mpack_node_data_t nil_node; /* a nil node to be returned in case of error */
+    mpack_node_data_t
+        missing_node; /* a missing node to be returned in optional lookups */
     mpack_error_t error;
 
-    #ifdef MPACK_MALLOC
-    char* buffer;
+#        ifdef MPACK_MALLOC
+    char *buffer;
     size_t buffer_capacity;
-    #endif
+#        endif
 
-    const char* data;
+    const char *data;
     size_t data_length; // length of data (and content of buffer, if used)
 
-    size_t size; // size in bytes of tree (usually matches data_length, but not if tree has trailing data)
+    size_t size; // size in bytes of tree (usually matches data_length, but not
+                 // if tree has trailing data)
     size_t node_count; // total number of nodes in tree (across all pages)
 
-    size_t max_size;  // maximum message size
+    size_t max_size; // maximum message size
     size_t max_nodes; // maximum nodes in a message
 
     mpack_tree_parser_t parser;
-    mpack_node_data_t* root;
+    mpack_node_data_t *root;
 
-    mpack_node_data_t* pool; // pool, or NULL if no pool provided
+    mpack_node_data_t *pool; // pool, or NULL if no pool provided
     size_t pool_count;
 
-    #ifdef MPACK_MALLOC
-    mpack_tree_page_t* next;
-    #endif
+#        ifdef MPACK_MALLOC
+    mpack_tree_page_t *next;
+#        endif
 };
 
 // internal functions
 
-MPACK_INLINE mpack_node_t mpack_node(mpack_tree_t* tree, mpack_node_data_t* data) {
+MPACK_INLINE mpack_node_t
+mpack_node(mpack_tree_t *tree, mpack_node_data_t *data)
+{
     mpack_node_t node;
     node.data = data;
     node.tree = tree;
     return node;
 }
 
-MPACK_INLINE mpack_node_data_t* mpack_node_child(mpack_node_t node, size_t child) {
+MPACK_INLINE mpack_node_data_t *
+mpack_node_child(mpack_node_t node, size_t child)
+{
     return node.data->value.children + child;
 }
 
-MPACK_INLINE mpack_node_t mpack_tree_nil_node(mpack_tree_t* tree) {
+MPACK_INLINE mpack_node_t
+mpack_tree_nil_node(mpack_tree_t *tree)
+{
     return mpack_node(tree, &tree->nil_node);
 }
 
-MPACK_INLINE mpack_node_t mpack_tree_missing_node(mpack_tree_t* tree) {
+MPACK_INLINE mpack_node_t
+mpack_tree_missing_node(mpack_tree_t *tree)
+{
     return mpack_node(tree, &tree->missing_node);
 }
 
 /** @endcond */
-
-
 
 /**
  * @name Tree Initialization
  * @{
  */
 
-#ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
 /**
  * Initializes a tree parser with the given data.
  *
@@ -6023,14 +6444,16 @@ MPACK_INLINE mpack_node_t mpack_tree_missing_node(mpack_tree_t* tree) {
  * Any string or blob data types reference the original data, so the given data
  * pointer must remain valid until after the tree is destroyed.
  */
-void mpack_tree_init_data(mpack_tree_t* tree, const char* data, size_t length);
+void mpack_tree_init_data(mpack_tree_t *tree, const char *data, size_t length);
 
 /**
  * Deprecated.
  *
  * \deprecated Renamed to mpack_tree_init_data().
  */
-MPACK_INLINE void mpack_tree_init(mpack_tree_t* tree, const char* data, size_t length) {
+MPACK_INLINE void
+mpack_tree_init(mpack_tree_t *tree, const char *data, size_t length)
+{
     mpack_tree_init_data(tree, data, length);
 }
 
@@ -6061,9 +6484,9 @@ MPACK_INLINE void mpack_tree_init(mpack_tree_t* tree, const char* data, size_t l
  * @see mpack_tree_read_t
  * @see mpack_reader_context()
  */
-void mpack_tree_init_stream(mpack_tree_t* tree, mpack_tree_read_t read_fn, void* context,
-        size_t max_message_size, size_t max_message_nodes);
-#endif
+void mpack_tree_init_stream(mpack_tree_t *tree, mpack_tree_read_t read_fn,
+    void *context, size_t max_message_size, size_t max_message_nodes);
+#        endif
 
 /**
  * Initializes a tree parser with the given data, using the given node data
@@ -6071,22 +6494,22 @@ void mpack_tree_init_stream(mpack_tree_t* tree, mpack_tree_read_t read_fn, void*
  *
  * Configure the tree if desired, then call mpack_tree_parse() to parse it.
  *
- * If the data does not fit in the pool, @ref mpack_error_too_big will be flagged
- * on the tree.
+ * If the data does not fit in the pool, @ref mpack_error_too_big will be
+ * flagged on the tree.
  *
  * The tree must be destroyed with mpack_tree_destroy(), even if parsing fails.
  */
-void mpack_tree_init_pool(mpack_tree_t* tree, const char* data, size_t length,
-        mpack_node_data_t* node_pool, size_t node_pool_count);
+void mpack_tree_init_pool(mpack_tree_t *tree, const char *data, size_t length,
+    mpack_node_data_t *node_pool, size_t node_pool_count);
 
 /**
  * Initializes an MPack tree directly into an error state. Use this if you
  * are writing a wrapper to another <tt>mpack_tree_init*()</tt> function which
  * can fail its setup.
  */
-void mpack_tree_init_error(mpack_tree_t* tree, mpack_error_t error);
+void mpack_tree_init_error(mpack_tree_t *tree, mpack_error_t error);
 
-#if MPACK_STDIO
+#        if MPACK_STDIO
 /**
  * Initializes a tree to parse the given file. The tree must be destroyed with
  * mpack_tree_destroy(), even if parsing fails.
@@ -6098,14 +6521,17 @@ void mpack_tree_init_error(mpack_tree_t* tree, mpack_error_t error);
  * @param filename The filename passed to fopen() to read the file
  * @param max_bytes The maximum size of file to load, or 0 for unlimited size.
  */
-void mpack_tree_init_filename(mpack_tree_t* tree, const char* filename, size_t max_bytes);
+void mpack_tree_init_filename(
+    mpack_tree_t *tree, const char *filename, size_t max_bytes);
 
 /**
  * Deprecated.
  *
  * \deprecated Renamed to mpack_tree_init_filename().
  */
-MPACK_INLINE void mpack_tree_init_file(mpack_tree_t* tree, const char* filename, size_t max_bytes) {
+MPACK_INLINE void
+mpack_tree_init_file(mpack_tree_t *tree, const char *filename, size_t max_bytes)
+{
     mpack_tree_init_filename(tree, filename, max_bytes);
 }
 
@@ -6129,8 +6555,9 @@ MPACK_INLINE void mpack_tree_init_file(mpack_tree_t* tree, const char* filename,
  *          is used on stdin, the parser will block until it is closed, even if
  *          a complete message has been written to it!
  */
-void mpack_tree_init_stdfile(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes, bool close_when_done);
-#endif
+void mpack_tree_init_stdfile(
+    mpack_tree_t *tree, FILE *stdfile, size_t max_bytes, bool close_when_done);
+#        endif
 
 /**
  * @}
@@ -6155,8 +6582,8 @@ void mpack_tree_init_stdfile(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes
  * @param max_message_nodes The maximum number of nodes per message. See
  *        @ref mpack_node_data_t for the size of nodes.
  */
-void mpack_tree_set_limits(mpack_tree_t* tree, size_t max_message_size,
-        size_t max_message_nodes);
+void mpack_tree_set_limits(
+    mpack_tree_t *tree, size_t max_message_size, size_t max_message_nodes);
 
 /**
  * Parses a MessagePack message into a tree of immutable nodes.
@@ -6175,7 +6602,7 @@ void mpack_tree_set_limits(mpack_tree_t* tree, size_t max_message_size,
  *
  * There is no way to recover a tree in an error state. It must be destroyed.
  */
-void mpack_tree_parse(mpack_tree_t* tree);
+void mpack_tree_parse(mpack_tree_t *tree);
 
 /**
  * Attempts to parse a MessagePack message from a non-blocking stream into a
@@ -6199,7 +6626,7 @@ void mpack_tree_parse(mpack_tree_t* tree);
  *
  * @see mpack_tree_init_stream()
  */
-bool mpack_tree_try_parse(mpack_tree_t* tree);
+bool mpack_tree_try_parse(mpack_tree_t *tree);
 
 /**
  * Returns the root node of the tree, if the tree is not in an error state.
@@ -6208,12 +6635,14 @@ bool mpack_tree_try_parse(mpack_tree_t* tree);
  * @warning You must call mpack_tree_parse() before calling this. If
  * @ref mpack_tree_parse() was never called, the tree will assert.
  */
-mpack_node_t mpack_tree_root(mpack_tree_t* tree);
+mpack_node_t mpack_tree_root(mpack_tree_t *tree);
 
 /**
  * Returns the error state of the tree.
  */
-MPACK_INLINE mpack_error_t mpack_tree_error(mpack_tree_t* tree) {
+MPACK_INLINE mpack_error_t
+mpack_tree_error(mpack_tree_t *tree)
+{
     return tree->error;
 }
 
@@ -6227,14 +6656,16 @@ MPACK_INLINE mpack_error_t mpack_tree_error(mpack_tree_t* tree) {
  * portion of the data that the first complete object occupies cannot
  * be determined if the data is invalid or corrupted.)
  */
-MPACK_INLINE size_t mpack_tree_size(mpack_tree_t* tree) {
+MPACK_INLINE size_t
+mpack_tree_size(mpack_tree_t *tree)
+{
     return tree->size;
 }
 
 /**
  * Destroys the tree.
  */
-mpack_error_t mpack_tree_destroy(mpack_tree_t* tree);
+mpack_error_t mpack_tree_destroy(mpack_tree_t *tree);
 
 /**
  * Sets the custom pointer to pass to the tree callbacks, such as teardown.
@@ -6244,7 +6675,9 @@ mpack_error_t mpack_tree_destroy(mpack_tree_t* tree);
  *
  * @see mpack_reader_context()
  */
-MPACK_INLINE void mpack_tree_set_context(mpack_tree_t* tree, void* context) {
+MPACK_INLINE void
+mpack_tree_set_context(mpack_tree_t *tree, void *context)
+{
     tree->context = context;
 }
 
@@ -6254,7 +6687,9 @@ MPACK_INLINE void mpack_tree_set_context(mpack_tree_t* tree, void* context) {
  * @see mpack_tree_set_context
  * @see mpack_tree_init_stream
  */
-MPACK_INLINE void* mpack_tree_context(mpack_tree_t* tree) {
+MPACK_INLINE void *
+mpack_tree_context(mpack_tree_t *tree)
+{
     return tree->context;
 }
 
@@ -6271,7 +6706,9 @@ MPACK_INLINE void* mpack_tree_context(mpack_tree_t* tree) {
  * @param tree The MPack tree.
  * @param error_fn The function to call when an error is flagged on the tree.
  */
-MPACK_INLINE void mpack_tree_set_error_handler(mpack_tree_t* tree, mpack_tree_error_t error_fn) {
+MPACK_INLINE void
+mpack_tree_set_error_handler(mpack_tree_t *tree, mpack_tree_error_t error_fn)
+{
     tree->error_fn = error_fn;
 }
 
@@ -6284,7 +6721,9 @@ MPACK_INLINE void mpack_tree_set_error_handler(mpack_tree_t* tree, mpack_tree_er
  * @param tree The MPack tree.
  * @param teardown The function to call when the tree is destroyed.
  */
-MPACK_INLINE void mpack_tree_set_teardown(mpack_tree_t* tree, mpack_tree_teardown_t teardown) {
+MPACK_INLINE void
+mpack_tree_set_teardown(mpack_tree_t *tree, mpack_tree_teardown_t teardown)
+{
     tree->teardown = teardown;
 }
 
@@ -6298,7 +6737,7 @@ MPACK_INLINE void mpack_tree_set_teardown(mpack_tree_t* tree, mpack_tree_teardow
  * If the tree is already in an error state, this call is ignored and no
  * error callback is called.
  */
-void mpack_tree_flag_error(mpack_tree_t* tree, mpack_error_t error);
+void mpack_tree_flag_error(mpack_tree_t *tree, mpack_error_t error);
 
 /**
  * @}
@@ -6324,7 +6763,9 @@ void mpack_node_flag_error(mpack_node_t node, mpack_error_t error);
 /**
  * Returns the error state of the node's tree.
  */
-MPACK_INLINE mpack_error_t mpack_node_error(mpack_node_t node) {
+MPACK_INLINE mpack_error_t
+mpack_node_error(mpack_node_t node)
+{
     return mpack_tree_error(node.tree);
 }
 
@@ -6336,7 +6777,7 @@ mpack_tag_t mpack_node_tag(mpack_node_t node);
 
 /** @cond */
 
-#if MPACK_DEBUG && MPACK_STDIO
+#        if MPACK_DEBUG && MPACK_STDIO
 /*
  * Converts a node to a pseudo-JSON string for debugging purposes, placing the
  * result in the given buffer with a null-terminator.
@@ -6347,7 +6788,8 @@ mpack_tag_t mpack_node_tag(mpack_node_t node);
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-void mpack_node_print_to_buffer(mpack_node_t node, char* buffer, size_t buffer_size);
+void mpack_node_print_to_buffer(
+    mpack_node_t node, char *buffer, size_t buffer_size);
 
 /*
  * Converts a node to pseudo-JSON for debugging purposes, calling the given
@@ -6358,7 +6800,8 @@ void mpack_node_print_to_buffer(mpack_node_t node, char* buffer, size_t buffer_s
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-void mpack_node_print_to_callback(mpack_node_t node, mpack_print_callback_t callback, void* context);
+void mpack_node_print_to_callback(
+    mpack_node_t node, mpack_print_callback_t callback, void *context);
 
 /*
  * Converts a node to pseudo-JSON for debugging purposes
@@ -6367,7 +6810,7 @@ void mpack_node_print_to_callback(mpack_node_t node, mpack_print_callback_t call
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-void mpack_node_print_to_file(mpack_node_t node, FILE* file);
+void mpack_node_print_to_file(mpack_node_t node, FILE *file);
 
 /*
  * Converts a node to pseudo-JSON for debugging purposes
@@ -6376,7 +6819,9 @@ void mpack_node_print_to_file(mpack_node_t node, FILE* file);
  * This is only available in debug mode, and only if stdio is available (since
  * it uses snprintf().) It's strictly for debugging purposes.
  */
-MPACK_INLINE void mpack_node_print_to_stdout(mpack_node_t node) {
+MPACK_INLINE void
+mpack_node_print_to_stdout(mpack_node_t node)
+{
     mpack_node_print_to_file(node, stdout);
 }
 
@@ -6385,10 +6830,12 @@ MPACK_INLINE void mpack_node_print_to_stdout(mpack_node_t node) {
  *
  * \deprecated Renamed to mpack_node_print_to_stdout().
  */
-MPACK_INLINE void mpack_node_print(mpack_node_t node) {
+MPACK_INLINE void
+mpack_node_print(mpack_node_t node)
+{
     mpack_node_print_to_stdout(node);
 }
-#endif
+#        endif
 
 /** @endcond */
 
@@ -6415,7 +6862,8 @@ mpack_type_t mpack_node_type(mpack_node_t node);
 bool mpack_node_is_nil(mpack_node_t node);
 
 /**
- * Returns true if the given node handle indicates a missing node; false otherwise.
+ * Returns true if the given node handle indicates a missing node; false
+ * otherwise.
  *
  * To ensure that a node is missing and flag an error otherwise, use
  * mpack_node_missing().
@@ -6509,7 +6957,8 @@ int64_t mpack_node_i64(mpack_node_t node);
  *
  * Returns zero if an error occurs.
  *
- * @throws mpack_error_type If the node is not an integer type or does not fit in the range of an unsigned int
+ * @throws mpack_error_type If the node is not an integer type or does not fit
+ * in the range of an unsigned int
  */
 unsigned int mpack_node_uint(mpack_node_t node);
 
@@ -6518,7 +6967,8 @@ unsigned int mpack_node_uint(mpack_node_t node);
  *
  * Returns zero if an error occurs.
  *
- * @throws mpack_error_type If the node is not an integer type or does not fit in the range of an int
+ * @throws mpack_error_type If the node is not an integer type or does not fit
+ * in the range of an int
  */
 int mpack_node_int(mpack_node_t node);
 
@@ -6529,7 +6979,8 @@ int mpack_node_int(mpack_node_t node);
  * @note Reading a double or a large integer with this function can incur a
  * loss of precision.
  *
- * @throws mpack_error_type if the underlying value is not a float, double or integer.
+ * @throws mpack_error_type if the underlying value is not a float, double or
+ * integer.
  */
 float mpack_node_float(mpack_node_t node);
 
@@ -6540,7 +6991,8 @@ float mpack_node_float(mpack_node_t node);
  * @note Reading a very large integer with this function can incur a
  * loss of precision.
  *
- * @throws mpack_error_type if the underlying value is not a float, double or integer.
+ * @throws mpack_error_type if the underlying value is not a float, double or
+ * integer.
  */
 double mpack_node_double(mpack_node_t node);
 
@@ -6560,7 +7012,7 @@ float mpack_node_float_strict(mpack_node_t node);
  */
 double mpack_node_double_strict(mpack_node_t node);
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Returns a timestamp.
  *
@@ -6588,7 +7040,7 @@ int64_t mpack_node_timestamp_seconds(mpack_node_t node);
  * @throws mpack_error_type if the underlying value is not a timestamp.
  */
 uint32_t mpack_node_timestamp_nanoseconds(mpack_node_t node);
-#endif
+#        endif
 
 /**
  * @}
@@ -6602,12 +7054,14 @@ uint32_t mpack_node_timestamp_nanoseconds(mpack_node_t node);
 /**
  * Checks that the given node contains a valid UTF-8 string.
  *
- * If the string is invalid, this flags an error, which would cause subsequent calls
- * to mpack_node_str() to return NULL and mpack_node_strlen() to return zero. So you
- * can check the node for error immediately after calling this, or you can call those
- * functions to use the data anyway and check for errors later.
+ * If the string is invalid, this flags an error, which would cause subsequent
+ * calls to mpack_node_str() to return NULL and mpack_node_strlen() to return
+ * zero. So you can check the node for error immediately after calling this, or
+ * you can call those functions to use the data anyway and check for errors
+ * later.
  *
- * @throws mpack_error_type If this node is not a string or does not contain valid UTF-8.
+ * @throws mpack_error_type If this node is not a string or does not contain
+ * valid UTF-8.
  *
  * @param node The string node to test
  *
@@ -6619,16 +7073,17 @@ void mpack_node_check_utf8(mpack_node_t node);
 /**
  * Checks that the given node contains a valid UTF-8 string with no NUL bytes.
  *
- * This does not check that the string has a null-terminator! It only checks whether
- * the string could safely be represented as a C-string by appending a null-terminator.
- * (If the string does already contain a null-terminator, this will flag an error.)
+ * This does not check that the string has a null-terminator! It only checks
+ * whether the string could safely be represented as a C-string by appending a
+ * null-terminator. (If the string does already contain a null-terminator, this
+ * will flag an error.)
  *
  * This is performed automatically by other UTF-8 cstr helper functions. Only
  * call this if you will do something else with the data directly, but you still
  * want to ensure it will be valid as a UTF-8 C-string.
  *
- * @throws mpack_error_type If this node is not a string, does not contain valid UTF-8,
- *     or contains a NUL byte.
+ * @throws mpack_error_type If this node is not a string, does not contain valid
+ * UTF-8, or contains a NUL byte.
  *
  * @param node The string node to test
  *
@@ -6639,7 +7094,7 @@ void mpack_node_check_utf8(mpack_node_t node);
  */
 void mpack_node_check_utf8_cstr(mpack_node_t node);
 
-#if MPACK_EXTENSIONS
+#        if MPACK_EXTENSIONS
 /**
  * Returns the extension type of the given ext node.
  *
@@ -6648,14 +7103,15 @@ void mpack_node_check_utf8_cstr(mpack_node_t node);
  * @note This requires @ref MPACK_EXTENSIONS.
  */
 int8_t mpack_node_exttype(mpack_node_t node);
-#endif
+#        endif
 
 /**
  * Returns the number of bytes in the given bin node.
  *
  * This returns zero if the tree is in an error state.
  *
- * If this node is not a bin, @ref mpack_error_type is raised and zero is returned.
+ * If this node is not a bin, @ref mpack_error_type is raised and zero is
+ * returned.
  */
 size_t mpack_node_bin_size(mpack_node_t node);
 
@@ -6664,8 +7120,8 @@ size_t mpack_node_bin_size(mpack_node_t node);
  *
  * This returns zero if the tree is in an error state.
  *
- * If this node is not a str, bin or map, @ref mpack_error_type is raised and zero
- * is returned.
+ * If this node is not a str, bin or map, @ref mpack_error_type is raised and
+ * zero is returned.
  */
 uint32_t mpack_node_data_len(mpack_node_t node);
 
@@ -6675,7 +7131,8 @@ uint32_t mpack_node_data_len(mpack_node_t node);
  *
  * This returns zero if the tree is in an error state.
  *
- * If this node is not a str, @ref mpack_error_type is raised and zero is returned.
+ * If this node is not a str, @ref mpack_error_type is raised and zero is
+ * returned.
  */
 size_t mpack_node_strlen(mpack_node_t node);
 
@@ -6688,13 +7145,14 @@ size_t mpack_node_strlen(mpack_node_t node);
  *
  * The pointer is valid as long as the data backing the tree is valid.
  *
- * If this node is not a string, @ref mpack_error_type is raised and @c NULL is returned.
+ * If this node is not a string, @ref mpack_error_type is raised and @c NULL is
+ * returned.
  *
  * @see mpack_node_copy_cstr()
  * @see mpack_node_cstr_alloc()
  * @see mpack_node_utf8_cstr_alloc()
  */
-const char* mpack_node_str(mpack_node_t node);
+const char *mpack_node_str(mpack_node_t node);
 
 /**
  * Returns a pointer to the data contained by this node.
@@ -6704,14 +7162,15 @@ const char* mpack_node_str(mpack_node_t node);
  *
  * The pointer is valid as long as the data backing the tree is valid.
  *
- * If this node is not of a str, bin or map, @ref mpack_error_type is raised, and
+ * If this node is not of a str, bin or map, @ref mpack_error_type is raised,
+ * and
  * @c NULL is returned.
  *
  * @see mpack_node_copy_cstr()
  * @see mpack_node_cstr_alloc()
  * @see mpack_node_utf8_cstr_alloc()
  */
-const char* mpack_node_data(mpack_node_t node);
+const char *mpack_node_data(mpack_node_t node);
 
 /**
  * Returns a pointer to the data contained by this bin node.
@@ -6721,7 +7180,7 @@ const char* mpack_node_data(mpack_node_t node);
  * If this node is not a bin, @ref mpack_error_type is raised and @c NULL is
  * returned.
  */
-const char* mpack_node_bin_data(mpack_node_t node);
+const char *mpack_node_bin_data(mpack_node_t node);
 
 /**
  * Copies the bytes contained by this node into the given buffer, returning the
@@ -6736,7 +7195,7 @@ const char* mpack_node_bin_data(mpack_node_t node);
  *
  * @return The number of bytes in the node, or zero if an error occurs.
  */
-size_t mpack_node_copy_data(mpack_node_t node, char* buffer, size_t bufsize);
+size_t mpack_node_copy_data(mpack_node_t node, char *buffer, size_t bufsize);
 
 /**
  * Checks that the given node contains a valid UTF-8 string and copies the
@@ -6751,14 +7210,14 @@ size_t mpack_node_copy_data(mpack_node_t node, char* buffer, size_t bufsize);
  *
  * @return The number of bytes in the node, or zero if an error occurs.
  */
-size_t mpack_node_copy_utf8(mpack_node_t node, char* buffer, size_t bufsize);
+size_t mpack_node_copy_utf8(mpack_node_t node, char *buffer, size_t bufsize);
 
 /**
- * Checks that the given node contains a string with no NUL bytes, copies the string
- * into the given buffer, and adds a null terminator.
+ * Checks that the given node contains a string with no NUL bytes, copies the
+ * string into the given buffer, and adds a null terminator.
  *
- * If this node is not of a string type, @ref mpack_error_type is raised. If the string
- * does not fit, @ref mpack_error_data is raised.
+ * If this node is not of a string type, @ref mpack_error_type is raised. If the
+ * string does not fit, @ref mpack_error_data is raised.
  *
  * If any error occurs, the buffer will contain an empty null-terminated string.
  *
@@ -6766,14 +7225,14 @@ size_t mpack_node_copy_utf8(mpack_node_t node, char* buffer, size_t bufsize);
  * @param buffer A buffer in which to copy the node's string
  * @param size The size of the given buffer
  */
-void mpack_node_copy_cstr(mpack_node_t node, char* buffer, size_t size);
+void mpack_node_copy_cstr(mpack_node_t node, char *buffer, size_t size);
 
 /**
  * Checks that the given node contains a valid UTF-8 string with no NUL bytes,
  * copies the string into the given buffer, and adds a null terminator.
  *
- * If this node is not of a string type, @ref mpack_error_type is raised. If the string
- * does not fit, @ref mpack_error_data is raised.
+ * If this node is not of a string type, @ref mpack_error_type is raised. If the
+ * string does not fit, @ref mpack_error_data is raised.
  *
  * If any error occurs, the buffer will contain an empty null-terminated string.
  *
@@ -6781,9 +7240,9 @@ void mpack_node_copy_cstr(mpack_node_t node, char* buffer, size_t size);
  * @param buffer A buffer in which to copy the node's string
  * @param size The size of the given buffer
  */
-void mpack_node_copy_utf8_cstr(mpack_node_t node, char* buffer, size_t size);
+void mpack_node_copy_utf8_cstr(mpack_node_t node, char *buffer, size_t size);
 
-#ifdef MPACK_MALLOC
+#        ifdef MPACK_MALLOC
 /**
  * Allocates a new chunk of data using MPACK_MALLOC() with the bytes
  * contained by this node.
@@ -6801,7 +7260,7 @@ void mpack_node_copy_utf8_cstr(mpack_node_t node, char* buffer, size_t size);
  *
  * @return The allocated data, or NULL if any error occurs.
  */
-char* mpack_node_data_alloc(mpack_node_t node, size_t maxsize);
+char *mpack_node_data_alloc(mpack_node_t node, size_t maxsize);
 
 /**
  * Allocates a new null-terminated string using MPACK_MALLOC() with the string
@@ -6820,7 +7279,7 @@ char* mpack_node_data_alloc(mpack_node_t node, size_t maxsize);
  *
  * @return The allocated string, or NULL if any error occurs.
  */
-char* mpack_node_cstr_alloc(mpack_node_t node, size_t maxsize);
+char *mpack_node_cstr_alloc(mpack_node_t node, size_t maxsize);
 
 /**
  * Allocates a new null-terminated string using MPACK_MALLOC() with the UTF-8
@@ -6840,8 +7299,8 @@ char* mpack_node_cstr_alloc(mpack_node_t node, size_t maxsize);
  *
  * @return The allocated string, or NULL if any error occurs.
  */
-char* mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxsize);
-#endif
+char *mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxsize);
+#        endif
 
 /**
  * Searches the given string array for a string matching the given
@@ -6871,7 +7330,7 @@ char* mpack_node_utf8_cstr_alloc(mpack_node_t node, size_t maxsize);
  * @param count The number of strings
  * @return The index of the matched string, or @a count in case of error
  */
-size_t mpack_node_enum(mpack_node_t node, const char* strings[], size_t count);
+size_t mpack_node_enum(mpack_node_t node, const char *strings[], size_t count);
 
 /**
  * Searches the given string array for a string matching the given node,
@@ -6900,7 +7359,8 @@ size_t mpack_node_enum(mpack_node_t node, const char* strings[], size_t count);
  * @param count The number of strings
  * @return The index of the matched string, or @a count in case of error
  */
-size_t mpack_node_enum_optional(mpack_node_t node, const char* strings[], size_t count);
+size_t mpack_node_enum_optional(
+    mpack_node_t node, const char *strings[], size_t count);
 
 /**
  * @}
@@ -6961,7 +7421,8 @@ mpack_node_t mpack_node_map_value_at(mpack_node_t node, size_t index);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node does not contain exactly one entry with the given key
+ * @throws mpack_error_data If the node does not contain exactly one entry with
+ * the given key
  *
  * @return The value node for the given key, or a nil node in case of error
  */
@@ -6975,7 +7436,8 @@ mpack_node_t mpack_node_map_int(mpack_node_t node, int64_t num);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  *
  * @return The value node for the given key, or a missing node if the key does
  *         not exist, or a nil node in case of error
@@ -6994,7 +7456,8 @@ mpack_node_t mpack_node_map_int_optional(mpack_node_t node, int64_t num);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node does not contain exactly one entry with the given key
+ * @throws mpack_error_data If the node does not contain exactly one entry with
+ * the given key
  *
  * @return The value node for the given key, or a nil node in case of error
  */
@@ -7008,7 +7471,8 @@ mpack_node_t mpack_node_map_uint(mpack_node_t node, uint64_t num);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  *
  * @return The value node for the given key, or a missing node if the key does
  *         not exist, or a nil node in case of error
@@ -7027,11 +7491,13 @@ mpack_node_t mpack_node_map_uint_optional(mpack_node_t node, uint64_t num);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node does not contain exactly one entry with the given key
+ * @throws mpack_error_data If the node does not contain exactly one entry with
+ * the given key
  *
  * @return The value node for the given key, or a nil node in case of error
  */
-mpack_node_t mpack_node_map_str(mpack_node_t node, const char* str, size_t length);
+mpack_node_t mpack_node_map_str(
+    mpack_node_t node, const char *str, size_t length);
 
 /**
  * Returns the value node in the given map for the given string key, or a nil
@@ -7041,14 +7507,16 @@ mpack_node_t mpack_node_map_str(mpack_node_t node, const char* str, size_t lengt
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  *
  * @return The value node for the given key, or a missing node if the key does
  *         not exist, or a nil node in case of error
  *
  * @see mpack_node_is_missing()
  */
-mpack_node_t mpack_node_map_str_optional(mpack_node_t node, const char* str, size_t length);
+mpack_node_t mpack_node_map_str_optional(
+    mpack_node_t node, const char *str, size_t length);
 
 /**
  * Returns the value node in the given map for the given null-terminated
@@ -7061,11 +7529,12 @@ mpack_node_t mpack_node_map_str_optional(mpack_node_t node, const char* str, siz
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node does not contain exactly one entry with the given key
+ * @throws mpack_error_data If the node does not contain exactly one entry with
+ * the given key
  *
  * @return The value node for the given key, or a nil node in case of error
  */
-mpack_node_t mpack_node_map_cstr(mpack_node_t node, const char* cstr);
+mpack_node_t mpack_node_map_cstr(mpack_node_t node, const char *cstr);
 
 /**
  * Returns the value node in the given map for the given null-terminated
@@ -7075,14 +7544,15 @@ mpack_node_t mpack_node_map_cstr(mpack_node_t node, const char* cstr);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  *
  * @return The value node for the given key, or a missing node if the key does
  *         not exist, or a nil node in case of error
  *
  * @see mpack_node_is_missing()
  */
-mpack_node_t mpack_node_map_cstr_optional(mpack_node_t node, const char* cstr);
+mpack_node_t mpack_node_map_cstr_optional(mpack_node_t node, const char *cstr);
 
 /**
  * Returns true if the given node map contains exactly one entry with the
@@ -7092,7 +7562,8 @@ mpack_node_t mpack_node_map_cstr_optional(mpack_node_t node, const char* cstr);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  */
 bool mpack_node_map_contains_int(mpack_node_t node, int64_t num);
 
@@ -7104,7 +7575,8 @@ bool mpack_node_map_contains_int(mpack_node_t node, int64_t num);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  */
 bool mpack_node_map_contains_uint(mpack_node_t node, uint64_t num);
 
@@ -7116,9 +7588,11 @@ bool mpack_node_map_contains_uint(mpack_node_t node, uint64_t num);
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  */
-bool mpack_node_map_contains_str(mpack_node_t node, const char* str, size_t length);
+bool mpack_node_map_contains_str(
+    mpack_node_t node, const char *str, size_t length);
 
 /**
  * Returns true if the given node map contains exactly one entry with the
@@ -7128,9 +7602,10 @@ bool mpack_node_map_contains_str(mpack_node_t node, const char* str, size_t leng
  * entries with the given key.
  *
  * @throws mpack_error_type If the node is not a map
- * @throws mpack_error_data If the node contains more than one entry with the given key
+ * @throws mpack_error_data If the node contains more than one entry with the
+ * given key
  */
-bool mpack_node_map_contains_cstr(mpack_node_t node, const char* cstr);
+bool mpack_node_map_contains_cstr(mpack_node_t node, const char *cstr);
 
 /**
  * @}
@@ -7140,12 +7615,10 @@ bool mpack_node_map_contains_cstr(mpack_node_t node, const char* cstr);
  * @}
  */
 
-#endif
+#    endif
 
 MPACK_HEADER_END
 
 #endif
 
-
 #endif
-


### PR DESCRIPTION
The vendor folder was not included in the list of folders for
clang-format and therefore not formatted. Use find to search
for all .h, .c and .cpp files and call clang-format on them.