### PR TITLE
ci: Simplify and run archive job only on main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,21 +147,16 @@ jobs:
     name: Create Release Archive
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: ${{ needs.test.result == 'success' && github.repository_owner == 'getsentry' }}
+    if: ${{ needs.test.result == 'success' && secrets.ZEUS_HOOK_BASE }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Remove unneeded files
-        shell: bash
-        run: rm -rf build .c* .e* .git* scripts Makefile external/breakpad/src/tools external/breakpad/src/processor
-
       - name: Create source archive
-        shell: python
         run: |
-          import shutil
-          shutil.make_archive("sentry-native-source", "zip", ".")
+          rm -rf build .c* .e* .git* scripts Makefile external/breakpad/src/tools external/breakpad/src/processor
+          zip -r sentry-native-source.zip .
 
       - name: Upload source artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     name: Create Release Archive
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: ${{ needs.test.result == 'success' && secrets.ZEUS_HOOK_BASE }}
+    if: ${{ needs.test.result == 'success' && github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This now runs the archiving job only for pushes, so they don’t get run for PRs and have them fail if they originate from a foreign branch.