### PR TITLE
ContextRecord incorrectly passed to StackWalk64

### DIFF
--- a/src/unwinder/sentry_unwinder_dbghelp.c
+++ b/src/unwinder/sentry_unwinder_dbghelp.c
@@ -38,21 +38,21 @@ sentry__unwind_stack_dbghelp(
 
     sentry__init_dbghelp();
 
-    CONTEXT *ctx = uctx->exception_ptrs.ContextRecord;
+    CONTEXT ctx = *uctx->exception_ptrs.ContextRecord;
     STACKFRAME64 stack_frame;
     memset(&stack_frame, 0, sizeof(stack_frame));
 
     size_t size = 0;
 #if defined(_WIN64)
     int machine_type = IMAGE_FILE_MACHINE_AMD64;
-    stack_frame.AddrPC.Offset = ctx->Rip;
-    stack_frame.AddrFrame.Offset = ctx->Rbp;
-    stack_frame.AddrStack.Offset = ctx->Rsp;
+    stack_frame.AddrPC.Offset = ctx.Rip;
+    stack_frame.AddrFrame.Offset = ctx.Rbp;
+    stack_frame.AddrStack.Offset = ctx.Rsp;
 #else
     int machine_type = IMAGE_FILE_MACHINE_I386;
-    stack_frame.AddrPC.Offset = ctx->Eip;
-    stack_frame.AddrFrame.Offset = ctx->Ebp;
-    stack_frame.AddrStack.Offset = ctx->Esp;
+    stack_frame.AddrPC.Offset = ctx.Eip;
+    stack_frame.AddrFrame.Offset = ctx.Ebp;
+    stack_frame.AddrStack.Offset = ctx.Esp;
 #endif
     stack_frame.AddrPC.Mode = AddrModeFlat;
     stack_frame.AddrFrame.Mode = AddrModeFlat;


### PR DESCRIPTION
The ContextRecord parameter should be a PCONTEXT (not a PCONTEXT* as was coded)
A local copy of context made as StackWalk64 can alter it.