### PR TITLE
fix: Add a linker script to enforce exported symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Breaking changes**:
+
+- When built as a shared library for Android or Linux, the Native SDK limits the export of symbols to the `sentry_`-prefix. The option `SENTRY_EXPORT_SYMBOLS` is no longer available and the linker settings are constrained to the Native SDK and no longer `PUBLIC` to parent projects. ([#363](https://github.com/getsentry/sentry-native/pull/363))
+
 **Features**:
 
 - A session may be ended with a different status code. ([#801](https://github.com/getsentry/sentry-native/pull/801))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,11 +338,19 @@ target_include_directories(sentry
 # as `PUBLIC`, so libraries that depend on sentry get these too:
 # `-E`: To have all symbols in the dynamic symbol table.
 # `--build-id`: To have a build-id in the ELF object.
+# `--version-script`: The given script makes sure only `sentry_*` symbols are exported
 # FIXME: cmake 3.13 introduced target_link_options
+target_link_libraries(sentry PUBLIC
+	"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,--build-id=sha1,--version-script=${PROJECT_SOURCE_DIR}/src/exports.map>")
+
 option(SENTRY_EXPORT_SYMBOLS "Export symbols for modulefinder and symbolizer" ON)
 if(SENTRY_EXPORT_SYMBOLS)
 	target_link_libraries(sentry PUBLIC
-		"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E,--build-id=sha1>")
+		"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E>")
+else()
+	set(CMAKE_C_VISIBILITY_PRESET hidden)
+	set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+	set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 endif()
 
 #respect CMAKE_SYSTEM_VERSION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,24 +334,6 @@ target_include_directories(sentry
 		"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
 )
 
-# The modulefinder and symbolizer need these two settings, and they are exported
-# as `PUBLIC`, so libraries that depend on sentry get these too:
-# `-E`: To have all symbols in the dynamic symbol table.
-# `--build-id`: To have a build-id in the ELF object.
-# `--version-script`: The given script makes sure only `sentry_*` symbols are exported
-# FIXME: cmake 3.13 introduced target_link_options
-target_link_libraries(sentry PUBLIC
-	"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,--build-id=sha1,--version-script=${PROJECT_SOURCE_DIR}/src/exports.map>")
-
-option(SENTRY_EXPORT_SYMBOLS "Export symbols for modulefinder and symbolizer" ON)
-if(SENTRY_EXPORT_SYMBOLS)
-	target_link_libraries(sentry PUBLIC
-		"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E>")
-else()
-	set(CMAKE_C_VISIBILITY_PRESET hidden)
-	set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-	set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-endif()
 
 #respect CMAKE_SYSTEM_VERSION
 if(WIN32)
@@ -608,4 +590,30 @@ if(SENTRY_BUILD_EXAMPLES)
 	endif()
 
 	add_test(NAME sentry_example COMMAND sentry_example)
+endif()
+
+# Make sure that we do not expose more symbols than from our API. This must be a PRIVATE setting or otherwise projects
+# using the Native SDK as a sub-project will inherit these settings, which, for something as invasive as the definition
+# of the symbol-surface is almost never a good idea. Previously this was set to PUBLIC, which led to the introduction of
+# switches to turn it off. By making it private it is also no longer necessary to turn this off for projects using
+# libsentry as a static library, which shouldn't have any issues with exported symbols, but projects had issues because
+# they inherited our public settings when linking their executables with out static lib.
+#
+# We are doing this at the end of the build-script since some sub-directories are inheriting link-libraries from the
+# sentry target, with those they will inherit the export map too, which doesn't make sense for an executable like a
+# unit-test that tries to find all symbols in its reproducibly, some of which are not in the sentry_ namespace.
+#
+# Used linker parameters:
+# `--build-id`: To have a build-id in the ELF object.
+# `--version-script`: The given script makes sure only `sentry_*` symbols are exported
+# FIXME: cmake 3.13 introduced target_link_options (blocked by Android)
+
+option(SENTRY_EXPORT_SYMBOLS "Export symbols for modulefinder and symbolizer" ON)
+if(SENTRY_EXPORT_SYMBOLS AND NOT SENTRY_BUILD_SHARED_LIBS)
+	# FIXME: why was this introduced in the first place? is this client project convenience?
+	target_link_libraries(sentry PUBLIC
+			"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E,--build-id=sha1>")
+else()
+	target_link_libraries(sentry PRIVATE
+			"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,--build-id=sha1,--version-script=${PROJECT_SOURCE_DIR}/src/exports.map>")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,28 +592,15 @@ if(SENTRY_BUILD_EXAMPLES)
 	add_test(NAME sentry_example COMMAND sentry_example)
 endif()
 
-# Make sure that we do not expose more symbols than from our API. This must be a PRIVATE setting or otherwise projects
-# using the Native SDK as a sub-project will inherit these settings, which, for something as invasive as the definition
-# of the symbol-surface is almost never a good idea. Previously this was set to PUBLIC, which led to the introduction of
-# switches to turn it off. By making it private it is also no longer necessary to turn this off for projects using
-# libsentry as a static library, which shouldn't have any issues with exported symbols, but projects had issues because
-# they inherited our public settings when linking their executables with out static lib.
-#
-# We are doing this at the end of the build-script since some sub-directories are inheriting link-libraries from the
-# sentry target, with those they will inherit the export map too, which doesn't make sense for an executable like a
-# unit-test that tries to find all symbols in its reproducibly, some of which are not in the sentry_ namespace.
+# Limit the exported symbols when sentry is built as a shared library to those with a "sentry_" prefix:
+# - we do this at the end of the file as to not affect subdirectories reading target_link_libraries from the parent.
+# - we do this as PRIVATE since our version script does not make sense in any other project that adds us.
 #
 # Used linker parameters:
 # `--build-id`: To have a build-id in the ELF object.
-# `--version-script`: The given script makes sure only `sentry_*` symbols are exported
+# `--version-script`: version script either hides "foreign" symbols or defers them as unknown ("U") to system libraries.
 # FIXME: cmake 3.13 introduced target_link_options (blocked by Android)
-
-option(SENTRY_EXPORT_SYMBOLS "Export symbols for modulefinder and symbolizer" ON)
-if(SENTRY_EXPORT_SYMBOLS AND NOT SENTRY_BUILD_SHARED_LIBS)
-	# FIXME: why was this introduced in the first place? is this client project convenience?
-	target_link_libraries(sentry PUBLIC
-			"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E,--build-id=sha1>")
-else()
+if(SENTRY_BUILD_SHARED_LIBS)
 	target_link_libraries(sentry PRIVATE
 			"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,--build-id=sha1,--version-script=${PROJECT_SOURCE_DIR}/src/exports.map>")
 endif()

--- a/src/exports.map
+++ b/src/exports.map
@@ -1,0 +1,4 @@
+{
+   global: sentry_*;
+   local: *;
+};

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(sentry_test_unit PRIVATE
 	${SENTRY_LINK_LIBRARIES}
 	${SENTRY_INTERFACE_LINK_LIBRARIES}
 	"$<$<PLATFORM_ID:Linux>:rt>"
+	"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,-E,--build-id=sha1>"
 )
 
 if(MINGW)


### PR DESCRIPTION
Trying to implement the suggestion from https://github.com/getsentry/sentry-android/issues/509

CC @eakoli and @blinkov since you added that CMake setting.

I’m thinking if we should maybe expose the breakpad and crashpad symbols? Maybe users might expect to be able to call out to crashpad if they link to sentry built with the crashpad backend.