### PR TITLE
ref: Remove name parameter from sentry_options_add_attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Breaking Changes**:
 
 - The `sentry_options_set_logger` function now accepts a `userdata` parameter.
+- The `name` parameter of `sentry_options_add_attachment(w)` was removed, it will
+  now be inferred from the filename of `path`.
 
 **Features**:
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -65,8 +65,7 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "attachment")) {
         // assuming the example / test is run directly from the cmake build
         // directory
-        sentry_options_add_attachment(
-            options, "CMakeCache.txt", "./CMakeCache.txt");
+        sentry_options_add_attachment(options, "./CMakeCache.txt");
     }
 
     if (has_arg(argc, argv, "stdout")) {

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -773,7 +773,7 @@ SENTRY_API int sentry_options_get_symbolize_stacktraces(
  * instead.
  */
 SENTRY_API void sentry_options_add_attachment(
-    sentry_options_t *opts, const char *name, const char *path);
+    sentry_options_t *opts, const char *path);
 
 /**
  * Sets the path to the crashpad handler if the crashpad backend is used.
@@ -818,7 +818,7 @@ SENTRY_API void sentry_options_set_database_path(
  * Wide char version of `sentry_options_add_attachment`.
  */
 SENTRY_API void sentry_options_add_attachmentw(
-    sentry_options_t *opts, const char *name, const wchar_t *path);
+    sentry_options_t *opts, const wchar_t *path);
 
 /**
  * Wide char version of `sentry_options_set_handler_path`.

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -49,7 +49,6 @@ void
 sentry__attachment_free(sentry_attachment_t *attachment)
 {
     sentry__path_free(attachment->path);
-    sentry_free(attachment->name);
     sentry_free(attachment);
 }
 
@@ -250,34 +249,25 @@ sentry_options_set_system_crash_reporter_enabled(
 }
 
 static void
-add_attachment(
-    sentry_options_t *opts, const char *orig_name, sentry_path_t *path)
+add_attachment(sentry_options_t *opts, sentry_path_t *path)
 {
     if (!path) {
         return;
     }
-    char *name = sentry__string_clone(orig_name);
-    if (!name) {
-        sentry__path_free(path);
-        return;
-    }
     sentry_attachment_t *attachment = SENTRY_MAKE(sentry_attachment_t);
     if (!attachment) {
-        sentry_free(name);
         sentry__path_free(path);
         return;
     }
-    attachment->name = name;
     attachment->path = path;
     attachment->next = opts->attachments;
     opts->attachments = attachment;
 }
 
 void
-sentry_options_add_attachment(
-    sentry_options_t *opts, const char *name, const char *path)
+sentry_options_add_attachment(sentry_options_t *opts, const char *path)
 {
-    add_attachment(opts, name, sentry__path_from_str(path));
+    add_attachment(opts, sentry__path_from_str(path));
 }
 
 void
@@ -296,10 +286,9 @@ sentry_options_set_database_path(sentry_options_t *opts, const char *path)
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 void
-sentry_options_add_attachmentw(
-    sentry_options_t *opts, const char *name, const wchar_t *path)
+sentry_options_add_attachmentw(sentry_options_t *opts, const wchar_t *path)
 {
-    add_attachment(opts, name, sentry__path_from_wstr(path));
+    add_attachment(opts, sentry__path_from_wstr(path));
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -20,7 +20,6 @@ struct sentry_backend_s;
  */
 typedef struct sentry_attachment_s sentry_attachment_t;
 struct sentry_attachment_s {
-    char *name;
     sentry_path_t *path;
     sentry_attachment_t *next;
 };

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -36,10 +36,9 @@ SENTRY_TEST(lazy_attachments)
         options, sentry_new_function_transport(send_envelope, &testdata));
     sentry_options_set_release(options, "prod");
 
+    sentry_options_add_attachment(options, PREFIX ".existing-file-attachment");
     sentry_options_add_attachment(
-        options, "existing-attachment", PREFIX ".existing-file-attachment");
-    sentry_options_add_attachment(options, "non-existing-attachment",
-        PREFIX ".non-existing-file-attachment");
+        options, PREFIX ".non-existing-file-attachment");
     sentry_path_t *existing
         = sentry__path_from_str(PREFIX ".existing-file-attachment");
     sentry_path_t *non_existing
@@ -59,7 +58,8 @@ SENTRY_TEST(lazy_attachments)
                    "foo\n")
         != NULL);
     TEST_CHECK(
-        strstr(serialized, "\"filename\":\"non-existing-attachment\"") == NULL);
+        strstr(serialized, "\"filename\":\".non-existing-file-attachment\"")
+        == NULL);
     sentry_free(serialized);
 
     sentry__path_write_buffer(existing, "foobar", 6);


### PR DESCRIPTION
This is now unused with the latest crashpad changes.