### PR TITLE
meta: Add Contribution guide and issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+<!-- A clear and concise description of what the bug is. -->
+
+**When does the problem happen**
+<!-- Put an `x` where relevant. -->
+- [ ] During build
+- [ ] During run-time
+- [ ] When capturing a hard crash
+
+**Environment**
+<!-- Some issues are very OS and compiler-dependent. -->
+- OS: [e.g. Windows 10, 64-bit]
+- Compiler: [e.g. MSVC 19]
+- CMake config: [e.g. SENTRY_BACKEND=inproc]
+
+**Steps To Reproduce**
+<!-- The best way is to provide a minimal code snippet -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+**Contribution Checklist**
+
+<!--
+Put an `x` in the boxes that apply, preferably every one ;-)
+This is more of a checklist for you as a contributor.
+-->
+
+- [ ] Code was auto-formatted and passes linters. (`make format`)
+- [ ] The Code is covered by some kind of test. (integration, unit, or regression test)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,10 @@
-**Contribution Checklist**
-
 <!--
-Put an `x` in the boxes that apply, preferably every one ;-)
-This is more of a checklist for you as a contributor.
--->
+This is a small checklist for you as a contributor:
 
-- [ ] Code was auto-formatted and passes linters. (`make format`)
-- [ ] The Code is covered by some kind of test. (integration, unit, or regression test)
+* Make sure code is formatted properly: `make format`.
+* Make sure to run tests for your code: `make test`.
+* Create new tests where appropriate:
+  - Create new unit-tests or integration-tests covering your change.
+  - When you create a bugfix, try to add a regression-test as well.
+  - Make sure you run the tests with a leak checker or other static analyzer.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,12 @@ Building and testing `sentry-native` currently requires the following tools:
 
 `pytest` and `black` are installed as virtualenv dependencies automatically.
 
-## Setting up Git Hooks
+## Setting up Environment
 
     $ make setup
 
-Installs a pre-commit hook, and initializes/updates the necessary git submodules.
+This sets up both git, including a pre-commit hook and submodules, and installs
+a python virtualenv which is used to run tests and formatting.
 
 ## Formatting Code
 
@@ -34,11 +35,7 @@ be done manually.
 
     $ make test
 
-Creates a virtualenv with python, and runs all the tests through `pytest`.
-
-The Makefile currently assumes python 3.7, but this can be overridden manually:
-
-    $ make SENTRY_NATIVE_PYTHON_VERSION=python3.8 setup-venv
+Creates a python virtualenv, and runs all the tests through `pytest`.
 
 **Running integration-tests manually**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contribution guidelines
+
+We love and welcome contributions!
+
+In order to maintain a high quality, we run a great number of checks on
+different OS / Compiler combinations, and using different analysis tools.
+
+## Prerequisites
+
+Building and testing `sentry-native` currently requires the following tools:
+
+- **CMake** and a supported C/C++ compiler, to actually build the code.
+- **python** and **pytest**, to run integration tests.
+- **clang-format** and **black**, to format the C/C++ and python code respectively.
+
+## Setting up Git Hooks
+
+    $ make setup
+
+Installs a pre-commit hook, and initializes/updates the necessary git submodules.
+
+## Formatting Code
+
+    $ make format
+
+This should be done automatically as part of the pre-commit hook, but can also
+done manually.
+
+    $ black tests
+
+## Running Tests
+
+    $ make test
+
+Creates a virtualenv with python, and runs all the tests through `pytest`.
+
+The Makefile currently assumes python 3.7, but this can be overridden manually:
+
+    $ make SENTRY_NATIVE_PYTHON_VERSION=python3.8 setup-venv
+
+**Running integration-tests manually**:
+
+    $ pytest --verbose --maxfail=1 --capture=no tests/
+
+When all the python dependencies have been installed, the integration test suite
+can also be invoked directly.
+
+The `maxfail` parameter will abort after the first failure, and `capture=no`
+will print the complete compiler output, and test log.
+
+**Running unit-tests manually**:
+
+    $ cmake -B build -D CMAKE_RUNTIME_OUTPUT_DIRECTORY=$(pwd)/build
+    $ cmake --build build --target sentry_test_unit
+    $ ./build/sentry_test_unit
+
+The unit-tests are a separate executable target and can be built and run on
+their own.
+
+## How to interpret CI failures
+
+The way that tests are run unfortunately does not make immediately obvious from
+the summary what the actual failure is, especially for compile-time failures.
+In such cases, it is good to scan the test output _from top to bottom_ and find
+the offending compile error.
+
+When running tests locally, one can use the `--maxfail=1` / `-x` parameter to
+abort after the first failure.
+
+## Integration Test Parameters
+
+The integration test suite runs the `sentry_example` target using a variety of
+different compile-time parameters, and asserts different use-cases.
+
+Some of its behavior is controlled by env-variables:
+
+- `ERROR_ON_WARNINGS`: Turns on `-Werror` for gcc compatible compilers.
+  This is also the default for `MSVC` on windows.
+- `RUN_ANALYZER`: Runs the code with/through one or more of the given analyzers.
+  This accepts a comma-separated list, and currently has support for:
+  - `asan`: Uses clangs AddressSanitizer and runs integration tests with the
+    `detect_leaks` flag.
+  - `scan-build`: Runs the build through the `scan-build` tool.
+  - `code-checker`: Uses the [`CodeChecker`](https://github.com/Ericsson/codechecker)
+    tool for builds.
+  - `kcov`: Uses [`kcov`](https://github.com/SimonKagstrom/kcov) to collect
+    code-coverage statistics.
+  - `gcc`: Use the `-fanalyzer` flag of `gcc > 10`.
+    This is currently not stable enough to use, as it leads to false positives
+    and internal compiler errors.
+- `TEST_X86`: Passes flags to CMake to enable a 32-bit (cross-)compile.
+- `ANDROID_API` / `ANDROID_NDK` / `ANDROID_ARCH`: Instructs the test runner to
+  build using the given Android `NDK` version, targeting the given `API` and
+  `ARCH`. The test runner assumes an already running simulator matching the
+  `ARCH`, and will run the tests on that.
+
+**Running examples manually**:
+
+    $ cmake -B build -D CMAKE_RUNTIME_OUTPUT_DIRECTORY=$(pwd)/build
+    $ cmake --build build --target sentry_example
+    $ ./build/sentry_example log capture-event
+
+The example can be run manually with a variety of flags to test different
+scenarios. Additionally, it will use the `SENTRY_DSN` env-variable, and can thus
+also be used to capture events/crashes directly to sentry.
+
+The example currently supports the following flags:
+
+- `capture-event`: Captures an event.
+- `crash`: Triggers a crash to be captured.
+- `log`: Enables debug logging.
+- `release-env`: Uses the `SENTRY_RELEASE` env-variable for the release,
+  instead of a hardcoded value.
+- `attachment`: Adds an attachment, which is currently defined as the
+  `CMakeCache.txt` file, which is part of the CMake build folder.
+- `stdout`: Uses a custom transport which dumps all envelopes to `stdout`.
+- `no-setup`: Skips all scope and breadcrumb initialization code.
+- `start-session`: Starts a new release-health session.
+- `overflow-breadcrumbs`: Creates a large number of breadcrumbs that overflow
+  the maximum allowed number.
+- `capture-multiple`: Captures a number of events.
+- `sleep`: Introduces a 10 second sleep.
+- `add-stacktrace`: Adds the current thread stacktrace to the captured event.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We love and welcome contributions!
 
-In order to maintain a high quality, we run a great number of checks on
+In order to maintain a high quality, we run a number of checks on
 different OS / Compiler combinations, and using different analysis tools.
 
 ## Prerequisites
@@ -12,6 +12,8 @@ Building and testing `sentry-native` currently requires the following tools:
 - **CMake** and a supported C/C++ compiler, to actually build the code.
 - **python** and **pytest**, to run integration tests.
 - **clang-format** and **black**, to format the C/C++ and python code respectively.
+
+`pytest` and `black` are installed as virtualenv dependencies automatically.
 
 ## Setting up Git Hooks
 
@@ -24,7 +26,7 @@ Installs a pre-commit hook, and initializes/updates the necessary git submodules
     $ make format
 
 This should be done automatically as part of the pre-commit hook, but can also
-done manually.
+be done manually.
 
     $ black tests
 
@@ -59,7 +61,7 @@ their own.
 
 ## How to interpret CI failures
 
-The way that tests are run unfortunately does not make immediately obvious from
+The way that tests are run unfortunately does not make it immediately obvious from
 the summary what the actual failure is, especially for compile-time failures.
 In such cases, it is good to scan the test output _from top to bottom_ and find
 the offending compile error.
@@ -100,11 +102,11 @@ Some of its behavior is controlled by env-variables:
     $ cmake --build build --target sentry_example
     $ ./build/sentry_example log capture-event
 
-The example can be run manually with a variety of flags to test different
+The example can be run manually with a variety of commands to test different
 scenarios. Additionally, it will use the `SENTRY_DSN` env-variable, and can thus
 also be used to capture events/crashes directly to sentry.
 
-The example currently supports the following flags:
+The example currently supports the following commends:
 
 - `capture-event`: Captures an event.
 - `crash`: Triggers a crash to be captured.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export SENTRY_NATIVE_PYTHON_VERSION := python3.7
-
 all: test
 
 update-test-discovery:
@@ -42,7 +40,7 @@ clean: build/Makefile
 	@$(MAKE) -C build clean
 .PHONY: clean
 
-setup: setup-git
+setup: setup-git setup-venv
 .PHONY: setup
 
 setup-git: .git/hooks/pre-commit
@@ -58,7 +56,7 @@ setup-venv: .venv/bin/python
 .venv/bin/python: Makefile tests/requirements.txt
 	@rm -rf .venv
 	@which virtualenv || sudo pip install virtualenv
-	virtualenv -p $$SENTRY_NATIVE_PYTHON_VERSION .venv
+	virtualenv -p python3 .venv
 	.venv/bin/pip install --upgrade --requirement tests/requirements.txt
 
 format: setup-venv

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
     only supported on Windows and macOS, and used as the default there.
   - **breakpad**: This uses the in-process breakpad handler. It is currently
     only supported on Linux and Windows, and used as the default on Linux.
-  - **inproc**: A small in-process handler which is supported on all platforms, 
+  - **inproc**: A small in-process handler which is supported on all platforms,
     and is used as default on Android.
   - **none**: This builds `sentry-native` without a backend, so it does not handle
     crashes at all. It is primarily used for tests.
@@ -240,31 +240,4 @@ Legend:
 
 ## Development
 
-Some external dependencies, such as `crashpad` are used via `git submodules`.
-When working with this repository, make sure to check out the submodules
-recursively.
-
-    $ git clone --recurse-submodules https://github.com/getsentry/sentry-native.git
-
-Or when working with an existing clone:
-
-    $ git submodule update --init --recursive
-
-Alternatively, the `make setup` target will do that for you, and might be
-extended in the future if other dependencies are added.
-
-### Running Tests
-
-The SDK ships with a unit-test suite based on [acutest]. Additionally, the
-`sentry_example` executable is also used for integration tests which are run
-via `pytest`.
-The unit-tests are built as a separate `sentry_test_unit` executable.
-
-On macOS and Linux, the _top-level Makefile_ contains a convenience command to
-run tests:
-
-```sh
-make test
-```
-
-[acutest]: https://github.com/mity/acutest
+Please see the [contribution guide](./CONTRIBUTING.md).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+trigger:
+  - master
+  - release/*
+
 stages:
   - stage: test
     displayName: Build & Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ stages:
         steps:
           - checkout: self
           - task: UsePythonVersion@0
-          - script: make SENTRY_NATIVE_PYTHON_VERSION=python3.8 style
+          - script: make style
             displayName: Lint
 
       - job:


### PR DESCRIPTION
* Creates a contribution guide, which documents the testing infrastructure and options.
* Adds issue/PR templates, which ask for relevant versions/options, and instruct contributors to run tests.
* Configures CI to not run for every push ;-)