### PR TITLE
Add cmake option to disable exposing symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,11 @@ target_include_directories(sentry
 # `-E`: To have all symbols in the dynamic symbol table.
 # `--build-id`: To have a build-id in the ELF object.
 # FIXME: cmake 3.13 introduced target_link_options
-target_link_libraries(sentry PUBLIC
-	"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E,--build-id=sha1>")
+option(SENTRY_EXPORT_SYMBOLS "Export symbols for modulefinder and symbolizer" ON)
+if(SENTRY_EXPORT_SYMBOLS)
+	target_link_libraries(sentry PUBLIC
+		"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E,--build-id=sha1>")
+endif()
 
 #respect CMAKE_SYSTEM_VERSION
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ Legend:
 - ✓ supported
 - unsupported
 
+- `SENTRY_EXPORT_SYMBOLS` (Default: ON):
+  By default, `sentry` exposes all symbols in the dynamic symbol table. You might want to disable it in case the program intends to `dlopen` third-party shared libraries and avoid symbol collisions.
+
 ### Build Targets
 
 - `sentry`: This is the main library and the only default build target.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 
 - `SENTRY_PIC` (Default: ON):
   By default, `sentry` is built as a position independent library.
+  
+- `SENTRY_EXPORT_SYMBOLS` (Default: ON):
+  By default, `sentry` exposes all symbols in the dynamic symbol table. You might want to disable it in case the program intends to `dlopen` third-party shared libraries and avoid symbol collisions.
 
 - `CMAKE_SYSTEM_VERSION`: (Default: depending on Windows SDK version):
   Sets up a minimal version of Windows where sentry-native can be guaranteed to run.
@@ -200,9 +203,6 @@ Legend:
 - ☑ default
 - ✓ supported
 - unsupported
-
-- `SENTRY_EXPORT_SYMBOLS` (Default: ON):
-  By default, `sentry` exposes all symbols in the dynamic symbol table. You might want to disable it in case the program intends to `dlopen` third-party shared libraries and avoid symbol collisions.
 
 ### Build Targets
 


### PR DESCRIPTION
These options are undesirable in the case when the binary is intended to `dlopen` third-party `.so` files (in our case ODBC drivers) and hide its symbols from them. Exposing symbols lead to segfaults when there's a collision between binary and library symbols.