### PR TITLE
feat: implement logger hook

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -70,6 +70,7 @@ extern "C" {
 #endif
 
 #include <inttypes.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -716,6 +717,14 @@ SENTRY_API void sentry_options_set_debug(sentry_options_t *opts, int debug);
  * Returns the current value of the debug flag.
  */
 SENTRY_API int sentry_options_get_debug(const sentry_options_t *opts);
+
+/**
+ * Sets the sentry-native logger function.
+ * Used for logging debug events when the `debug` option is set to true.
+ */
+SENTRY_API void sentry_options_set_logger(sentry_options_t *opts,
+    void (*logger_func)(
+        sentry_level_t level, const char *message, va_list args));
 
 /**
  * Enables or disables user consent requirements for uploads.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ sentry_target_sources_cwd(sentry
 	sentry_envelope.h
 	sentry_json.c
 	sentry_json.h
+	sentry_logger.c
+	sentry_logger.h
 	sentry_modulefinder.h
 	sentry_options.c
 	sentry_options.h

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -2,31 +2,9 @@
 #define SENTRY_CORE_H_INCLUDED
 
 #include "sentry_boot.h"
+#include "sentry_logger.h"
 
 #define SENTRY_BREADCRUMBS_MAX 100
-
-#ifdef SENTRY_PLATFORM_ANDROID
-#    include <android/log.h>
-#    define SENTRY_FPRINTF(fd, message, ...)                                   \
-        __android_log_print(                                                   \
-            ANDROID_LOG_INFO, "sentry-native", message, __VA_ARGS__)
-#else
-#    define SENTRY_FPRINTF(fd, message, ...)                                   \
-        fprintf(fd, "[sentry] " message, __VA_ARGS__)
-#endif
-#define SENTRY_DEBUGF(message, ...)                                            \
-    do {                                                                       \
-        const sentry_options_t *_options = sentry_get_options();               \
-        if (_options && sentry_options_get_debug(_options)) {                  \
-            SENTRY_FPRINTF(stderr, message "\n", __VA_ARGS__);                 \
-        }                                                                      \
-    } while (0)
-
-#define SENTRY_DEBUG(message) SENTRY_DEBUGF("%s", message "")
-
-// TODO: we might want to have different log levels at some point
-#define SENTRY_TRACEF(message, ...) SENTRY_DEBUGF(message, __VA_ARGS__)
-#define SENTRY_TRACE(message) SENTRY_DEBUG(message)
 
 #if defined(__GNUC__) && (__GNUC__ >= 4)
 #    define MUST_USE __attribute__((warn_unused_result))

--- a/src/sentry_logger.c
+++ b/src/sentry_logger.c
@@ -1,0 +1,90 @@
+#include <stdio.h>
+
+#include "sentry_logger.h"
+#include "sentry_options.h"
+
+#if defined(SENTRY_PLATFORM_ANDROID)
+
+#    include <android/log.h>
+void
+sentry__logger_defaultlogger(
+    sentry_level_t level, const char *message, va_list args)
+{
+    android_LogPriority priority = ANDROID_LOG_UNKNOWN;
+    switch (level) {
+    case SENTRY_LEVEL_DEBUG:
+        priority = ANDROID_LOG_DEBUG;
+        break;
+    case SENTRY_LEVEL_INFO:
+        priority = ANDROID_LOG_INFO;
+        break;
+    case SENTRY_LEVEL_WARNING:
+        priority = ANDROID_LOG_WARN;
+        break;
+    case SENTRY_LEVEL_ERROR:
+        priority = ANDROID_LOG_ERROR;
+        break;
+    case SENTRY_LEVEL_FATAL:
+        priority = ANDROID_LOG_FATAL;
+        break;
+    default:
+        break;
+    }
+    __android_log_vprint(priority, "sentry-native", message, args);
+}
+
+#else
+
+void
+sentry__logger_defaultlogger(
+    sentry_level_t level, const char *message, va_list args)
+{
+    const char *prefix = "[sentry] ";
+    const char *priority = sentry__logger_describe(level);
+
+    char *format = sentry_malloc(
+        strlen(prefix) + strlen(priority) + strlen(message) + 1);
+    strcpy(format, prefix);
+    strcat(format, priority);
+    strcat(format, message);
+
+    vfprintf(stderr, format, args);
+
+    sentry_free(format);
+}
+
+#endif
+
+const char *
+sentry__logger_describe(sentry_level_t level)
+{
+    switch (level) {
+    case SENTRY_LEVEL_DEBUG:
+        return "DEBUG ";
+    case SENTRY_LEVEL_INFO:
+        return "INFO ";
+    case SENTRY_LEVEL_WARNING:
+        return "WARN ";
+    case SENTRY_LEVEL_ERROR:
+        return "ERROR ";
+    case SENTRY_LEVEL_FATAL:
+        return "FATAL ";
+    default:
+        return "UNKNOWN ";
+    }
+}
+
+void
+sentry__logger_log(sentry_level_t level, const char *message, ...)
+{
+    const sentry_options_t *options = sentry_get_options();
+    if (options && options->logger && sentry_options_get_debug(options)) {
+
+        va_list args;
+        va_start(args, message);
+
+        options->logger(level, message, args);
+
+        va_end(args);
+    }
+}

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -1,0 +1,26 @@
+#include "sentry.h"
+
+void sentry__logger_defaultlogger(
+    sentry_level_t level, const char *message, va_list args);
+
+const char *sentry__logger_describe(sentry_level_t level);
+
+void sentry__logger_log(sentry_level_t level, const char *message, ...);
+
+#define SENTRY_TRACEF(message, ...)                                            \
+    sentry__logger_log(SENTRY_LEVEL_DEBUG, message "\n", __VA_ARGS__)
+
+#define SENTRY_TRACE(message)                                                  \
+    sentry__logger_log(SENTRY_LEVEL_DEBUG, message "\n")
+
+#define SENTRY_DEBUGF(message, ...)                                            \
+    sentry__logger_log(SENTRY_LEVEL_INFO, message "\n", __VA_ARGS__)
+
+#define SENTRY_DEBUG(message)                                                  \
+    sentry__logger_log(SENTRY_LEVEL_INFO, message "\n")
+
+#define SENTRY_WARNF(message, ...)                                             \
+    sentry__logger_log(SENTRY_LEVEL_WARNING, message "\n", __VA_ARGS__)
+
+#define SENTRY_WARN(message)                                                   \
+    sentry__logger_log(SENTRY_LEVEL_WARNING, message "\n")

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -2,6 +2,7 @@
 #include "sentry_alloc.h"
 #include "sentry_backend.h"
 #include "sentry_database.h"
+#include "sentry_logger.h"
 #include "sentry_path.h"
 #include "sentry_string.h"
 #include "sentry_transport.h"
@@ -20,6 +21,7 @@ sentry_options_new(void)
     sentry_options_set_dsn(opts, getenv("SENTRY_DSN"));
     const char *debug = getenv("SENTRY_DEBUG");
     opts->debug = debug && sentry__string_eq(debug, "1");
+    opts->logger = sentry__logger_defaultlogger;
 #ifdef SENTRY_PLATFORM_WINDOWS
     opts->release = sentry__string_from_wstr(_wgetenv(L"SENTRY_RELEASE"));
     opts->environment
@@ -205,6 +207,14 @@ int
 sentry_options_get_debug(const sentry_options_t *opts)
 {
     return opts->debug;
+}
+
+void
+sentry_options_set_logger(sentry_options_t *opts,
+    void (*logger_func)(
+        sentry_level_t level, const char *message, va_list args))
+{
+    opts->logger = logger_func;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -35,6 +35,7 @@ typedef struct sentry_options_s {
     char *ca_certs;
     sentry_path_t *database_path;
     sentry_path_t *handler_path;
+    void (*logger)(sentry_level_t level, const char *message, va_list args);
     bool debug;
     bool require_user_consent;
     bool symbolize_stacktraces;


### PR DESCRIPTION
add ability to create logger hook

```c
void logger_hook(sentry_level_t level, const char* message, va_list args)
{
    char buf[1024]{};
    vsprintf(buf, message, args);
    OutputDebugStringA(buf);
}

...

void init_sentry() 
{
    sentry_options_t* _options = sentry_options_new();
    sentry_options_set_logger(_options, logger_hook);

   ...
}

```

fixes #148 
references #244