### PR TITLE
fix: Flush scope immediately when starting Crashpad Backend

### DIFF
--- a/src/sentry_logger.c
+++ b/src/sentry_logger.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 #include "sentry_logger.h"
 #include "sentry_options.h"


### PR DESCRIPTION
Otherwise we would end up with an empty event file.

fixes #208