### PR TITLE
fix: Parse rate limits with multiple categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**
+
+- Fix parsing rate limit headers with multiple categories.
+
 ## 0.4.0
 
 **Breaking Changes**:

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -837,7 +837,7 @@ SENTRY_API void sentry_options_set_handler_path(
  * artifacts in case of a crash. This will also be used by the crashpad backend
  * if it is configured.
  *
- * The directory is used for "cached" data, which needs to persist accross
+ * The directory is used for "cached" data, which needs to persist across
  * application restarts to ensure proper flagging of release-health sessions,
  * but might otherwise be safely purged regularly.
  *
@@ -847,7 +847,10 @@ SENTRY_API void sentry_options_set_handler_path(
  *
  * It is recommended that users set an explicit absolute path, depending
  * on their apps runtime directory. The path will be created if it does not
- * exist, and will be resolved to an absolute path inside of `sentry_init`.
+ * exist, and will be resolved to an absolute path inside of `sentry_init`. The
+ * directory should not be shared with other application data/configuration, as
+ * sentry-native will enumerate and possibly delete files in that directory. An
+ * example might be `$XDG_CACHE_HOME/your-app/sentry`
  *
  * If no explicit path it set, sentry-native will default to `.sentry-native` in
  * the current working directory, with no specific platform-specific handling.

--- a/src/sentry_ratelimiter.c
+++ b/src/sentry_ratelimiter.c
@@ -56,6 +56,7 @@ sentry__rate_limiter_update_from_header(
             }
 
             categories = sentry__slice_advance(categories, category.len);
+            sentry__slice_consume_if(&categories, ';');
         }
 
         size_t next = sentry__slice_find(slice, ',');

--- a/tests/unit/test_ratelimiter.c
+++ b/tests/unit/test_ratelimiter.c
@@ -7,8 +7,10 @@ SENTRY_TEST(rate_limit_parsing)
 {
     uint64_t now = sentry__monotonic_time();
     sentry_rate_limiter_t *rl = sentry__rate_limiter_new();
-    TEST_CHECK(sentry__rate_limiter_update_from_header(
-        rl, "120:error:project, 60:session:foo, 30::bar, 120:invalid:invalid"));
+    TEST_CHECK(sentry__rate_limiter_update_from_header(rl,
+        "120:error:project, 60:session:foo, 30::bar, "
+        "120:invalid:invalid, "
+        "4711:foo;bar;baz;security:project"));
 
     TEST_CHECK(
         sentry__rate_limiter_get_disabled_until(rl, SENTRY_RL_CATEGORY_ERROR)


### PR DESCRIPTION
fixes #361 

looks like another change slipped through that I forgot to commit in https://github.com/getsentry/sentry-native/commit/2fed9755d351334ea366e3390dacbd9ff7666df9