### PR TITLE
fix: Avoid memory unsafety when loading session from disk

### DIFF
--- a/src/sentry_session.c
+++ b/src/sentry_session.c
@@ -65,7 +65,7 @@ sentry__session_new(void)
         = sentry__string_clone(sentry_options_get_environment(opts));
 
     rv->release = release;
-    rv->environment = sentry__string_clone(environment);
+    rv->environment = environment;
     rv->session_id = sentry_uuid_new_v4();
     rv->distinct_id = sentry_value_new_null();
     rv->status = SENTRY_SESSION_STATUS_OK;

--- a/src/sentry_session.h
+++ b/src/sentry_session.h
@@ -20,8 +20,8 @@ typedef enum {
  * metadata.
  */
 typedef struct sentry_session_s {
-    const char *release;
-    const char *environment;
+    char *release;
+    char *environment;
     sentry_uuid_t session_id;
     sentry_value_t distinct_id;
     uint64_t started_ms;

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -150,9 +150,7 @@ def test_abnormal_session(tmp_path):
     output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
     envelope = Envelope.deserialize(output)
 
-    assert_session(
-        envelope, {"status": "abnormal", "errors": 0, "duration": 10}
-    )
+    assert_session(envelope, {"status": "abnormal", "errors": 0, "duration": 10})
 
 
 @pytest.mark.skipif(not has_inproc, reason="test needs inproc backend")

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import os
 import time
+import json
 from . import cmake, check_output, run, Envelope
 from .conditions import has_inproc, has_breakpad, has_files
 from .assertions import (
@@ -14,6 +15,7 @@ from .assertions import (
     assert_crash,
     assert_minidump,
     assert_timestamp,
+    assert_session,
 )
 
 
@@ -113,6 +115,44 @@ def test_multi_process(tmp_path):
         if run.endswith(".run") or run.endswith(".lock")
     ]
     assert len(runs) == 0
+
+
+@pytest.mark.skipif(not has_files, reason="test needs a local filesystem")
+def test_abnormal_session(tmp_path):
+    cmake(
+        tmp_path,
+        ["sentry_example"],
+        {"SENTRY_BACKEND": "none", "SENTRY_TRANSPORT": "none"},
+    )
+
+    # create a bogus session file
+    db_dir = tmp_path.joinpath(".sentry-native")
+    db_dir.mkdir()
+    run_dir = db_dir.joinpath("foobar.run")
+    run_dir.mkdir()
+    with open(run_dir.joinpath("session.json"), "w") as session_file:
+        json.dump(
+            {
+                "sid": "00000000-0000-0000-0000-000000000000",
+                "did": "42",
+                "status": "started",
+                "errors": 0,
+                "started": "2020-06-02T10:04:53.680Z",
+                "duration": 10,
+                "attrs": {
+                    "release": "test-example-release",
+                    "environment": "development",
+                },
+            },
+            session_file,
+        )
+
+    output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
+    envelope = Envelope.deserialize(output)
+
+    assert_session(
+        envelope, {"status": "abnormal", "errors": 0, "duration": 10}
+    )
 
 
 @pytest.mark.skipif(not has_inproc, reason="test needs inproc backend")


### PR DESCRIPTION
The session now owns its `release`/`environment`, to avoid borrowing problems when loading from disk. And also add a test that ensures loading from disk and flagging as abnormal works.