### PR TITLE
fix(crashpad): Send sentry_client with all crashpad requests

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -25,7 +25,7 @@ extern "C" {
 /* SDK Version */
 #define SENTRY_SDK_NAME "sentry.native"
 #define SENTRY_SDK_VERSION "0.4.3"
-#define SENTRY_SDK_USER_AGENT (SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION)
+#define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION
 
 /* common platform detection */
 #ifdef _WIN32

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -309,8 +309,8 @@ sentry__dsn_get_auth_header(const sentry_dsn_t *dsn)
     sentry__stringbuilder_init(&sb);
     sentry__stringbuilder_append(&sb, "Sentry sentry_key=");
     sentry__stringbuilder_append(&sb, dsn->public_key);
-    sentry__stringbuilder_append(&sb, ", sentry_version=7, sentry_client=");
-    sentry__stringbuilder_append(&sb, SENTRY_SDK_USER_AGENT);
+    sentry__stringbuilder_append(
+        &sb, ", sentry_version=7, sentry_client=" SENTRY_SDK_USER_AGENT);
     return sentry__stringbuilder_into_string(&sb);
 }
 
@@ -348,7 +348,8 @@ sentry__dsn_get_minidump_url(const sentry_dsn_t *dsn)
     }
     sentry_stringbuilder_t sb;
     init_string_builder_for_url(&sb, dsn);
-    sentry__stringbuilder_append(&sb, "/minidump/?sentry_key=");
+    sentry__stringbuilder_append(
+        &sb, "/minidump/?sentry_client=" SENTRY_SDK_USER_AGENT "&sentry_key=");
     sentry__stringbuilder_append(&sb, dsn->public_key);
     return sentry__stringbuilder_into_string(&sb);
 }

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -109,7 +109,8 @@ SENTRY_TEST(dsn_store_url_with_path)
     sentry_free(url);
     url = sentry__dsn_get_minidump_url(dsn);
     TEST_CHECK_STRING_EQUAL(url,
-        "http://example.com:80/foo/bar/api/42/minidump/?sentry_key=username");
+        "http://example.com:80/foo/bar/api/42/minidump/"
+        "?sentry_client=" SENTRY_SDK_USER_AGENT "&sentry_key=username");
     sentry_free(url);
     sentry__dsn_decref(dsn);
 }
@@ -123,8 +124,9 @@ SENTRY_TEST(dsn_store_url_without_path)
     TEST_CHECK_STRING_EQUAL(url, "http://example.com:80/api/42/envelope/");
     sentry_free(url);
     url = sentry__dsn_get_minidump_url(dsn);
-    TEST_CHECK_STRING_EQUAL(
-        url, "http://example.com:80/api/42/minidump/?sentry_key=username");
+    TEST_CHECK_STRING_EQUAL(url,
+        "http://example.com:80/api/42/minidump/"
+        "?sentry_client=" SENTRY_SDK_USER_AGENT "&sentry_key=username");
     sentry_free(url);
     sentry__dsn_decref(dsn);
 }


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/822, we added more diagnostics to log invalid payloads sent by SDKs. The Native SDK does not send a `sentry_client` identifier when using the minidump endpoint, which is relevant for debugging invalid msgpack payloads sent through the crashpad handler.

This adds the `sentry_client` query parameter to the minidump URL which is then passed to crashpad. For envelope and old-style store requests, this had been part of the auth header.