### PR TITLE
meta: gitignore only root build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 CMakeSettings.json
 
 # CMake builds
-build
-build*
+/build
+/build*
 leak-build
 
 # Run files


### PR DESCRIPTION
ignore only root build folders as there are needed build folders in dependencies