### PR TITLE
Define UNICODE for Breakpad build

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 
 if(WIN32)
     target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON_WINDOWS} ${BREAKPAD_SOURCES_CLIENT_WINDOWS})
-    target_compile_definitions(breakpad_client PRIVATE _UNICODE)
+    target_compile_definitions(breakpad_client PRIVATE _UNICODE UNICODE)
 
     # set static runtime if enabled
     if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)


### PR DESCRIPTION
Discovered a problem with building breakpad backend on windows:

This is from my small [demo](https://github.com/variar/qt_cpp_sentry/runs/1195358380?check_suite_focus=true)
```
[38/46] Building CXX object external\sentry-native\external\CMakeFiles\breakpad_client.dir\breakpad\src\client\windows\handler\exception_handler.cc.obj
FAILED: external/sentry-native/external/CMakeFiles/breakpad_client.dir/breakpad/src/client/windows/handler/exception_handler.cc.obj 
C:\PROGRA~2\MICROS~1\2019\ENTERP~1\VC\Tools\MSVC\1427~1.291\bin\Hostx64\x64\cl.exe  /nologo /TP -D_UNICODE -Igenerated -I..\external\sentry-native\external\breakpad\src -I..\external\sentry-native\external /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MD /Zi /O2 /Ob1 /DNDEBUG -std:c++14 /showIncludes /Foexternal\sentry-native\external\CMakeFiles\breakpad_client.dir\breakpad\src\client\windows\handler\exception_handler.cc.obj /Fdexternal\sentry-native\external\CMakeFiles\breakpad_client.dir\breakpad_client.pdb /FS -c ..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc
..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc(229): error C2664: 'HMODULE LoadLibraryA(LPCSTR)': cannot convert argument 1 from 'const wchar_t [12]' to 'LPCSTR'
..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc(229): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\libloaderapi.h(657): note: see declaration of 'LoadLibraryA'
..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc(238): error C2664: 'HMODULE LoadLibraryA(LPCSTR)': cannot convert argument 1 from 'const wchar_t [11]' to 'LPCSTR'
..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc(238): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\libloaderapi.h(657): note: see declaration of 'LoadLibraryA'
..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc(920): error C2664: 'HANDLE CreateFileA(LPCSTR,DWORD,DWORD,LPSECURITY_ATTRIBUTES,DWORD,DWORD,HANDLE)': cannot convert argument 1 from 'const wchar_t *' to 'LPCSTR'
..\external\sentry-native\external\breakpad\src\client\windows\handler\exception_handler.cc(920): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\fileapi.h(81): note: see declaration of 'CreateFileA'
```

Defining `UNICODE` in addition to `_UNICODE` [fixes](https://github.com/variar/qt_cpp_sentry/runs/1195439781?check_suite_focus=true) this issue
