### PR TITLE
feat: name sentry background worker thread

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -729,6 +729,18 @@ SENTRY_API const char *sentry_options_get_ca_certs(
     const sentry_options_t *opts);
 
 /**
+ * Configures the name of background worker thread
+ */
+SENTRY_API void sentry_options_set_bgworker_name(
+    sentry_options_t *opts, const char *name);
+
+/**
+ * Returns the configured background worker thread name.
+ */
+SENTRY_API const char *sentry_options_get_bgworker_name(
+    const sentry_options_t *opts);
+
+/**
  * Enables or disables debug printing mode.
  */
 SENTRY_API void sentry_options_set_debug(sentry_options_t *opts, int debug);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -729,15 +729,15 @@ SENTRY_API const char *sentry_options_get_ca_certs(
     const sentry_options_t *opts);
 
 /**
- * Configures the name of background worker thread
+ * Configures the name of the http transport thread.
  */
-SENTRY_API void sentry_options_set_bgworker_name(
+SENTRY_API void sentry_options_set_transport_thread_name(
     sentry_options_t *opts, const char *name);
 
 /**
- * Returns the configured background worker thread name.
+ * Returns the configured http transport thread name.
  */
-SENTRY_API const char *sentry_options_get_bgworker_name(
+SENTRY_API const char *sentry_options_get_transport_thread_name(
     const sentry_options_t *opts);
 
 /**

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -24,6 +24,7 @@ sentry_options_new(void)
     opts->debug = debug && sentry__string_eq(debug, "1");
     sentry_logger_t logger = { sentry__logger_defaultlogger, NULL };
     opts->logger = logger;
+    opts->bgworker_name = sentry__string_clone("Sentry BgWorker");
 #ifdef SENTRY_PLATFORM_WINDOWS
     opts->release = sentry__string_from_wstr(_wgetenv(L"SENTRY_RELEASE"));
     opts->environment
@@ -76,6 +77,7 @@ sentry_options_free(sentry_options_t *opts)
     sentry_free(opts->dist);
     sentry_free(opts->http_proxy);
     sentry_free(opts->ca_certs);
+    sentry_free(opts->bgworker_name);
     sentry__path_free(opts->database_path);
     sentry__path_free(opts->handler_path);
     sentry_transport_free(opts->transport);
@@ -202,6 +204,19 @@ const char *
 sentry_options_get_ca_certs(const sentry_options_t *opts)
 {
     return opts->ca_certs;
+}
+
+void
+sentry_options_set_bgworker_name(sentry_options_t *opts, const char *name)
+{
+    sentry_free(opts->bgworker_name);
+    opts->bgworker_name = sentry__string_clone(name);
+}
+
+const char *
+sentry_options_get_bgworker_name(const sentry_options_t *opts)
+{
+    return opts->bgworker_name;
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -24,7 +24,7 @@ sentry_options_new(void)
     opts->debug = debug && sentry__string_eq(debug, "1");
     sentry_logger_t logger = { sentry__logger_defaultlogger, NULL };
     opts->logger = logger;
-    opts->bgworker_name = sentry__string_clone("Sentry BgWorker");
+    opts->transport_thread_name = sentry__string_clone("sentry-http");
 #ifdef SENTRY_PLATFORM_WINDOWS
     opts->release = sentry__string_from_wstr(_wgetenv(L"SENTRY_RELEASE"));
     opts->environment
@@ -77,7 +77,7 @@ sentry_options_free(sentry_options_t *opts)
     sentry_free(opts->dist);
     sentry_free(opts->http_proxy);
     sentry_free(opts->ca_certs);
-    sentry_free(opts->bgworker_name);
+    sentry_free(opts->transport_thread_name);
     sentry__path_free(opts->database_path);
     sentry__path_free(opts->handler_path);
     sentry_transport_free(opts->transport);
@@ -207,16 +207,17 @@ sentry_options_get_ca_certs(const sentry_options_t *opts)
 }
 
 void
-sentry_options_set_bgworker_name(sentry_options_t *opts, const char *name)
+sentry_options_set_transport_thread_name(
+    sentry_options_t *opts, const char *name)
 {
-    sentry_free(opts->bgworker_name);
-    opts->bgworker_name = sentry__string_clone(name);
+    sentry_free(opts->transport_thread_name);
+    opts->transport_thread_name = sentry__string_clone(name);
 }
 
 const char *
-sentry_options_get_bgworker_name(const sentry_options_t *opts)
+sentry_options_get_transport_thread_name(const sentry_options_t *opts)
 {
-    return opts->bgworker_name;
+    return opts->transport_thread_name;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -36,6 +36,7 @@ typedef struct sentry_options_s {
     char *dist;
     char *http_proxy;
     char *ca_certs;
+    char *bgworker_name;
     sentry_path_t *database_path;
     sentry_path_t *handler_path;
     sentry_logger_t logger;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -36,7 +36,7 @@ typedef struct sentry_options_s {
     char *dist;
     char *http_proxy;
     char *ca_certs;
-    char *bgworker_name;
+    char *transport_thread_name;
     sentry_path_t *database_path;
     sentry_path_t *handler_path;
     sentry_logger_t logger;

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -329,6 +329,12 @@ int sentry__bgworker_start(sentry_bgworker_t *bgw);
 int sentry__bgworker_shutdown(sentry_bgworker_t *bgw, uint64_t timeout);
 
 /**
+ * This will set a preferable thread name for background worker.
+ * Should be executed before worker start
+ */
+void sentry__bgworker_setname(sentry_bgworker_t *bgw, const char *thread_name);
+
+/**
  * This will submit a new task to the background thread.
  *
  * Takes ownership of `data`, freeing it using the provided `cleanup_func`.

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -78,7 +78,7 @@ sentry__curl_transport_start(
     state->curl_handle = curl_easy_init();
     state->debug = options->debug;
 
-    sentry__bgworker_setname(bgworker, options->bgworker_name);
+    sentry__bgworker_setname(bgworker, options->transport_thread_name);
 
     if (!state->curl_handle) {
         // In this case we don’t start the worker at all, which means we can

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -78,6 +78,8 @@ sentry__curl_transport_start(
     state->curl_handle = curl_easy_init();
     state->debug = options->debug;
 
+    sentry__bgworker_setname(bgworker, options->bgworker_name);
+
     if (!state->curl_handle) {
         // In this case we don’t start the worker at all, which means we can
         // still dump all unsent envelopes to disk on shutdown.

--- a/src/transports/sentry_transport_winhttp.c
+++ b/src/transports/sentry_transport_winhttp.c
@@ -65,7 +65,7 @@ sentry__winhttp_transport_start(
     state->user_agent = sentry__string_to_wstr(SENTRY_SDK_USER_AGENT);
     state->debug = opts->debug;
 
-    sentry__bgworker_setname(bgworker, opts->bgworker_name);
+    sentry__bgworker_setname(bgworker, opts->transport_thread_name);
 
     // ensure the proxy starts with `http://`, otherwise ignore it
     if (opts->http_proxy

--- a/src/transports/sentry_transport_winhttp.c
+++ b/src/transports/sentry_transport_winhttp.c
@@ -65,6 +65,8 @@ sentry__winhttp_transport_start(
     state->user_agent = sentry__string_to_wstr(SENTRY_SDK_USER_AGENT);
     state->debug = opts->debug;
 
+    sentry__bgworker_setname(bgworker, opts->bgworker_name);
+
     // ensure the proxy starts with `http://`, otherwise ignore it
     if (opts->http_proxy
         && strstr(opts->http_proxy, "http://") == opts->http_proxy) {


### PR DESCRIPTION
Add "Sentry BgWorker" description to the Sentry background worker thread.

Fixes #411 

---

Fun fact: in Windows, Thread Handle != Thread Id.
But in sentry-native, `sentry_threadid_t` is actually thread handle, not id :)