### PR TITLE
fix: Add sentry_reset_backend API

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -925,6 +925,16 @@ SENTRY_API int sentry_shutdown(void);
 SENTRY_EXPERIMENTAL_API void sentry_clear_modulecache(void);
 
 /**
+ * Re-initializes the Sentry backend
+ *
+ * This is mainly meant for if a third-party library hijacks Sentry's signal
+ * handler and we need to reinstall it.
+ *
+ * Returns 0 on success.
+ */
+SENTRY_API int sentry_reset_backend(void);
+
+/**
  * Gives user consent.
  */
 SENTRY_API void sentry_user_consent_give(void);

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -213,6 +213,22 @@ sentry_clear_modulecache(void)
     sentry__modulefinder_cleanup();
 }
 
+int
+sentry_reset_backend(void)
+{
+    sentry_backend_t *backend = g_options->backend;
+    if (backend && backend->shutdown_func) {
+        backend->shutdown_func(backend);
+    }
+
+    if (backend && backend->startup_func) {
+        if (g_options->backend->startup_func(g_options->backend, g_options)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static void
 set_user_consent(sentry_user_consent_t new_val)
 {


### PR DESCRIPTION
We have a third-party dynamic library (.NET Core runtime) that is loaded far into our application's runtime which, on load, steals all signal handlers. On Linux this works out fine, they are responsible and call whatever signal handler was there before them. No such luck on Windows. Forking and patching the .NET Core runtime is quite a bit more work, and we may run into this kind of issue in the future, so our internal fix is to add this API, and hopefully we can get this upstreamed and avoid forking sentry-native altogether.

I'm not really sure how to write tests for this, but I can definitely add tests for it with a bit of guidance!
