### PR TITLE
fix: Use doubles to represent signal numbers

### DIFF
--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -193,8 +193,10 @@ make_signal_event(
     if (sig_slot) {
         sentry_value_set_by_key(
             signal_meta, "name", sentry_value_new_string(sig_slot->signame));
+        // at least on windows, the signum is a true u32 which we can't
+        // otherwise represent.
         sentry_value_set_by_key(signal_meta, "number",
-            sentry_value_new_int32((int32_t)sig_slot->signum));
+            sentry_value_new_double((double)sig_slot->signum));
     }
     sentry_value_set_by_key(mechanism_meta, "signal", signal_meta);
     sentry_value_set_by_key(

--- a/src/sentry_json.c
+++ b/src/sentry_json.c
@@ -219,7 +219,8 @@ sentry__jsonwriter_write_double(sentry_jsonwriter_t *jw, double val)
 {
     if (can_write_item(jw)) {
         char buf[50];
-        snprintf(buf, sizeof(buf), "%g", val);
+        // The MAX_SAFE_INTEGER is 9007199254740991, which has 16 digits
+        snprintf(buf, sizeof(buf), "%.16g", val);
         write_str(jw, buf);
     }
 }

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -77,6 +77,12 @@ SENTRY_TEST(value_double)
     TEST_CHECK(sentry_value_refcount(val) == 1);
     TEST_CHECK(sentry_value_is_frozen(val));
     sentry_value_decref(val);
+
+    val = sentry_value_new_double(4294967295.);
+    TEST_CHECK(sentry_value_get_type(val) == SENTRY_VALUE_TYPE_DOUBLE);
+    TEST_CHECK(sentry_value_as_double(val) == 4294967295.);
+    TEST_CHECK_JSON_VALUE(val, "4294967295");
+    sentry_value_decref(val);
 }
 
 SENTRY_TEST(value_string)


### PR DESCRIPTION
`EXCEPTION_ACCESS_VIOLATION` is defined as `0xC0000005`, which overflows
an i32 and will turn negative, which causes processing problems later on.

This is a simpler alternative to #385 as it just uses a double for the signal number, and makes sure doubles are printed to json in full fidelity.