### PR TITLE
fix(doc): Mention minimum supported Sentry version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@
 
 The _Sentry Native SDK_ is an error and crash reporting client for native
 applications, optimized for C and C++. Sentry allows to add tags, breadcrumbs
-and arbitrary custom context to enrich error reports.
+and arbitrary custom context to enrich error reports. Supports Sentry _20.6.0_
+and later.
 
 **Note**: This SDK is being actively developed and still in Beta. We recommend
 to check for updates regularly to benefit from latest features and bug fixes.
 Please see [Known Limitations](#known-limitations).
 
-## Resources
+## Resources <!-- omit in toc -->
 
 - [Discord](https://discord.gg/ez5KZN7) server for project discussions.
 - Follow [@getsentry](https://twitter.com/getsentry) on Twitter for updates


### PR DESCRIPTION
Updates documentation to mention the minimum supported onpremise version. This constraint comes from using the Envelope endpoint, which has first been introduced via Relay into 20.6.0.