### PR TITLE
fix: Lock global options whenever they are accessed

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,4 @@ IndentPPDirectives: AfterHash
 ColumnLimit: 80
 AlwaysBreakAfterDefinitionReturnType: All
 PointerAlignment: Right
-ForEachMacros: ['SENTRY_WITH_SCOPE', 'SENTRY_WITH_SCOPE_MUT']
+ForEachMacros: ['SENTRY_WITH_SCOPE', 'SENTRY_WITH_SCOPE_MUT', 'SENTRY_WITH_SCOPE_MUT_NO_FLUSH', 'SENTRY_WITH_OPTIONS']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Breaking Changes**:
 
 - The minimum CMake version required to build on windows was raised to `3.16.4` to avoid potential build failures on older versions.
+- The `sentry_get_options` function was removed, as it was unsafe to use after a `sentry_shutdown` call.
 - The `sentry_options_set_logger` function now accepts a `userdata` parameter.
 - The `name` parameter of `sentry_options_add_attachment(w)` was removed, it will now be inferred from the filename of `path`.
 - The transport startup hook that is set via `sentry_transport_set_startup_func` now needs to return an `int`, and a failure will propagate to `sentry_init`.
@@ -50,7 +51,7 @@ sentry_transport_set_shutdown_func(transport, transport_shutdown);
 **Fixes**:
 
 - Reworked thread synchronization code and logic in `sentry_shutdown`, avoiding an abort in case of an unclean shutdown. ([#323](https://github.com/getsentry/sentry-native/pull/323))
-- Similarly, reworked options locking, avoiding thread safety issues. ([#333](https://github.com/getsentry/sentry-native/pull/333))
+- Similarly, reworked global options handling, avoiding thread safety issues. ([#333](https://github.com/getsentry/sentry-native/pull/333))
 - Fixed errors not being properly recorded in sessions. ([#317](https://github.com/getsentry/sentry-native/pull/317))
 - Fixed some potential memory leaks and other issues. ([#304](https://github.com/getsentry/sentry-native/pull/304) and others)
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -626,12 +626,12 @@ SENTRY_API void sentry_options_set_transport(
 /**
  * Type of the `before_send` callback.
  *
- * The callback taken ownership of the `event`, and will usually return that
- * same event. In the case the event should be discarded, the callback needs to
+ * The callback takes ownership of the `event`, and should usually return that
+ * same event. In case the event should be discarded, the callback needs to
  * call `sentry_value_decref` on the provided event, and return a
- * `sentry_value_new_null` instead.
+ * `sentry_value_new_null()` instead.
  * This function may be invoked inside of a signal handler and must be safe for
- * that purpose.
+ * that purpose, see https://man7.org/linux/man-pages/man7/signal-safety.7.html.
  */
 typedef sentry_value_t (*sentry_event_function_t)(
     sentry_value_t event, void *hint, void *closure);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -906,9 +906,11 @@ SENTRY_API int sentry_shutdown(void);
 SENTRY_EXPERIMENTAL_API void sentry_clear_modulecache(void);
 
 /**
- * Returns the client options.
+ * Returns the currently active client options.
  *
  * This might return NULL if sentry is not yet initialized.
+ * The returned options pointer is not synchronized, and calling
+ * `sentry_shutdown` concurrently can lead to use-after-free situations.
  */
 SENTRY_API const sentry_options_t *sentry_get_options(void);
 

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -71,6 +71,7 @@ sentry__breakpad_backend_callback(
     SENTRY_WITH_OPTIONS (options) {
         sentry__write_crash_marker(options);
 
+        sentry_value_t event = sentry_value_new_event();
         sentry_envelope_t *envelope
             = sentry__prepare_event(options, event, NULL);
         sentry_session_t *session = sentry__end_current_session_with_status(
@@ -78,8 +79,8 @@ sentry__breakpad_backend_callback(
         sentry__envelope_add_session(envelope, session);
 
         // the minidump is added as an attachment, with type `event.minidump`
-        sentry_envelope_item_t *item = sentry__envelope_add_from_path(
-            envelope, state->dump_path, "attachment");
+        sentry_envelope_item_t *item
+            = sentry__envelope_add_from_path(envelope, dump_path, "attachment");
         if (item) {
             sentry__envelope_item_set_header(item, "attachment_type",
                 sentry_value_new_string("event.minidump"));
@@ -90,7 +91,7 @@ sentry__breakpad_backend_callback(
 #else
                 sentry_value_new_string(
 #endif
-                    sentry__path_filename(state->dump_path)));
+                    sentry__path_filename(dump_path)));
         }
 
         // capture the envelope with the disk transport

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -131,6 +131,11 @@ sentry__breakpad_backend_callback(
 {
     SENTRY_DEBUG("entering breakpad minidump callback");
 
+    if (!succeeded) {
+        SENTRY_WARN("breakpad failed creating minidump");
+        return succeeded;
+    }
+
 #ifndef SENTRY_PLATFORM_WINDOWS
     sentry__page_allocator_enable();
     sentry__enter_signal_handler();

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -177,7 +177,8 @@ sentry__crashpad_backend_startup(
     data->db = crashpad::CrashReportDatabase::Initialize(database).release();
 
     crashpad::CrashpadClient client;
-    char *minidump_url = sentry__dsn_get_minidump_url(&options->dsn);
+    char *minidump_url = sentry__dsn_get_minidump_url(options->dsn);
+    SENTRY_TRACEF("using minidump url \"%s\"", minidump_url);
     std::string url = minidump_url ? std::string(minidump_url) : std::string();
     sentry_free(minidump_url);
     bool success = client.StartHandler(handler, database, database, url,

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -21,7 +21,27 @@
 #include "transports/sentry_disk_transport.h"
 
 static sentry_options_t *g_options = NULL;
-static sentry_mutex_t g_options_mutex = SENTRY__MUTEX_INIT;
+static sentry_mutex_t g_options_lock = SENTRY__MUTEX_INIT;
+
+// This function is unsynchronized and can potentially lead to use-after-free
+const sentry_options_t *
+sentry_get_options(void)
+{
+    return g_options;
+}
+
+sentry_options_t *
+sentry__options_lock(void)
+{
+    sentry__mutex_lock(&g_options_lock);
+    return g_options;
+}
+
+void
+sentry__options_unlock(void)
+{
+    sentry__mutex_unlock(&g_options_lock);
+}
 
 static void
 load_user_consent(sentry_options_t *opts)
@@ -47,12 +67,11 @@ load_user_consent(sentry_options_t *opts)
 bool
 sentry__should_skip_upload(void)
 {
-    sentry__mutex_lock(&g_options_mutex);
-    const sentry_options_t *opts = sentry_get_options();
-    bool skip = !opts
-        || (opts->require_user_consent
-            && opts->user_consent != SENTRY_USER_CONSENT_GIVEN);
-    sentry__mutex_unlock(&g_options_mutex);
+    bool skip = true;
+    SENTRY_WITH_OPTIONS (options) {
+        skip = options->require_user_consent
+            && options->user_consent != SENTRY_USER_CONSENT_GIVEN;
+    }
     return skip;
 }
 
@@ -96,6 +115,11 @@ sentry_init(sentry_options_t *options)
 
     load_user_consent(options);
 
+    if (!options->dsn || !options->dsn->is_valid) {
+        const char *raw_dsn = sentry_options_get_dsn(options);
+        SENTRY_WARNF("the provided DSN \"%s\" is not valid", raw_dsn || "");
+    }
+
     if (transport) {
         if (sentry__transport_startup(transport, options) != 0) {
             SENTRY_WARN("failed to initialize transport");
@@ -113,9 +137,9 @@ sentry_init(sentry_options_t *options)
         }
     }
 
-    sentry__mutex_lock(&g_options_mutex);
+    sentry__options_lock();
     g_options = options;
-    sentry__mutex_unlock(&g_options_mutex);
+    sentry__options_unlock();
 
     // *after* setting the global options, trigger a scope and consent flush,
     // since at least crashpad needs that.
@@ -152,12 +176,11 @@ sentry_shutdown(void)
 {
     sentry_end_session();
 
-    sentry__mutex_lock(&g_options_mutex);
-    sentry_options_t *options = g_options;
-    sentry__mutex_unlock(&g_options_mutex);
-
     size_t dumped_envelopes = 0;
-    if (options) {
+    SENTRY_WITH_OPTIONS (options) {
+        // we unset the global here, to try to minimize the chance of errors
+        // with unsynchronized concurrent accesses
+        g_options = NULL;
         if (options->backend && options->backend->shutdown_func) {
             SENTRY_TRACE("shutting down backend");
             options->backend->shutdown_func(options->backend);
@@ -175,12 +198,9 @@ sentry_shutdown(void)
         if (!dumped_envelopes) {
             sentry__run_clean(options->run);
         }
+        sentry_options_free(options);
     }
 
-    sentry__mutex_lock(&g_options_mutex);
-    sentry_options_free(options);
-    g_options = NULL;
-    sentry__mutex_unlock(&g_options_mutex);
     sentry__scope_cleanup();
     sentry__modulefinder_cleanup();
     return (int)dumped_envelopes;
@@ -192,39 +212,29 @@ sentry_clear_modulecache(void)
     sentry__modulefinder_cleanup();
 }
 
-const sentry_options_t *
-sentry_get_options(void)
-{
-    return g_options;
-}
-
 static void
 set_user_consent(sentry_user_consent_t new_val)
 {
-    sentry__mutex_lock(&g_options_mutex);
-    if (!g_options) {
-        sentry__mutex_unlock(&g_options_mutex);
-        return;
-    }
-    g_options->user_consent = new_val;
-    sentry__mutex_unlock(&g_options_mutex);
-    sentry_path_t *consent_path
-        = sentry__path_join_str(g_options->database_path, "user-consent");
-    switch (new_val) {
-    case SENTRY_USER_CONSENT_GIVEN:
-        sentry__path_write_buffer(consent_path, "1\n", 2);
-        break;
-    case SENTRY_USER_CONSENT_REVOKED:
-        sentry__path_write_buffer(consent_path, "0\n", 2);
-        break;
-    case SENTRY_USER_CONSENT_UNKNOWN:
-        sentry__path_remove(consent_path);
-        break;
-    }
-    sentry__path_free(consent_path);
+    SENTRY_WITH_OPTIONS (options) {
+        options->user_consent = new_val;
+        sentry_path_t *consent_path
+            = sentry__path_join_str(options->database_path, "user-consent");
+        switch (new_val) {
+        case SENTRY_USER_CONSENT_GIVEN:
+            sentry__path_write_buffer(consent_path, "1\n", 2);
+            break;
+        case SENTRY_USER_CONSENT_REVOKED:
+            sentry__path_write_buffer(consent_path, "0\n", 2);
+            break;
+        case SENTRY_USER_CONSENT_UNKNOWN:
+            sentry__path_remove(consent_path);
+            break;
+        }
+        sentry__path_free(consent_path);
 
-    if (g_options->backend && g_options->backend->user_consent_changed_func) {
-        g_options->backend->user_consent_changed_func(g_options->backend);
+        if (options->backend && options->backend->user_consent_changed_func) {
+            options->backend->user_consent_changed_func(options->backend);
+        }
     }
 }
 
@@ -250,27 +260,30 @@ sentry_user_consent_t
 sentry_user_consent_get(void)
 {
     sentry_user_consent_t rv = SENTRY_USER_CONSENT_UNKNOWN;
-    sentry__mutex_lock(&g_options_mutex);
-    if (g_options) {
-        rv = g_options->user_consent;
+    SENTRY_WITH_OPTIONS (options) {
+        rv = options->user_consent;
     }
-    sentry__mutex_unlock(&g_options_mutex);
     return rv;
 }
 
 void
 sentry__capture_envelope(sentry_envelope_t *envelope)
 {
-    const sentry_options_t *opts = sentry_get_options();
     bool has_consent = !sentry__should_skip_upload();
-    if (opts && opts->transport && has_consent) {
-        sentry__transport_send_envelope(opts->transport, envelope);
-    } else {
-        if (!has_consent) {
-            SENTRY_TRACE("discarding envelope due to missing user consent");
-        } else {
-            SENTRY_TRACE("discarding envelope due to invalid transport");
+    if (!has_consent) {
+        SENTRY_TRACE("discarding envelope due to missing user consent");
+        sentry_envelope_free(envelope);
+        return;
+    }
+    bool was_sent = false;
+    SENTRY_WITH_OPTIONS (options) {
+        if (options->transport) {
+            sentry__transport_send_envelope(options->transport, envelope);
+            was_sent = true;
         }
+    }
+    if (!was_sent) {
+        SENTRY_TRACE("discarding envelope due to invalid transport");
         sentry_envelope_free(envelope);
     }
 }
@@ -293,57 +306,58 @@ event_is_considered_error(sentry_value_t event)
 sentry_uuid_t
 sentry_capture_event(sentry_value_t event)
 {
-    const sentry_options_t *opts = sentry_get_options();
-    if (!opts) {
-        sentry_value_decref(event);
-        return sentry_uuid_nil();
-    }
-    uint64_t rnd;
-    if (opts->sample_rate < 1.0 && !sentry__getrandom(&rnd, sizeof(rnd))
-        && ((double)rnd / (double)UINT64_MAX) > opts->sample_rate) {
-        SENTRY_DEBUG("throwing away event due to sample rate");
-        sentry_value_decref(event);
-        return sentry_uuid_nil();
-    }
-
-    SENTRY_DEBUG("capturing event");
-    sentry_uuid_t event_id;
-    sentry__ensure_event_id(event, &event_id);
-
-    SENTRY_WITH_SCOPE (scope) {
-        SENTRY_TRACE("merging scope into event");
-        sentry_scope_mode_t mode = SENTRY_SCOPE_ALL;
-        if (!opts->symbolize_stacktraces) {
-            mode &= ~SENTRY_SCOPE_STACKTRACES;
-        }
-        sentry__scope_apply_to_event(scope, event, mode);
-    }
-
-    if (opts->before_send_func) {
-        event = opts->before_send_func(event, NULL, opts->before_send_data);
-    }
-    if (opts->transport && !sentry_value_is_null(event)) {
-        sentry_envelope_t *envelope = sentry__envelope_new();
-        if (!envelope) {
-            return event_id;
+    sentry_envelope_t *envelope = NULL;
+    // we need the options to sample, before_send and attachments
+    SENTRY_WITH_OPTIONS (options) {
+        uint64_t rnd;
+        if (options->sample_rate < 1.0 && !sentry__getrandom(&rnd, sizeof(rnd))
+            && ((double)rnd / (double)UINT64_MAX) > options->sample_rate) {
+            SENTRY_DEBUG("throwing away event due to sample rate");
+            break; // SENTRY_WITH_OPTIONS
         }
 
-        SENTRY_TRACE("adding attachments to envelope");
-        for (sentry_attachment_t *attachment = opts->attachments; attachment;
-             attachment = attachment->next) {
-            sentry_envelope_item_t *item = sentry__envelope_add_from_path(
-                envelope, attachment->path, "attachment");
-            if (!item) {
-                continue;
+        SENTRY_DEBUG("capturing event");
+
+        SENTRY_WITH_SCOPE (scope) {
+            SENTRY_TRACE("merging scope into event");
+            sentry_scope_mode_t mode = SENTRY_SCOPE_ALL;
+            if (!options->symbolize_stacktraces) {
+                mode &= ~SENTRY_SCOPE_STACKTRACES;
             }
-            sentry__envelope_item_set_header(item, "filename",
-#ifdef SENTRY_PLATFORM_WINDOWS
-                sentry__value_new_string_from_wstr(
-#else
-                sentry_value_new_string(
-#endif
-                    sentry__path_filename(attachment->path)));
+            sentry__scope_apply_to_event(scope, event, mode);
         }
+
+        if (options->before_send_func) {
+            event = options->before_send_func(
+                event, NULL, options->before_send_data);
+        }
+        if (options->transport && !sentry_value_is_null(event)) {
+            envelope = sentry__envelope_new();
+
+            SENTRY_TRACE("adding attachments to envelope");
+            for (sentry_attachment_t *attachment = options->attachments;
+                 attachment; attachment = attachment->next) {
+                sentry_envelope_item_t *item = sentry__envelope_add_from_path(
+                    envelope, attachment->path, "attachment");
+                if (!item) {
+                    continue;
+                }
+                sentry__envelope_item_set_header(item, "filename",
+#ifdef SENTRY_PLATFORM_WINDOWS
+                    sentry__value_new_string_from_wstr(
+#else
+                    sentry_value_new_string(
+#endif
+                        sentry__path_filename(attachment->path)));
+            }
+        }
+    }
+    // we don’t need options from now on, but most importantly,
+    // `sentry__capture_envelope` does its own locking yet again.
+
+    if (envelope) {
+        sentry_uuid_t event_id;
+        sentry__ensure_event_id(event, &event_id);
 
         if (event_is_considered_error(event)) {
             sentry__record_errors_on_current_session(1);
@@ -352,34 +366,36 @@ sentry_capture_event(sentry_value_t event)
 
         if (sentry__envelope_add_event(envelope, event)) {
             sentry__capture_envelope(envelope);
-        } else {
-            sentry_envelope_free(envelope);
+            return event_id;
         }
+        // else: fall through, free everything and return nil on error
+        sentry_envelope_free(envelope);
     }
 
-    return event_id;
+    sentry_value_decref(event);
+    return sentry_uuid_nil();
 }
 
 void
 sentry_handle_exception(const sentry_ucontext_t *uctx)
 {
-    const sentry_options_t *opts = sentry_get_options();
-    if (!opts) {
-        return;
-    }
-    SENTRY_DEBUG("handling exception");
-    if (opts->backend && opts->backend->except_func) {
-        opts->backend->except_func(opts->backend, uctx);
+    SENTRY_WITH_OPTIONS (options) {
+        SENTRY_DEBUG("handling exception");
+        if (options->backend && options->backend->except_func) {
+            options->backend->except_func(options->backend, uctx);
+        }
     }
 }
 
-void
-sentry__enforce_disk_transport(void)
+sentry_transport_t *
+sentry__swap_disk_transport(sentry_options_t *options)
 {
-    // Freeing the old transport would, in the case of the curl transport, try
-    // to flush its send queue, which I’m not sure we can do in the signal
-    // handler. So rather we just leak it.
-    g_options->transport = sentry_new_disk_transport(g_options->run);
+    sentry_transport_t *disk_transport
+        = sentry_new_disk_transport(options->run);
+
+    sentry_transport_t *transport = options->transport;
+    options->transport = disk_transport;
+    return transport;
 }
 
 sentry_uuid_t
@@ -430,16 +446,19 @@ sentry_add_breadcrumb(sentry_value_t breadcrumb)
     sentry_value_incref(breadcrumb);
     // the `no_flush` will avoid triggering *both* scope-change and
     // breadcrumb-add events.
-    SENTRY_WITH_SCOPE_MUT_NO_FLUSH(scope)
-    {
+    SENTRY_WITH_SCOPE_MUT_NO_FLUSH (scope) {
         sentry__value_append_bounded(
             scope->breadcrumbs, breadcrumb, SENTRY_BREADCRUMBS_MAX);
     }
 
-    if (g_options && g_options->backend
-        && g_options->backend->add_breadcrumb_func) {
-        g_options->backend->add_breadcrumb_func(g_options->backend, breadcrumb);
-    } else {
+    bool was_added = false;
+    SENTRY_WITH_OPTIONS (options) {
+        if (options->backend && options->backend->add_breadcrumb_func) {
+            options->backend->add_breadcrumb_func(options->backend, breadcrumb);
+            was_added = true;
+        }
+    }
+    if (!was_added) {
         sentry_value_decref(breadcrumb);
     }
 }

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -29,16 +29,28 @@
 bool sentry__should_skip_upload(void);
 
 /**
- * This function is essential to capture reports in the case of a hard crash.
- * It will set a special transport that will dump events to disk.
- * See `sentry__run_write_envelope`.
+ * Convert the given event into an envelope.
+ *
+ * More specifically, it will do the following things:
+ * - sample the event, possibly discarding it,
+ * - apply the scope to it,
+ * - call the before_send hook on it,
+ * - add the event to a new envelope,
+ * - record errors on the current session,
+ * - add any attachments to the envelope as well
+ *
+ * The function will ensure the event has a UUID and write it into the
+ * `event_id` out-parameter.
  */
-sentry_transport_t *sentry__swap_disk_transport(sentry_options_t *options);
+sentry_envelope_t *sentry__prepare_event(const sentry_options_t *options,
+    sentry_value_t event, sentry_uuid_t *event_id);
 
 /**
- * This function will submit the given `envelope` to the configured transport.
+ * This function will submit the `envelope` to the given `transport`, first
+ * checking for consent.
  */
-void sentry__capture_envelope(sentry_envelope_t *envelope);
+void sentry__capture_envelope(
+    sentry_transport_t *transport, sentry_envelope_t *envelope);
 
 /**
  * Generates a new random UUID for events.
@@ -54,9 +66,9 @@ sentry_value_t sentry__ensure_event_id(
     sentry_value_t event, sentry_uuid_t *uuid_out);
 
 /**
- * This will acquire a lock on the global options and return them.
+ * This will return an owned reference to the global options.
  */
-sentry_options_t *sentry__options_lock(void);
+const sentry_options_t *sentry__options_getref(void);
 
 /**
  * Release the lock on the global options.
@@ -64,7 +76,7 @@ sentry_options_t *sentry__options_lock(void);
 void sentry__options_unlock(void);
 
 #define SENTRY_WITH_OPTIONS(Options)                                           \
-    for (sentry_options_t *Options = sentry__options_lock();                   \
-         Options || (sentry__options_unlock(), false); Options = NULL)
+    for (const sentry_options_t *Options = sentry__options_getref(); Options;  \
+         sentry_options_free((sentry_options_t *)Options), Options = NULL)
 
 #endif

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -33,7 +33,7 @@ bool sentry__should_skip_upload(void);
  * It will set a special transport that will dump events to disk.
  * See `sentry__run_write_envelope`.
  */
-void sentry__enforce_disk_transport(void);
+sentry_transport_t *sentry__swap_disk_transport(sentry_options_t *options);
 
 /**
  * This function will submit the given `envelope` to the configured transport.
@@ -52,5 +52,19 @@ sentry_uuid_t sentry__new_event_id(void);
  */
 sentry_value_t sentry__ensure_event_id(
     sentry_value_t event, sentry_uuid_t *uuid_out);
+
+/**
+ * This will acquire a lock on the global options and return them.
+ */
+sentry_options_t *sentry__options_lock(void);
+
+/**
+ * Release the lock on the global options.
+ */
+void sentry__options_unlock(void);
+
+#define SENTRY_WITH_OPTIONS(Options)                                           \
+    for (sentry_options_t *Options = sentry__options_lock();                   \
+         Options || (sentry__options_unlock(), false); Options = NULL)
 
 #endif

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -180,9 +180,7 @@ sentry__process_old_runs(const sentry_options_t *options)
                 if (!session_envelope) {
                     session_envelope = sentry__envelope_new();
                 }
-                if (session_envelope) {
-                    sentry__envelope_add_session(session_envelope, session);
-                }
+                sentry__envelope_add_session(session_envelope, session);
                 sentry__session_free(session);
                 if ((++session_num) >= SENTRY_MAX_ENVELOPE_ITEMS) {
                     sentry__capture_envelope(

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -145,10 +145,11 @@ sentry__envelope_new(void)
     rv->contents.items.item_count = 0;
     rv->contents.items.headers = sentry_value_new_object();
 
-    const sentry_options_t *options = sentry_get_options();
-    if (options && !options->dsn.empty) {
-        sentry__envelope_set_header(rv, "dsn",
-            sentry_value_new_string(sentry_options_get_dsn(options)));
+    SENTRY_WITH_OPTIONS (options) {
+        if (options->dsn && options->dsn->is_valid) {
+            sentry__envelope_set_header(rv, "dsn",
+                sentry_value_new_string(sentry_options_get_dsn(options)));
+        }
     }
 
     return rv;

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -232,6 +232,9 @@ sentry_envelope_item_t *
 sentry__envelope_add_session(
     sentry_envelope_t *envelope, const sentry_session_t *session)
 {
+    if (!envelope || !session) {
+        return NULL;
+    }
     sentry_jsonwriter_t *jw = sentry__jsonwriter_new_in_memory();
     if (!jw) {
         return NULL;
@@ -259,6 +262,9 @@ sentry_envelope_item_t *
 sentry__envelope_add_from_path(
     sentry_envelope_t *envelope, const sentry_path_t *path, const char *type)
 {
+    if (!envelope) {
+        return NULL;
+    }
     size_t buf_len;
     char *buf = sentry__path_read_to_buffer(path, &buf_len);
     if (!buf) {

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -51,10 +51,9 @@ sentry_options_new(void)
 sentry_options_t *
 sentry__options_incref(sentry_options_t *options)
 {
-    if (!options) {
-        return NULL;
+    if (options) {
+        sentry__atomic_fetch_and_add(&options->refcount, 1);
     }
-    sentry__atomic_fetch_and_add(&options->refcount, 1);
     return options;
 }
 

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -59,8 +59,7 @@ sentry_options_free(sentry_options_t *opts)
     if (!opts) {
         return;
     }
-    sentry_free(opts->raw_dsn);
-    sentry__dsn_cleanup(&opts->dsn);
+    sentry__dsn_decref(opts->dsn);
     sentry_free(opts->release);
     sentry_free(opts->environment);
     sentry_free(opts->dist);
@@ -100,20 +99,16 @@ sentry_options_set_before_send(
 }
 
 void
-sentry_options_set_dsn(sentry_options_t *opts, const char *dsn)
+sentry_options_set_dsn(sentry_options_t *opts, const char *raw_dsn)
 {
-    sentry__dsn_cleanup(&opts->dsn);
-    /* XXX: log warning here or propagate parsing error */
-    sentry_free(opts->raw_dsn);
-    sentry__dsn_parse(&opts->dsn, dsn);
-    /* TODO: canonicalize DSN */
-    opts->raw_dsn = sentry__string_clone(dsn);
+    sentry__dsn_decref(opts->dsn);
+    opts->dsn = sentry__dsn_new(raw_dsn);
 }
 
 const char *
 sentry_options_get_dsn(const sentry_options_t *opts)
 {
-    return opts->raw_dsn;
+    return opts->dsn ? opts->dsn->raw : NULL;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -29,9 +29,8 @@ struct sentry_attachment_s {
  * the sentry internals.
  */
 typedef struct sentry_options_s {
-    char *raw_dsn;
-    sentry_dsn_t dsn;
     double sample_rate;
+    sentry_dsn_t *dsn;
     char *release;
     char *environment;
     char *dist;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -55,7 +55,14 @@ typedef struct sentry_options_s {
     /* everything from here on down are options which are stored here but
        not exposed through the options API */
     struct sentry_backend_s *backend;
-    sentry_user_consent_t user_consent;
+
+    long user_consent;
+    long refcount;
 } sentry_options_t;
+
+/**
+ * Increments the reference count and returns the options.
+ */
+sentry_options_t *sentry__options_incref(sentry_options_t *options);
 
 #endif

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -98,17 +98,15 @@ sentry__scope_unlock(void)
 void
 sentry__scope_flush(const sentry_scope_t *scope)
 {
-    const sentry_options_t *options = sentry_get_options();
-    if (!options) {
-        return;
-    }
-    if (options->backend && options->backend->flush_scope_func) {
-        options->backend->flush_scope_func(options->backend, scope);
-    }
-    if (scope->session) {
-        sentry__run_write_session(options->run, scope->session);
-    } else {
-        sentry__run_clear_session(options->run);
+    SENTRY_WITH_OPTIONS (options) {
+        if (options->backend && options->backend->flush_scope_func) {
+            options->backend->flush_scope_func(options->backend, scope);
+        }
+        if (scope->session) {
+            sentry__run_write_session(options->run, scope->session);
+        } else {
+            sentry__run_clear_session(options->run);
+        }
     }
 }
 
@@ -235,8 +233,7 @@ sentry__scope_apply_to_event(
 
     PLACE_STRING("platform", "native");
 
-    const sentry_options_t *options = sentry_get_options();
-    if (options) {
+    SENTRY_WITH_OPTIONS (options) {
         PLACE_STRING("release", options->release);
         PLACE_STRING("dist", options->dist);
         PLACE_STRING("environment", options->environment);

--- a/src/sentry_session.c
+++ b/src/sentry_session.c
@@ -47,23 +47,25 @@ status_from_string(const char *status)
 sentry_session_t *
 sentry__session_new(void)
 {
-    const sentry_options_t *opts = sentry_get_options();
-    if (!opts) {
-        return NULL;
+    char *release = NULL;
+    char *environment = NULL;
+    SENTRY_WITH_OPTIONS (options) {
+        release = sentry__string_clone(sentry_options_get_release(options));
+        environment
+            = sentry__string_clone(sentry_options_get_environment(options));
     }
-    char *release = sentry__string_clone(sentry_options_get_release(opts));
+
     if (!release) {
+        sentry_free(environment);
         return NULL;
     }
 
     sentry_session_t *rv = SENTRY_MAKE(sentry_session_t);
     if (!rv) {
         sentry_free(release);
+        sentry_free(environment);
         return NULL;
     }
-
-    char *environment
-        = sentry__string_clone(sentry_options_get_environment(opts));
 
     rv->release = release;
     rv->environment = environment;

--- a/src/sentry_session.c
+++ b/src/sentry_session.c
@@ -2,6 +2,7 @@
 #include "sentry_alloc.h"
 #include "sentry_envelope.h"
 #include "sentry_json.h"
+#include "sentry_options.h"
 #include "sentry_scope.h"
 #include "sentry_string.h"
 #include "sentry_utils.h"
@@ -218,17 +219,6 @@ sentry_start_session(void)
 }
 
 void
-sentry__end_current_session_with_status(sentry_session_status_t status)
-{
-    SENTRY_WITH_SCOPE_MUT (scope) {
-        if (scope->session) {
-            scope->session->status = status;
-        }
-    }
-    sentry_end_session();
-}
-
-void
 sentry__record_errors_on_current_session(uint32_t error_count)
 {
     SENTRY_WITH_SCOPE_MUT (scope) {
@@ -238,25 +228,45 @@ sentry__record_errors_on_current_session(uint32_t error_count)
     }
 }
 
+static sentry_session_t *
+sentry__end_session_internal(void)
+{
+    sentry_session_t *session = NULL;
+    SENTRY_WITH_SCOPE_MUT (scope) {
+        session = scope->session;
+        scope->session = NULL;
+    }
+
+    if (session && session->status == SENTRY_SESSION_STATUS_OK) {
+        session->status = SENTRY_SESSION_STATUS_EXITED;
+    }
+    return session;
+}
+
+sentry_session_t *
+sentry__end_current_session_with_status(sentry_session_status_t status)
+{
+    sentry_session_t *session = sentry__end_session_internal();
+    if (session) {
+        session->status = status;
+    }
+    return session;
+}
+
 void
 sentry_end_session(void)
 {
-    sentry_envelope_t *envelope = NULL;
-
-    SENTRY_WITH_SCOPE_MUT (scope) {
-        if (scope->session) {
-            if (scope->session->status == SENTRY_SESSION_STATUS_OK) {
-                scope->session->status = SENTRY_SESSION_STATUS_EXITED;
-            }
-            envelope = sentry__envelope_new();
-            sentry__envelope_add_session(envelope, scope->session);
-            sentry__session_free(scope->session);
-            scope->session = NULL;
-        }
+    sentry_session_t *session = sentry__end_session_internal();
+    if (!session) {
+        return;
     }
 
-    if (envelope) {
-        sentry__capture_envelope(envelope);
+    sentry_envelope_t *envelope = sentry__envelope_new();
+    sentry__envelope_add_session(envelope, session);
+    sentry__session_free(session);
+
+    SENTRY_WITH_OPTIONS (options) {
+        sentry__capture_envelope(options->transport, envelope);
     }
 }
 

--- a/src/sentry_session.h
+++ b/src/sentry_session.h
@@ -62,7 +62,8 @@ sentry_session_t *sentry__session_from_path(const sentry_path_t *path);
 /**
  * This will end the current session with an explicit `status` code.
  */
-void sentry__end_current_session_with_status(sentry_session_status_t status);
+sentry_session_t *sentry__end_current_session_with_status(
+    sentry_session_status_t status);
 
 /**
  * This will add `error_count` new errors to the current session.

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -264,7 +264,21 @@ sentry__atomic_fetch_and_add(volatile long *val, long diff)
     return InterlockedExchangeAdd((LONG *)val, diff);
 #    endif
 #else
-    return __sync_fetch_and_add(val, diff);
+    return __atomic_fetch_add(val, diff, __ATOMIC_SEQ_CST);
+#endif
+}
+
+static inline long
+sentry__atomic_store(volatile long *val, long value)
+{
+#ifdef SENTRY_PLATFORM_WINDOWS
+#    if SIZEOF_LONG == 8
+    return InterlockedExchange64((LONG64 *)val, value);
+#    else
+    return InterlockedExchange((LONG *)val, value);
+#    endif
+#else
+    return __atomic_exchange_n(val, value, __ATOMIC_SEQ_CST);
 #endif
 }
 

--- a/src/sentry_transport.c
+++ b/src/sentry_transport.c
@@ -61,6 +61,13 @@ void
 sentry__transport_send_envelope(
     sentry_transport_t *transport, sentry_envelope_t *envelope)
 {
+    if (!envelope) {
+        return;
+    }
+    if (!transport) {
+        SENTRY_TRACE("discarding envelope due to invalid transport");
+        sentry_envelope_free(envelope);
+    }
     SENTRY_TRACE("sending envelope");
     transport->send_envelope_func(envelope, transport->state);
 }

--- a/src/sentry_transport.c
+++ b/src/sentry_transport.c
@@ -67,6 +67,7 @@ sentry__transport_send_envelope(
     if (!transport) {
         SENTRY_TRACE("discarding envelope due to invalid transport");
         sentry_envelope_free(envelope);
+        return;
     }
     SENTRY_TRACE("sending envelope");
     transport->send_envelope_func(envelope, transport->state);

--- a/src/sentry_transport.h
+++ b/src/sentry_transport.h
@@ -3,6 +3,7 @@
 
 #include "sentry_boot.h"
 
+typedef struct sentry_dsn_s sentry_dsn_t;
 typedef struct sentry_run_s sentry_run_t;
 typedef struct sentry_rate_limiter_s sentry_rate_limiter_t;
 
@@ -73,7 +74,8 @@ typedef struct sentry_prepared_http_request_s {
  * rate limited.
  */
 sentry_prepared_http_request_t *sentry__prepare_http_request(
-    sentry_envelope_t *envelope, const sentry_rate_limiter_t *rl);
+    sentry_envelope_t *envelope, const sentry_dsn_t *dsn,
+    const sentry_rate_limiter_t *rl);
 
 /**
  * Free a previously allocated HTTP request.

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -39,28 +39,36 @@ void sentry__url_cleanup(sentry_url_t *url);
 /**
  * This is the internal representation of a parsed DSN.
  */
-typedef struct {
-    bool is_secure;
+typedef struct sentry_dsn_s {
+    char *raw;
     char *host;
-    int port;
+    char *path;
     char *secret_key;
     char *public_key;
     uint64_t project_id;
-    char *path;
-    bool empty;
+    int port;
+    long refcount;
+    bool is_valid;
+    bool is_secure;
 } sentry_dsn_t;
 
 /**
- * This will parse the DSN URL given in `dsn` into the pre-allocated `dsn_out`.
- * Returns 0 on success.
+ * This will parse the DSN URL given in `dsn`.
+ *
+ * The returned `sentry_dsn_t` will have have its `is_valid` flag set when the
+ * DSN has been successfully parsed.
  */
-int sentry__dsn_parse(sentry_dsn_t *dsn_out, const char *dsn);
+sentry_dsn_t *sentry__dsn_new(const char *dsn);
 
 /**
- * This will free all the internal members of `dsn`, but not `dsn` itself, as
- * that might have been stack allocated.
+ * Increases the reference-count of the DSN.
  */
-void sentry__dsn_cleanup(sentry_dsn_t *dsn);
+sentry_dsn_t *sentry__dsn_incref(sentry_dsn_t *dsn);
+
+/**
+ * Decrements the reference-count of the DSN.
+ */
+void sentry__dsn_decref(sentry_dsn_t *dsn);
 
 /**
  * This will create a new string, with the contents of the `X-Sentry-Auth`, as

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -90,7 +90,9 @@ def assert_minidump(envelope):
         "type": "attachment",
         "attachment_type": "event.minidump",
     }
-    assert any(matches(item.headers, expected) for item in envelope)
+    minidump = next(item for item in envelope if matches(item.headers, expected))
+    assert minidump.headers["length"] > 4
+    assert minidump.payload.bytes.startswith(b"MDMP")
 
 
 def assert_timestamp(ts, now=datetime.datetime.utcnow()):

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -32,20 +32,18 @@ def test_crashpad_crash(cmake, httpserver):
 
     httpserver.expect_request("/api/123456/minidump/").respond_with_data("OK")
     httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
     child = run(
         tmp_path,
         "sentry_example",
         ["log", "start-session", "attachment", "overflow-breadcrumbs", "crash"],
+        env=env,
     )
     assert child.returncode  # well, its a crash after all
 
     run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-setup"],
-        check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
     )
 
     time.sleep(2)  # lets wait a bit for crashpad sending in the background

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -33,19 +33,17 @@ def test_capture_http(cmake, httpserver):
     httpserver.expect_oneshot_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver), SENTRY_RELEASE="🤮🚀")
 
-    with httpserver.wait(raise_assertions=True, stop_on_nohandler=True) as waiting:
-        env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver), SENTRY_RELEASE="🤮🚀")
-        run(
-            tmp_path,
-            "sentry_example",
-            ["log", "release-env", "capture-event", "add-stacktrace"],
-            check=True,
-            env=env,
-        )
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "release-env", "capture-event", "add-stacktrace"],
+        check=True,
+        env=env,
+    )
 
-    assert waiting.result
-
+    assert len(httpserver.log) == 1
     output = httpserver.log[0][0].get_data()
     envelope = Envelope.deserialize(output)
 
@@ -62,6 +60,7 @@ def test_session_http(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
     # start once without a release, but with a session
     run(
@@ -69,14 +68,10 @@ def test_session_http(cmake, httpserver):
         "sentry_example",
         ["log", "release-env", "start-session"],
         check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        env=env,
     )
     run(
-        tmp_path,
-        "sentry_example",
-        ["log", "start-session"],
-        check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        tmp_path, "sentry_example", ["log", "start-session"], check=True, env=env,
     )
 
     assert len(httpserver.log) == 1
@@ -92,13 +87,14 @@ def test_capture_and_session_http(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
     run(
         tmp_path,
         "sentry_example",
         ["log", "start-session", "capture-event"],
         check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        env=env,
     )
 
     assert len(httpserver.log) == 2
@@ -119,13 +115,14 @@ def test_exception_and_session_http(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
     run(
         tmp_path,
         "sentry_example",
         ["log", "start-session", "capture-exception"],
         check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        env=env,
     )
 
     assert len(httpserver.log) == 2
@@ -147,6 +144,7 @@ def test_abnormal_session(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
     # create a bogus session file
     session = json.dumps(
@@ -170,11 +168,7 @@ def test_abnormal_session(cmake, httpserver):
             session_file.write(session)
 
     run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-setup"],
-        check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
     )
 
     assert len(httpserver.log) == 2
@@ -194,21 +188,21 @@ def test_abnormal_session(cmake, httpserver):
 def test_inproc_crash_http(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "inproc"})
 
-    child = run(
-        tmp_path, "sentry_example", ["log", "start-session", "attachment", "crash"]
-    )
-    assert child.returncode  # well, its a crash after all
-
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
-    run(
+    child = run(
         tmp_path,
         "sentry_example",
-        ["log", "no-setup"],
-        check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        ["log", "start-session", "attachment", "crash"],
+        env=env,
+    )
+    assert child.returncode  # well, its a crash after all
+
+    run(
+        tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
     )
 
     assert len(httpserver.log) == 2
@@ -235,8 +229,8 @@ def test_inproc_dump_inflight(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
-
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
     child = run(
         tmp_path, "sentry_example", ["log", "capture-multiple", "crash"], env=env
     )
@@ -252,21 +246,21 @@ def test_inproc_dump_inflight(cmake, httpserver):
 def test_breakpad_crash_http(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "breakpad"})
 
-    child = run(
-        tmp_path, "sentry_example", ["log", "start-session", "attachment", "crash"]
-    )
-    assert child.returncode  # well, its a crash after all
-
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
-    run(
+    child = run(
         tmp_path,
         "sentry_example",
-        ["log", "no-setup"],
-        check=True,
-        env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        ["log", "start-session", "attachment", "crash"],
+        env=env,
+    )
+    assert child.returncode  # well, its a crash after all
+
+    run(
+        tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
     )
 
     assert len(httpserver.log) == 2
@@ -294,8 +288,8 @@ def test_breakpad_dump_inflight(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
-
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
     child = run(
         tmp_path, "sentry_example", ["log", "capture-multiple", "crash"], env=env
     )
@@ -317,8 +311,8 @@ def test_shutdown_timeout(cmake, httpserver):
     httpserver.expect_request(
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_handler(delayed)
-
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
     # Using `sleep-after-shutdown` here means that the background worker will
     # deref/free itself, so we will not leak in that case!
     child = run(

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -261,7 +261,7 @@ def test_breakpad_crash_http(cmake, httpserver):
     assert len(httpserver.log) == 1
     envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
 
-    assert_session(envelope, {"init": True, "status": "crashed", "errors": 0})
+    assert_session(envelope, {"init": True, "status": "crashed", "errors": 1})
 
     assert_meta(envelope)
     assert_breadcrumb(envelope)

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -205,16 +205,11 @@ def test_inproc_crash_http(cmake, httpserver):
         tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
     )
 
-    assert len(httpserver.log) == 2
-    outputs = (httpserver.log[0][0].get_data(), httpserver.log[1][0].get_data())
-    session, event = (
-        outputs if b'"type":"session"' in outputs[0] else (outputs[1], outputs[0])
-    )
+    assert len(httpserver.log) == 1
+    envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
 
-    envelope = Envelope.deserialize(session)
-    assert_session(envelope, {"init": True, "status": "crashed", "errors": 0})
+    assert_session(envelope, {"init": True, "status": "crashed", "errors": 1})
 
-    envelope = Envelope.deserialize(event)
     assert_meta(envelope)
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
@@ -263,16 +258,10 @@ def test_breakpad_crash_http(cmake, httpserver):
         tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
     )
 
-    assert len(httpserver.log) == 2
-    outputs = (httpserver.log[0][0].get_data(), httpserver.log[1][0].get_data())
-    session, event = (
-        outputs if b'"type":"session"' in outputs[0] else (outputs[1], outputs[0])
-    )
+    assert len(httpserver.log) == 1
+    envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
 
-    envelope = Envelope.deserialize(session)
     assert_session(envelope, {"init": True, "status": "crashed", "errors": 0})
-
-    envelope = Envelope.deserialize(event)
 
     assert_meta(envelope)
     assert_breadcrumb(envelope)

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -56,7 +56,7 @@ SENTRY_TEST(lazy_attachments)
     TEST_CHECK(strstr(serialized,
                    "{\"type\":\"attachment\",\"length\":3,"
                    "\"filename\":\".existing-file-attachment\"}\n"
-                   "foo\n")
+                   "foo")
         != NULL);
     TEST_CHECK(
         strstr(serialized, "\"filename\":\".non-existing-file-attachment\"")
@@ -73,12 +73,12 @@ SENTRY_TEST(lazy_attachments)
     TEST_CHECK(strstr(serialized,
                    "{\"type\":\"attachment\",\"length\":6,"
                    "\"filename\":\".existing-file-attachment\"}\n"
-                   "foobar\n")
+                   "foobar")
         != NULL);
     TEST_CHECK(strstr(serialized,
                    "{\"type\":\"attachment\",\"length\":9,"
                    "\"filename\":\".non-existing-file-attachment\"}\n"
-                   "it exists\n")
+                   "it exists")
         != NULL);
     sentry_free(serialized);
 

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -42,4 +42,9 @@ SENTRY_TEST(custom_logger)
     sentry_shutdown();
 
     TEST_CHECK_INT_EQUAL(data.called, 1);
+
+    // *really* clear the logger instance
+    options = sentry_options_new();
+    sentry_init(options);
+    sentry_shutdown();
 }


### PR DESCRIPTION
Wraps all accesses of the global objects object in a lock. This also changes the DSN to be a heap allocated and refcounted type, since the http workers need to separately own a reference.

fixes #280