### PR TITLE
fix: Run through clang-analyzer and fail on warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,9 @@ stages:
               vmImage: "ubuntu-latest"
               CC: clang-9
               CXX: clang++-9
+              CFLAGS: -Werror
+              CXXFlags: -Werror
+              SCAN_BUILD: 1
             macOS:
               vmImage: "macOs-latest"
             Windows (VS2017, 32bit):

--- a/examples/example.c
+++ b/examples/example.c
@@ -33,6 +33,16 @@ has_arg(int argc, char **argv, const char *arg)
     return false;
 }
 
+static void *invalid_mem = (void *)1;
+
+static void
+trigger_crash()
+{
+    // Triggers a segfault by writing to `NULL`. We actually do a `1 - 1` to
+    // defeat static analyzers which would warn for the trivial case.
+    memset((char *)(invalid_mem - 1), 1, 100);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -131,7 +141,7 @@ main(int argc, char **argv)
     }
 
     if (has_arg(argc, argv, "crash")) {
-        memset((char *)0x0, 1, 100);
+        trigger_crash();
     }
 
     if (has_arg(argc, argv, "capture-event")) {

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -64,7 +64,12 @@ shutdown_task(void *data)
 #    define UNSIGNED_MINGW
 #endif
 
+// pthreads use `void *` return types, whereas windows uses `DWORD`
+#ifdef SENTRY_PLATFORM_WINDOWS
 static UNSIGNED_MINGW int THREAD_FUNCTION_API
+#else
+static void *
+#endif
 worker_thread(void *data)
 {
     sentry_bgworker_t *bgw = data;

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -226,9 +226,7 @@ typedef pthread_cond_t sentry_cond_t;
         } while (0)
 #    define sentry__cond_wake pthread_cond_signal
 #    define sentry__thread_spawn(ThreadId, Func, Data)                         \
-        (pthread_create(ThreadId, NULL, (void *(*)(void *))Func, Data) == 0    \
-                ? 0                                                            \
-                : 1)
+        (pthread_create(ThreadId, NULL, Func, Data) == 0 ? 0 : 1)
 #    define sentry__thread_join(ThreadId) pthread_join(ThreadId, NULL)
 #    define sentry__threadid_equal pthread_equal
 #    define sentry__current_thread pthread_self

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -161,7 +161,6 @@ sentry__url_parse(sentry_url_t *url_out, const char *url)
         tmp = ptr;
         SKIP_WHILE_NOT(tmp, 0);
         url_out->fragment = sentry__string_clonen(ptr, tmp - ptr);
-        ptr = tmp;
     }
 
     if (url_out->port == 0) {

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -6,14 +6,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef __GNUC__
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wstatic-in-inline"
-#endif
 #include "../vendor/mpack.h"
-#ifdef __GNUC__
-#    pragma GCC diagnostic pop
-#endif
 
 #include "sentry_alloc.h"
 #include "sentry_core.h"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -94,7 +94,10 @@ def cmake(cwd, targets, options=None):
                 "ANDROID_NATIVE_API_LEVEL": os.environ["ANDROID_API"],
             }
         )
-    configcmd = ["cmake"]
+    cmake = ["cmake"]
+    if os.environ.get("SCAN_BUILD"):
+        cmake = ["scan-build", "cmake"]
+    configcmd = [*cmake]
     for key, value in options.items():
         configcmd.append("-D{}={}".format(key, value))
     if sys.platform == "win32" and os.environ.get("TEST_X86"):
@@ -106,7 +109,7 @@ def cmake(cwd, targets, options=None):
     print("\n{} > {}".format(cwd, " ".join(configcmd)), flush=True)
     subprocess.run(configcmd, cwd=cwd, check=True)
 
-    buildcmd = ["cmake", "--build", ".", "--parallel"]
+    buildcmd = [*cmake, "--build", ".", "--parallel"]
     for target in targets:
         buildcmd.extend(["--target", target])
     print("{} > {}".format(cwd, " ".join(buildcmd)), flush=True)


### PR DESCRIPTION
* correct some issues found by clang-analyzer (dead stores, one of them
  seems to have been a bug in the page allocator all along)
* fix other warnings on clang
* try to turn of warnings-as-errors on CI, and run through `scan-build`