### PR TITLE
fix: Two issues uncovered by GCC analyzer

### DIFF
--- a/src/sentry_json.c
+++ b/src/sentry_json.c
@@ -411,6 +411,10 @@ tokens_to_value(jsmntok_t *tokens, size_t token_count, const char *buf,
     jsmntok_t *root = POP();
     sentry_value_t rv = sentry_value_new_null();
 
+    if (!root) {
+        goto error;
+    }
+
     switch (root->type) {
     case JSMN_PRIMITIVE: {
         switch (buf[root->start]) {

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -236,7 +236,9 @@ sentry__bgworker_foreach_matching(sentry_bgworker_t *bgw,
             bgw->task_count--;
             dropped++;
         } else {
-            prev_task->next_task = task;
+            if (prev_task) {
+                prev_task->next_task = task;
+            }
             prev_task = task;
         }
 


### PR DESCRIPTION
I ran gcc with `-fanalyzer`, which uncovered some potential null dereferences. 

It does however have some false positives as well, such as:

https://github.com/getsentry/sentry-native/blob/b48c21d244092658d6e2d1bb243b705fd968b9f7/src/sentry_envelope.c#L90

Plus it complains about some code in `mpack` which we vendor.