### PR TITLE
fix: Pad short code_ids with 0

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -284,7 +284,7 @@ sentry__procmaps_read_ids_from_elf(sentry_value_t value, void *elf_ptr)
         sentry_value_set_by_key(value, "code_id",
             sentry__value_new_hexstring(code_id, code_id_size));
 
-        memcpy(uuid.bytes, codeid, MIN(code_id_size, 16));
+        memcpy(uuid.bytes, code_id, MIN(code_id_size, 16));
     } else {
         uuid = get_code_id_from_text_fallback(elf_ptr);
     }

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -284,7 +284,7 @@ sentry__procmaps_read_ids_from_elf(sentry_value_t value, void *elf_ptr)
         sentry_value_set_by_key(value, "code_id",
             sentry__value_new_hexstring(code_id, code_id_size));
 
-        uuid = sentry_uuid_from_bytes((const char *)code_id);
+        memcpy(uuid.bytes, codeid, MIN(code_id_size, 16));
     } else {
         uuid = get_code_id_from_text_fallback(elf_ptr);
     }


### PR DESCRIPTION
Basically the same as https://github.com/getsentry/sentry-rust/issues/220, but we haven’t hit the case in native yet.