### PR TITLE
docs: Better document the database-path requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Please see [Known Limitations](#known-limitations).
 - [Building and Installation](#building-and-installation)
   - [Compile-Time Options](#compile-time-options)
   - [Build Targets](#build-targets)
+- [Runtime Configuration](#runtime-configuration)
 - [Known Limitations](#known-limitations)
 - [Development](#development)
 
@@ -236,6 +237,26 @@ Legend:
 - `sentry_example`: This is a small example program highlighting the API, which
   can be controlled via command-line parameters, and is also used for
   integration tests.
+
+## Runtime Configuration
+
+The minimum working example looks like this:
+
+```c
+sentry_options_t *options = sentry_options_new();
+sentry_options_set_dsn(options, "https://YOUR_KEY@oORG_ID.ingest.sentry.io/PROJECT_ID");
+sentry_init(options);
+
+// your application code …
+
+sentry_shutdown();
+```
+
+Other important configuration options include:
+
+- `sentry_options_set_database_path`: Sentry needs to persist some cache data across application restarts, especially for proper handling of release health sessions. It is recommended to set an explicit absolute path corresponding to the applications cache directory (equivalent to `AppData/Local` on Windows, and `XDG_CACHE_HOME` on Linux). When not set explicitly, sentry will create and use the `.sentry-native` directory inside of the current working directory.
+- `sentry_options_set_handler_path`: When using the crashpad backend, sentry will look for a `crashpad_handler` executable in the same directory as the running executable. It is recommended to set this as an explicit absolute path based on the applications install location.
+- `sentry_options_set_release`: Some features in sentry, including release health need to have a release version set. This corresponds to the applications version and needs to be set explicitly. See [Releases](https://docs.sentry.io/product/releases/) for more information.
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Legend:
 
 ## Runtime Configuration
 
-The minimum working example looks like this:
+A minimal working example looks like this. For a more elaborate example see the [example.c](examples/example.c) file which is also used to run sentries integration tests.
 
 ```c
 sentry_options_t *options = sentry_options_new();
@@ -254,9 +254,10 @@ sentry_shutdown();
 
 Other important configuration options include:
 
-- `sentry_options_set_database_path`: Sentry needs to persist some cache data across application restarts, especially for proper handling of release health sessions. It is recommended to set an explicit absolute path corresponding to the applications cache directory (equivalent to `AppData/Local` on Windows, and `XDG_CACHE_HOME` on Linux). When not set explicitly, sentry will create and use the `.sentry-native` directory inside of the current working directory.
+- `sentry_options_set_database_path`: Sentry needs to persist some cache data across application restarts, especially for proper handling of release health sessions. It is recommended to set an explicit absolute path corresponding to the applications cache directory (equivalent to `AppData/Local` on Windows, and `XDG_CACHE_HOME` on Linux). Sentry should be given its own directory which is not shared with other application data, as the SDK will enumerate and possibly delete files in that directory. An example might be `$XDG_CACHE_HOME/your-app/sentry`.
+  When not set explicitly, sentry will create and use the `.sentry-native` directory inside of the current working directory.
 - `sentry_options_set_handler_path`: When using the crashpad backend, sentry will look for a `crashpad_handler` executable in the same directory as the running executable. It is recommended to set this as an explicit absolute path based on the applications install location.
-- `sentry_options_set_release`: Some features in sentry, including release health need to have a release version set. This corresponds to the applications version and needs to be set explicitly. See [Releases](https://docs.sentry.io/product/releases/) for more information.
+- `sentry_options_set_release`: Some features in sentry, including release health, need to have a release version set. This corresponds to the application’s version and needs to be set explicitly. See [Releases](https://docs.sentry.io/product/releases/) for more information.
 
 ## Known Limitations
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -47,6 +47,8 @@ main(int argc, char **argv)
 {
     sentry_options_t *options = sentry_options_new();
 
+    // this is an example. for real usage, make sure to set this explicitly to
+    // an app specific cache location.
     sentry_options_set_database_path(options, ".sentry-native");
 
     sentry_options_set_auto_session_tracking(options, false);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -837,12 +837,20 @@ SENTRY_API void sentry_options_set_handler_path(
  * artifacts in case of a crash. This will also be used by the crashpad backend
  * if it is configured.
  *
- * The path defaults to `.sentry-native` in the current working directory, will
- * be created if it does not exist, and will be resolved to an absolute path
- * inside of `sentry_init`.
+ * The directory is used for "cached" data, which needs to persist accross
+ * application restarts to ensure proper flagging of release-health sessions,
+ * but might otherwise be safely purged regularly.
  *
- * It is recommended that library users set an explicit absolute path, depending
- * on their apps runtime directory.
+ * It is roughly equivalent to the type of `AppData/Local` on Windows and
+ * `XDG_CACHE_HOME` on Linux, and equivalent runtime directories on other
+ * platforms.
+ *
+ * It is recommended that users set an explicit absolute path, depending
+ * on their apps runtime directory. The path will be created if it does not
+ * exist, and will be resolved to an absolute path inside of `sentry_init`.
+ *
+ * If no explicit path it set, sentry-native will default to `.sentry-native` in
+ * the current working directory, with no specific platform-specific handling.
  *
  * `path` is assumed to be in platform-specific filesystem path encoding.
  * API Users on windows are encouraged to use


### PR DESCRIPTION
I think `XDG_CACHE_HOME` fits the usecase the best, as this is *non-essential* data and can be removed at any time without any real negative effects (apart from missing abnormal/crashed sessions). Not sure about user consent though.

closes #355 CC @sseyod how do you like the explanation?