### PR TITLE
fix: Flush session and send queue in crashpad backend

### DIFF
--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -180,15 +180,11 @@ sentry__backend_new(void)
     if (!backend) {
         return NULL;
     }
+    memset(backend, 0, sizeof(sentry_backend_t));
 
     backend->startup_func = sentry__breakpad_backend_startup;
     backend->shutdown_func = sentry__breakpad_backend_shutdown;
     backend->except_func = sentry__breakpad_backend_except;
-    backend->free_func = NULL;
-    backend->flush_scope_func = NULL;
-    backend->add_breadcrumb_func = NULL;
-    backend->user_consent_changed_func = NULL;
-    backend->data = NULL;
 
     return backend;
 }

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -105,7 +105,7 @@ sentry__crashpad_handler(int UNUSED(signum), siginfo_t *UNUSED(info),
     sentry__page_allocator_enable();
     sentry__enter_signal_handler();
 #    endif
-    SENTRY_DEBUG("flushing session and state before crashpad handler");
+    SENTRY_DEBUG("flushing session and queue before crashpad handler");
 
     SENTRY_WITH_OPTIONS (options) {
         sentry__write_crash_marker(options);
@@ -122,9 +122,11 @@ sentry__crashpad_handler(int UNUSED(signum), siginfo_t *UNUSED(info),
         sentry__capture_envelope(disk_transport, envelope);
         sentry__transport_dump_queue(disk_transport, options->run);
         sentry_transport_free(disk_transport);
+
+        sentry__transport_dump_queue(options->transport, options->run);
     }
 
-    SENTRY_DEBUG("handling control over to crashpad");
+    SENTRY_DEBUG("handing control over to crashpad");
 #    ifndef SENTRY_PLATFORM_WINDOWS
     sentry__leave_signal_handler();
 #    endif

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -364,6 +364,8 @@ sentry__backend_new(void)
     if (!backend) {
         return NULL;
     }
+    memset(backend, 0, sizeof(sentry_backend_t));
+
     crashpad_state_t *data = SENTRY_MAKE(crashpad_state_t);
     if (!data) {
         sentry_free(backend);

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -338,15 +338,11 @@ sentry__backend_new(void)
     if (!backend) {
         return NULL;
     }
+    memset(backend, 0, sizeof(sentry_backend_t));
 
     backend->startup_func = startup_inproc_backend;
     backend->shutdown_func = shutdown_inproc_backend;
     backend->except_func = handle_except;
-    backend->free_func = NULL;
-    backend->flush_scope_func = NULL;
-    backend->add_breadcrumb_func = NULL;
-    backend->user_consent_changed_func = NULL;
-    backend->data = NULL;
 
     return backend;
 }

--- a/src/sentry_backend.h
+++ b/src/sentry_backend.h
@@ -24,6 +24,7 @@ typedef struct sentry_backend_s {
     void (*add_breadcrumb_func)(
         struct sentry_backend_s *, sentry_value_t breadcrumb);
     void (*user_consent_changed_func)(struct sentry_backend_s *);
+    uint64_t (*get_last_crash_func)(struct sentry_backend_s *);
     void *data;
 } sentry_backend_t;
 

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -136,7 +136,7 @@ sentry__run_clear_session(const sentry_run_t *run)
 }
 
 void
-sentry__process_old_runs(const sentry_options_t *options)
+sentry__process_old_runs(const sentry_options_t *options, uint64_t last_crash)
 {
     sentry_pathiter_t *db_iter
         = sentry__path_iter_directory(options->database_path);
@@ -173,14 +173,32 @@ sentry__process_old_runs(const sentry_options_t *options)
         const sentry_path_t *file;
         while ((file = sentry__pathiter_next(run_iter)) != NULL) {
             if (sentry__path_filename_matches(file, "session.json")) {
-                sentry_session_t *session = sentry__session_from_path(file);
-                if (session->status == SENTRY_SESSION_STATUS_OK) {
-                    session->status = SENTRY_SESSION_STATUS_ABNORMAL;
-                }
                 if (!session_envelope) {
                     session_envelope = sentry__envelope_new();
                 }
+                sentry_session_t *session = sentry__session_from_path(file);
+                // this is just a heuristic: whenever the session was not
+                // closed properly, and we do have a crash that happened
+                // *after* the session was started, we will assume that the
+                // crash corresponds to the session and flag it as crashed.
+                // this should only happen when using crashpad, and there
+                // should normally be only a single unclosed session at a
+                // time.
+                if (session->status == SENTRY_SESSION_STATUS_OK) {
+                    bool was_crash
+                        = last_crash && last_crash > session->started_ms;
+                    if (was_crash) {
+                        session->duration_ms = last_crash - session->started_ms;
+                        session->errors += 1;
+                        // we only set at most one unclosed session as crashed
+                        last_crash = 0;
+                    }
+                    session->status = was_crash
+                        ? SENTRY_SESSION_STATUS_CRASHED
+                        : SENTRY_SESSION_STATUS_ABNORMAL;
+                }
                 sentry__envelope_add_session(session_envelope, session);
+
                 sentry__session_free(session);
                 if ((++session_num) >= SENTRY_MAX_ENVELOPE_ITEMS) {
                     sentry__capture_envelope(

--- a/src/sentry_database.h
+++ b/src/sentry_database.h
@@ -62,8 +62,12 @@ bool sentry__run_clear_session(const sentry_run_t *run);
  * will be locked, and any files named  `<event-uuid>.envelope` or
  * `session.json` will be queued for sending to the  backend. The files and
  * directories matching these criteria will be deleted afterwards.
+ * The following heuristic is applied to all unclosed sessions: If the session
+ * was started before the timestamp given by `last_crash`, the session is closed
+ * as "crashed" with an appropriate duration.
  */
-void sentry__process_old_runs(const sentry_options_t *options);
+void sentry__process_old_runs(
+    const sentry_options_t *options, uint64_t last_crash);
 
 /**
  * This will write the current ISO8601 formatted timestamp into the

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,6 +64,9 @@ def run(cwd, exe, args, env=dict(os.environ), **kwargs):
     ]
     if "asan" in os.environ.get("RUN_ANALYZER", ""):
         env["ASAN_OPTIONS"] = "detect_leaks=1"
+        env["LSAN_OPTIONS"] = "suppressions={}".format(
+            os.path.join(sourcedir, "tests", "leaks.txt")
+        )
     if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
         # continuous mode is only supported on mac right now
         continuous = "%c" if sys.platform == "darwin" else ""

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -21,8 +21,8 @@ class CMake:
 
         if key not in self.runs:
             cwd = self.factory.mktemp("cmake")
-            cmake(cwd, targets, options)
             self.runs[key] = cwd
+            cmake(cwd, targets, options)
 
         return self.runs[key]
 

--- a/tests/leaks.txt
+++ b/tests/leaks.txt
@@ -1,0 +1,5 @@
+# Not really sure if this is a real leak or just ASAN not correctly handling the autorelease pool.
+# The leak is reported both from the `crashpad_handler` as well as sentry itself.
+# Adding a manual `[paths release]` "fixes" the `crashpad_handler` leak, but leads to a use-after-free in sentry.
+# https://github.com/getsentry/crashpad/blob/9cd1a4dadb51b31665f5e50c5ffc25bb9d10571a/client/crash_report_database_mac.mm#L705
+leak:contentsOfDirectoryAtPath

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -79,9 +79,9 @@ def test_crashpad_dump_inflight(cmake, httpserver):
     )
     assert child.returncode  # well, its a crash after all
 
-    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
-
     time.sleep(2)  # lets wait a bit for crashpad sending in the background
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
 
     # we trigger 10 normal events, and 1 crash
     assert len(httpserver.log) >= 11

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -48,9 +48,9 @@ def test_crashpad_crash(cmake, httpserver):
     )
     assert child.returncode  # well, its a crash after all
 
-    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
-
     time.sleep(2)  # lets wait a bit for crashpad sending in the background
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
 
     assert len(httpserver.log) == 2
     outputs = (httpserver.log[0][0].get_data(), httpserver.log[1][0].get_data())
@@ -59,13 +59,7 @@ def test_crashpad_crash(cmake, httpserver):
     )
 
     envelope = Envelope.deserialize(session)
-    assert_session(
-        envelope,
-        {
-            "status": "crashed" if flushes_state else "abnormal",
-            "errors": 1 if flushes_state else 0,
-        },
-    )
+    assert_session(envelope, {"status": "crashed", "errors": 1})
 
     # TODO: crashpad actually sends a compressed multipart request,
     # which we don’t parse / assert right now.

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -1,15 +1,22 @@
 import pytest
 import os
+import sys
 import time
 from . import make_dsn, run, Envelope
 from .conditions import has_crashpad
 from .assertions import assert_session
 
+if not has_crashpad:
+    pytest.skip("test needs crashpad backend", allow_module_level=True)
+
+
 # TODO:
 # Actually assert that we get a correct event/breadcrumbs payload
 
+# Windows and Linux are currently able to flush all the state on crash
+flushes_state = sys.platform != "darwin"
 
-@pytest.mark.skipif(not has_crashpad, reason="test needs crashpad backend")
+
 def test_crashpad_capture(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -26,7 +33,6 @@ def test_crashpad_capture(cmake, httpserver):
     assert len(httpserver.log) == 2
 
 
-@pytest.mark.skipif(not has_crashpad, reason="test needs crashpad backend")
 def test_crashpad_crash(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -42,9 +48,7 @@ def test_crashpad_crash(cmake, httpserver):
     )
     assert child.returncode  # well, its a crash after all
 
-    run(
-        tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env,
-    )
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
 
     time.sleep(2)  # lets wait a bit for crashpad sending in the background
 
@@ -55,8 +59,35 @@ def test_crashpad_crash(cmake, httpserver):
     )
 
     envelope = Envelope.deserialize(session)
-    assert_session(envelope, {"status": "abnormal", "errors": 0})
+    assert_session(
+        envelope,
+        {
+            "status": "crashed" if flushes_state else "abnormal",
+            "errors": 1 if flushes_state else 0,
+        },
+    )
 
     # TODO: crashpad actually sends a compressed multipart request,
     # which we don’t parse / assert right now.
     # Ideally, we would pull in a real relay to do all the http tests against.
+
+
+@pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
+def test_crashpad_dump_inflight(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    httpserver.expect_request("/api/123456/minidump/").respond_with_data("OK")
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    child = run(
+        tmp_path, "sentry_example", ["log", "capture-multiple", "crash"], env=env
+    )
+    assert child.returncode  # well, its a crash after all
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    time.sleep(2)  # lets wait a bit for crashpad sending in the background
+
+    # we trigger 10 normal events, and 1 crash
+    assert len(httpserver.log) >= 11


### PR DESCRIPTION
This uses crashpads `SetFirstChanceExceptionHandler` on Linux,
and an additional exception filter on Windows, and a heuristic on macOS.