### PR TITLE
fix bug with absolute database path on windows

### DIFF
--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -361,11 +361,17 @@ sentry__path_create_dir_all(const sentry_path_t *path)
     size_t len = wcslen(path->path) + 1;
     p = sentry_malloc(sizeof(wchar_t) * len);
     memcpy(p, path->path, len * sizeof(wchar_t));
-
+    bool first_comp = false;
     for (ptr = p; *ptr; ptr++) {
         if (*ptr == '\\' && ptr != p) {
             *ptr = 0;
-            _TRY_MAKE_DIR;
+
+            if (!first_comp && strchr(p, ':') != NULL) { //skip drive letter  on first string component
+                _TRY_MAKE_DIR;
+            }
+            if (!first_comp) {
+                first_comp = true;
+            }
             *ptr = '\\';
         }
     }


### PR DESCRIPTION
If you on **windows** and set `sentry_options_set_database_path` to absolute path , then `sentry__path_create_dir_all` will **fail horribly**, because **it dont skip drive letter path component**.

In my case, I just want to set database to windows temp dir, because I dont have write permissions to program folder.

Interesting note, that  I failed to find this bug at first, because I set path with back slashes like
`c:/Users/<USERNAME>/AppData/Local/Temp/sentry-db-directory/` and `sentry__path_create_dir_all` will successfully create folder, but then it calls `sentry__path_absolute` that normalize it to forward slashes `c:\\Users\\<USERNAME>\\AppData\\Local\\Temp\\sentry-db-directory\\` and fail on `sentry__run_new`.

If you set forward slashes from start `c:\\Users\\<USERNAME>\\AppData\\Local\\Temp\\sentry-db-directory\\` it fails even creating `sentry-db-directory` for the same reason.

This patch fixes described problem for me.
