### PR TITLE
meta: Make codecov less annoying

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch: false
+
+comment:
+  layout: "diff"
+  require_changes: true
+  after_n_builds: 3 # linux llvm-cov, linux kcov, mac llvm-cov


### PR DESCRIPTION
This changes to PR comment to only update after all reports are in, and only include a short diff.
Also changes the github status to be informational only (without gating commits), and disables the `patch` status.