### PR TITLE
fix: Change NaN-boxing to Pointer Tagging

### DIFF
--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -26,38 +26,50 @@
 #include "sentry_value.h"
 
 /**
- * NaN-boxing of sentry_value_t
+ * Pointer Tagging of `sentry_value_t`
  *
- * We do encode 32-bit values as well as some constants and pointers into the
- * NaN-space of 64-bit floating-point numbers, like so:
+ * We expect all of the pointers we deal with to be at least 4-byte aligned,
+ * which means we can use the least significant 2 bits for tagging.
+ * We only ever save pointers to `thing_t`, which has an `alignof >= 4`, and
+ * also both our own allocator, and the system allocator should give us
+ * properly aligned pointers.
  *
- * 11111111 11111000 00000000 00000000 00000000 00000000 00000000 00000000
- *               |||
- *               001 - INT32
- *               010 - CONST
- *               100 - THING
- *
- * `THING` (pointers) are expected to be at least 4-byte aligned, as they are
- * shifted by 2 bits, which means we can encode pointers with up to *52* bits.
+ * xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxx00
+ *                                                                      ||
+ *               Pointer to a `thing_t`, a refcounted heap allocation - 00
+ * xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx -   A `int32_t` shifted by 32  - 01
+ *                                                     CONST as below - 10
+ *                                                            false - 0010
+ *                                                             true - 0110
+ *                                                             null - 1010
  */
 
-#define MAX_DOUBLE 0xfff8000000000000ULL
-#define TAG_INT32 0xfff9000000000000ULL
-#define TAG_CONST 0xfffa000000000000ULL
-#define TAG_THING 0xfffc000000000000ULL
+#define TAG_MASK 0x3
+#define TAG_INT32 0x1
+#define TAG_CONST 0x2
+
+#define NAN 0xfff8000000000000ULL
+
+#define CONST_FALSE 0x2
+#define CONST_TRUE 0x6
+#define CONST_NULL 0xa
 
 #define THING_TYPE_MASK 0x7f
 #define THING_TYPE_FROZEN 0x80
-#define THING_TYPE_LIST 1
-#define THING_TYPE_OBJECT 2
-#define THING_TYPE_STRING 0
+#define THING_TYPE_LIST 0
+#define THING_TYPE_OBJECT 1
+#define THING_TYPE_STRING 2
+#define THING_TYPE_DOUBLE 3
 
 /* internal value helpers */
 
 typedef struct {
-    void *payload;
+    union {
+        void *_ptr;
+        double _double;
+    } payload;
     long refcount;
-    char type;
+    uint8_t type;
 } thing_t;
 
 typedef struct {
@@ -126,7 +138,7 @@ reserve(void **buf, size_t item_size, size_t *allocated, size_t min_len)
 static int
 thing_get_type(const thing_t *thing)
 {
-    return thing->type & (char)THING_TYPE_MASK;
+    return thing->type & (uint8_t)THING_TYPE_MASK;
 }
 
 static void
@@ -134,7 +146,7 @@ thing_free(thing_t *thing)
 {
     switch (thing_get_type(thing)) {
     case THING_TYPE_LIST: {
-        list_t *list = thing->payload;
+        list_t *list = thing->payload._ptr;
         for (size_t i = 0; i < list->len; i++) {
             sentry_value_decref(list->items[i]);
         }
@@ -143,7 +155,7 @@ thing_free(thing_t *thing)
         break;
     }
     case THING_TYPE_OBJECT: {
-        obj_t *obj = thing->payload;
+        obj_t *obj = thing->payload._ptr;
         for (size_t i = 0; i < obj->len; i++) {
             sentry_free(obj->pairs[i].k);
             sentry_value_decref(obj->pairs[i].v);
@@ -153,7 +165,7 @@ thing_free(thing_t *thing)
         break;
     }
     case THING_TYPE_STRING: {
-        sentry_free(thing->payload);
+        sentry_free(thing->payload._ptr);
         break;
     }
     }
@@ -175,14 +187,14 @@ thing_freeze(thing_t *thing)
     thing->type |= 0x80;
     switch (thing_get_type(thing)) {
     case THING_TYPE_LIST: {
-        const list_t *l = thing->payload;
+        const list_t *l = thing->payload._ptr;
         for (size_t i = 0; i < l->len; i++) {
             sentry_value_freeze(l->items[i]);
         }
         break;
     }
     case THING_TYPE_OBJECT: {
-        const obj_t *o = thing->payload;
+        const obj_t *o = thing->payload._ptr;
         for (size_t i = 0; i < o->len; i++) {
             sentry_value_freeze(o->pairs[i].v);
         }
@@ -193,31 +205,28 @@ thing_freeze(thing_t *thing)
 }
 
 static sentry_value_t
-new_thing_value(void *ptr, int thing_type)
+new_thing_value(void *ptr, uint8_t thing_type)
 {
-    sentry_value_t rv;
     thing_t *thing = sentry_malloc(sizeof(thing_t));
     if (!thing) {
         return sentry_value_new_null();
     }
-
-    thing->payload = ptr;
+    thing->payload._ptr = ptr;
     thing->refcount = 1;
-    thing->type = (char)thing_type;
-    rv._bits = (((uint64_t)(size_t)thing) >> 2) | TAG_THING;
+    thing->type = thing_type;
+
+    sentry_value_t rv;
+    rv._bits = (uint64_t)(size_t)thing;
     return rv;
 }
 
 static thing_t *
 value_as_thing(sentry_value_t value)
 {
-    if (value._bits <= MAX_DOUBLE) {
-        return NULL;
-    } else if ((value._bits & TAG_THING) == TAG_THING) {
-        return (thing_t *)(size_t)((value._bits & ~TAG_THING) << 2);
-    } else {
+    if (value._bits & TAG_MASK) {
         return NULL;
     }
+    return (thing_t *)(size_t)value._bits;
 }
 
 static thing_t *
@@ -274,7 +283,7 @@ sentry_value_t
 sentry_value_new_null(void)
 {
     sentry_value_t rv;
-    rv._bits = (uint64_t)2 | TAG_CONST;
+    rv._bits = (uint64_t)CONST_NULL;
     return rv;
 }
 
@@ -282,21 +291,23 @@ sentry_value_t
 sentry_value_new_int32(int32_t value)
 {
     sentry_value_t rv;
-    rv._bits = (uint64_t)(uint32_t)value | TAG_INT32;
+    rv._bits = ((uint64_t)(uint32_t)value) << 32 | TAG_INT32;
     return rv;
 }
 
 sentry_value_t
 sentry_value_new_double(double value)
 {
-    sentry_value_t rv;
-    // if we are a nan value we want to become the max double value which
-    // is a NAN.
-    if (value != value) {
-        rv._bits = MAX_DOUBLE;
-    } else {
-        rv._double = value;
+    thing_t *thing = sentry_malloc(sizeof(thing_t));
+    if (!thing) {
+        return sentry_value_new_null();
     }
+    thing->payload._double = value;
+    thing->refcount = 1;
+    thing->type = (uint8_t)(THING_TYPE_DOUBLE | THING_TYPE_FROZEN);
+
+    sentry_value_t rv;
+    rv._bits = (uint64_t)(size_t)thing;
     return rv;
 }
 
@@ -304,7 +315,7 @@ sentry_value_t
 sentry_value_new_bool(int value)
 {
     sentry_value_t rv;
-    rv._bits = (uint64_t)(value ? 1 : 0) | TAG_CONST;
+    rv._bits = (uint64_t)(value ? CONST_TRUE : CONST_FALSE);
     return rv;
 }
 
@@ -403,6 +414,9 @@ sentry__value_new_object_with_size(size_t size)
 sentry_value_type_t
 sentry_value_get_type(sentry_value_t value)
 {
+    if (sentry_value_is_null(value)) {
+        return SENTRY_VALUE_TYPE_NULL;
+    }
     const thing_t *thing = value_as_thing(value);
     if (thing) {
         switch (thing_get_type(thing)) {
@@ -412,25 +426,17 @@ sentry_value_get_type(sentry_value_t value)
             return SENTRY_VALUE_TYPE_LIST;
         case THING_TYPE_OBJECT:
             return SENTRY_VALUE_TYPE_OBJECT;
+        case THING_TYPE_DOUBLE:
+            return SENTRY_VALUE_TYPE_DOUBLE;
         }
         assert(!"unreachable");
-    } else if (value._bits <= MAX_DOUBLE) {
-        return SENTRY_VALUE_TYPE_DOUBLE;
-    } else if ((value._bits & TAG_CONST) == TAG_CONST) {
-        uint64_t val = value._bits & ~TAG_CONST;
-        switch (val) {
-        case 0:
-        case 1:
-            return SENTRY_VALUE_TYPE_BOOL;
-        case 2:
-            return SENTRY_VALUE_TYPE_NULL;
-        default:
-            assert(!"unreachable");
-        }
-    } else if ((value._bits & TAG_INT32) == TAG_INT32) {
+    } else if ((value._bits & TAG_MASK) == TAG_CONST) {
+        return SENTRY_VALUE_TYPE_BOOL;
+    } else if ((value._bits & TAG_MASK) == TAG_INT32) {
         return SENTRY_VALUE_TYPE_INT32;
     }
-    return SENTRY_VALUE_TYPE_DOUBLE;
+    assert(!"unreachable");
+    return SENTRY_VALUE_TYPE_NULL;
 }
 
 int
@@ -440,7 +446,7 @@ sentry_value_set_by_key(sentry_value_t value, const char *k, sentry_value_t v)
     if (!thing || thing_get_type(thing) != THING_TYPE_OBJECT) {
         goto fail;
     }
-    obj_t *o = thing->payload;
+    obj_t *o = thing->payload._ptr;
     for (size_t i = 0; i < o->len; i++) {
         obj_pair_t *pair = &o->pairs[i];
         if (sentry__string_eq(pair->k, k)) {
@@ -476,7 +482,7 @@ sentry_value_remove_by_key(sentry_value_t value, const char *k)
     if (!thing || thing_get_type(thing) != THING_TYPE_OBJECT) {
         return 0;
     }
-    obj_t *o = thing->payload;
+    obj_t *o = thing->payload._ptr;
     for (size_t i = 0; i < o->len; i++) {
         obj_pair_t *pair = &o->pairs[i];
         if (sentry__string_eq(pair->k, k)) {
@@ -499,7 +505,7 @@ sentry_value_append(sentry_value_t value, sentry_value_t v)
         return 1;
     }
 
-    list_t *l = thing->payload;
+    list_t *l = thing->payload._ptr;
 
     if (!reserve((void **)&l->items, sizeof(l->items[0]), &l->allocated,
             l->len + 1)) {
@@ -551,7 +557,7 @@ sentry__value_clone(sentry_value_t value)
     }
     switch (thing_get_type(thing)) {
     case THING_TYPE_LIST: {
-        const list_t *list = thing->payload;
+        const list_t *list = thing->payload._ptr;
         sentry_value_t rv = sentry__value_new_list_with_size(list->len);
         for (size_t i = 0; i < list->len; i++) {
             sentry_value_incref(list->items[i]);
@@ -560,7 +566,7 @@ sentry__value_clone(sentry_value_t value)
         return rv;
     }
     case THING_TYPE_OBJECT: {
-        const obj_t *obj = thing->payload;
+        const obj_t *obj = thing->payload._ptr;
         sentry_value_t rv = sentry__value_new_object_with_size(obj->len);
         for (size_t i = 0; i < obj->len; i++) {
             sentry_value_incref(obj->pairs[i].v);
@@ -569,6 +575,7 @@ sentry__value_clone(sentry_value_t value)
         return rv;
     }
     case THING_TYPE_STRING:
+    case THING_TYPE_DOUBLE:
         sentry_value_incref(value);
         return value;
     default:
@@ -584,7 +591,7 @@ sentry__value_append_bounded(sentry_value_t value, sentry_value_t v, size_t max)
         return 1;
     }
 
-    list_t *l = thing->payload;
+    list_t *l = thing->payload._ptr;
 
     if (l->len < max) {
         return sentry_value_append(value, v);
@@ -612,7 +619,7 @@ sentry_value_set_by_index(sentry_value_t value, size_t index, sentry_value_t v)
         return 1;
     }
 
-    list_t *l = thing->payload;
+    list_t *l = thing->payload._ptr;
     if (!reserve(
             (void *)&l->items, sizeof(l->items[0]), &l->allocated, index + 1)) {
         return 1;
@@ -638,7 +645,7 @@ sentry_value_remove_by_index(sentry_value_t value, size_t index)
         return 1;
     }
 
-    list_t *l = thing->payload;
+    list_t *l = thing->payload._ptr;
     if (index >= l->len) {
         return 0;
     }
@@ -655,7 +662,7 @@ sentry_value_get_by_key(sentry_value_t value, const char *k)
 {
     const thing_t *thing = value_as_thing(value);
     if (thing && thing_get_type(thing) == THING_TYPE_OBJECT) {
-        obj_t *o = thing->payload;
+        obj_t *o = thing->payload._ptr;
         for (size_t i = 0; i < o->len; i++) {
             obj_pair_t *pair = &o->pairs[i];
             if (sentry__string_eq(pair->k, k)) {
@@ -679,7 +686,7 @@ sentry_value_get_by_index(sentry_value_t value, size_t index)
 {
     const thing_t *thing = value_as_thing(value);
     if (thing && thing_get_type(thing) == THING_TYPE_LIST) {
-        list_t *l = thing->payload;
+        list_t *l = thing->payload._ptr;
         if (index < l->len) {
             return l->items[index];
         }
@@ -702,11 +709,11 @@ sentry_value_get_length(sentry_value_t value)
     if (thing) {
         switch (thing_get_type(thing)) {
         case THING_TYPE_STRING:
-            return strlen(thing->payload);
+            return strlen(thing->payload._ptr);
         case THING_TYPE_LIST:
-            return ((const list_t *)thing->payload)->len;
+            return ((const list_t *)thing->payload._ptr)->len;
         case THING_TYPE_OBJECT:
-            return ((const obj_t *)thing->payload)->len;
+            return ((const obj_t *)thing->payload._ptr)->len;
         }
     }
     return 0;
@@ -715,8 +722,8 @@ sentry_value_get_length(sentry_value_t value)
 int32_t
 sentry_value_as_int32(sentry_value_t value)
 {
-    if ((value._bits & TAG_INT32) == TAG_INT32) {
-        return (int32_t)(value._bits & ~TAG_INT32);
+    if ((value._bits & TAG_MASK) == TAG_INT32) {
+        return (int32_t)((int64_t)value._bits >> 32);
     } else {
         return 0;
     }
@@ -725,12 +732,15 @@ sentry_value_as_int32(sentry_value_t value)
 double
 sentry_value_as_double(sentry_value_t value)
 {
-    if (value._bits <= MAX_DOUBLE) {
-        return value._double;
-    } else if ((value._bits & TAG_INT32) == TAG_INT32) {
+    if ((value._bits & TAG_MASK) == TAG_INT32) {
         return (double)sentry_value_as_int32(value);
+    }
+
+    const thing_t *thing = value_as_thing(value);
+    if (thing && thing_get_type(thing) == THING_TYPE_DOUBLE) {
+        return thing->payload._double;
     } else {
-        return MAX_DOUBLE;
+        return NAN;
     }
 }
 
@@ -739,7 +749,7 @@ sentry_value_as_string(sentry_value_t value)
 {
     const thing_t *thing = value_as_thing(value);
     if (thing && thing_get_type(thing) == THING_TYPE_STRING) {
-        return (const char *)thing->payload;
+        return (const char *)thing->payload._ptr;
     } else {
         return "";
     }
@@ -748,10 +758,13 @@ sentry_value_as_string(sentry_value_t value)
 int
 sentry_value_is_true(sentry_value_t value)
 {
+    if (value._bits == CONST_TRUE) {
+        return 1;
+    }
     switch (sentry_value_get_type(value)) {
     case SENTRY_VALUE_TYPE_BOOL:
     case SENTRY_VALUE_TYPE_NULL:
-        return (value._bits & ~TAG_CONST) == 1;
+        return 0;
     case SENTRY_VALUE_TYPE_INT32:
         return sentry_value_as_int32(value) != 0;
     case SENTRY_VALUE_TYPE_DOUBLE:
@@ -764,11 +777,7 @@ sentry_value_is_true(sentry_value_t value)
 int
 sentry_value_is_null(sentry_value_t value)
 {
-    if ((value._bits & TAG_CONST) == TAG_CONST) {
-        uint64_t val = value._bits & ~TAG_CONST;
-        return val == 2;
-    }
-    return false;
+    return value._bits == CONST_NULL;
 }
 
 static void
@@ -791,7 +800,7 @@ value_to_json(sentry_jsonwriter_t *jw, sentry_value_t value)
         sentry__jsonwriter_write_str(jw, sentry_value_as_string(value));
         break;
     case SENTRY_VALUE_TYPE_LIST: {
-        const list_t *l = value_as_thing(value)->payload;
+        const list_t *l = value_as_thing(value)->payload._ptr;
         sentry__jsonwriter_write_list_start(jw);
         for (size_t i = 0; i < l->len; i++) {
             value_to_json(jw, l->items[i]);
@@ -800,7 +809,7 @@ value_to_json(sentry_jsonwriter_t *jw, sentry_value_t value)
         break;
     }
     case SENTRY_VALUE_TYPE_OBJECT: {
-        const obj_t *o = value_as_thing(value)->payload;
+        const obj_t *o = value_as_thing(value)->payload._ptr;
         sentry__jsonwriter_write_object_start(jw);
         for (size_t i = 0; i < o->len; i++) {
             sentry__jsonwriter_write_key(jw, o->pairs[i].k);
@@ -841,7 +850,7 @@ value_to_msgpack(mpack_writer_t *writer, sentry_value_t value)
         break;
     }
     case SENTRY_VALUE_TYPE_LIST: {
-        const list_t *l = value_as_thing(value)->payload;
+        const list_t *l = value_as_thing(value)->payload._ptr;
 
         mpack_start_array(writer, (uint32_t)l->len);
         for (size_t i = 0; i < l->len; i++) {
@@ -851,7 +860,7 @@ value_to_msgpack(mpack_writer_t *writer, sentry_value_t value)
         break;
     }
     case SENTRY_VALUE_TYPE_OBJECT: {
-        const obj_t *o = value_as_thing(value)->payload;
+        const obj_t *o = value_as_thing(value)->payload._ptr;
 
         mpack_start_map(writer, (uint32_t)o->len);
         for (size_t i = 0; i < o->len; i++) {

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -11,9 +11,9 @@ SENTRY_TEST(value_null)
     TEST_CHECK(!sentry_value_is_true(val));
     TEST_CHECK_JSON_VALUE(val, "null");
     TEST_CHECK(sentry_value_refcount(val) == 1);
+    TEST_CHECK(sentry_value_is_frozen(val));
     sentry_value_decref(val);
     TEST_CHECK(sentry_value_refcount(val) == 1);
-    TEST_CHECK(sentry_value_is_frozen(val));
 }
 
 SENTRY_TEST(value_bool)
@@ -34,9 +34,9 @@ SENTRY_TEST(value_bool)
     TEST_CHECK(!sentry_value_is_true(val));
     TEST_CHECK_JSON_VALUE(val, "false");
     TEST_CHECK(sentry_value_refcount(val) == 1);
+    TEST_CHECK(sentry_value_is_frozen(val));
     sentry_value_decref(val);
     TEST_CHECK(sentry_value_refcount(val) == 1);
-    TEST_CHECK(sentry_value_is_frozen(val));
 }
 
 SENTRY_TEST(value_int32)
@@ -62,9 +62,9 @@ SENTRY_TEST(value_int32)
     TEST_CHECK(sentry_value_as_int32(val) == -1);
     TEST_CHECK(sentry_value_is_true(val) == true);
     TEST_CHECK(sentry_value_refcount(val) == 1);
+    TEST_CHECK(sentry_value_is_frozen(val));
     sentry_value_decref(val);
     TEST_CHECK(sentry_value_refcount(val) == 1);
-    TEST_CHECK(sentry_value_is_frozen(val));
 }
 
 SENTRY_TEST(value_double)
@@ -75,9 +75,8 @@ SENTRY_TEST(value_double)
     TEST_CHECK(sentry_value_is_true(val));
     TEST_CHECK_JSON_VALUE(val, "42.05");
     TEST_CHECK(sentry_value_refcount(val) == 1);
-    sentry_value_decref(val);
-    TEST_CHECK(sentry_value_refcount(val) == 1);
     TEST_CHECK(sentry_value_is_frozen(val));
+    sentry_value_decref(val);
 }
 
 SENTRY_TEST(value_string)


### PR DESCRIPTION
There is already this note here about `sentry_value_t`:

https://github.com/getsentry/sentry-native/blob/425b803d53acc2d598633fd64ac969508487007e/include/sentry.h#L127-L128

I think in a future version we can just typedef this to a `uint64_t`.

This now moves double values to a heap allocation with a refcount.