### PR TITLE
feat: Add on-device symbolication on Android

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,8 +62,16 @@ else()
 		sentry_unix_pageallocator.h
 		sentry_unix_spinlock.h
 		path/sentry_path_unix.c
-		symbolizer/sentry_symbolizer_unix.c
 	)
+	if(ANDROID)
+		sentry_target_sources_cwd(sentry
+			symbolizer/sentry_symbolizer_unix_demangled.cc
+		)
+	else()
+		sentry_target_sources_cwd(sentry
+			symbolizer/sentry_symbolizer_unix.c
+		)
+	endif()
 endif()
 
 # module finder

--- a/src/symbolizer/sentry_symbolizer_unix_demangled.cc
+++ b/src/symbolizer/sentry_symbolizer_unix_demangled.cc
@@ -1,0 +1,38 @@
+extern "C" {
+#include "sentry_boot.h"
+
+#include "sentry_symbolizer.h"
+}
+
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool
+sentry__symbolize(
+    void *addr, void (*func)(const sentry_frame_info_t *, void *), void *data)
+{
+    Dl_info info;
+
+    if (dladdr(addr, &info) == 0) {
+        return false;
+    }
+
+    sentry_frame_info_t frame_info;
+    memset(&frame_info, 0, sizeof(sentry_frame_info_t));
+    frame_info.load_addr = info.dli_fbase;
+    frame_info.symbol_addr = info.dli_saddr;
+    frame_info.instruction_addr = addr;
+    char *demangled = NULL;
+    if (info.dli_sname) {
+        int status;
+        demangled = abi::__cxa_demangle(info.dli_sname, NULL, NULL, &status);
+    }
+    frame_info.symbol = demangled ? demangled : info.dli_sname;
+    frame_info.object_name = info.dli_fname;
+    func(&frame_info, data);
+    free(demangled);
+
+    return true;
+}


### PR DESCRIPTION
It is important to symbolize as much as possible on Android devices because every
device has own libc and libart versions, so symbols can't be resolved by addrs remotely.

This patch adds symbolication and demangling into inproc handler used in Android.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
