### PR TITLE
fix: Retain run folder on shutdown

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -184,4 +184,8 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "sleep-after-shutdown")) {
         sleep_s(1);
     }
+
+    if (has_arg(argc, argv, "crash-after-shutdown")) {
+        trigger_crash();
+    }
 }

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -410,6 +410,7 @@ sentry__backend_new(void)
         = sentry__crashpad_backend_user_consent_changed;
     backend->get_last_crash_func = sentry__crashpad_backend_last_crash;
     backend->data = data;
+    backend->can_capture_after_shutdown = true;
 
     return backend;
 }

--- a/src/sentry_backend.h
+++ b/src/sentry_backend.h
@@ -25,6 +25,7 @@ typedef struct sentry_backend_s {
     void (*user_consent_changed_func)(struct sentry_backend_s *);
     uint64_t (*get_last_crash_func)(struct sentry_backend_s *);
     void *data;
+    bool can_capture_after_shutdown;
 } sentry_backend_t;
 
 /**

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -197,6 +197,13 @@ sentry_shutdown(void)
             dumped_envelopes = sentry__transport_dump_queue(
                 options->transport, options->run);
         }
+        // crashpad can capture crashes *after* calling `shutdown`, so we leave
+        // the run folder intact so that it can still upload the msgpack files.
+#ifndef SENTRY_BACKEND_CRASHPAD
+        if (!dumped_envelopes) {
+            sentry__run_clean(options->run);
+        }
+#endif
 
         sentry_options_free(options);
     }

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -197,9 +197,6 @@ sentry_shutdown(void)
             dumped_envelopes = sentry__transport_dump_queue(
                 options->transport, options->run);
         }
-        if (!dumped_envelopes) {
-            sentry__run_clean(options->run);
-        }
 
         sentry_options_free(options);
     }

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -197,7 +197,9 @@ sentry_shutdown(void)
             dumped_envelopes = sentry__transport_dump_queue(
                 options->transport, options->run);
         }
-        if (!dumped_envelopes && (!options->backend || !options->backend->can_capture_after_shutdown)) {
+        if (!dumped_envelopes
+            && (!options->backend
+                || !options->backend->can_capture_after_shutdown)) {
             sentry__run_clean(options->run);
         }
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -197,13 +197,9 @@ sentry_shutdown(void)
             dumped_envelopes = sentry__transport_dump_queue(
                 options->transport, options->run);
         }
-        // crashpad can capture crashes *after* calling `shutdown`, so we leave
-        // the run folder intact so that it can still upload the msgpack files.
-#ifndef SENTRY_BACKEND_CRASHPAD
-        if (!dumped_envelopes) {
+        if (!dumped_envelopes && (!options->backend || !options->backend->can_capture_after_shutdown)) {
             sentry__run_clean(options->run);
         }
-#endif
 
         sentry_options_free(options);
     }

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,4 +1,6 @@
 import datetime
+import email
+import gzip
 
 
 def matches(actual, expected):
@@ -131,3 +133,21 @@ def assert_crash(envelope):
     # depending on the unwinder, we currently don’t get any stack frames from
     # a `ucontext`
     assert_stacktrace(envelope, inside_exception=True, check_size=False)
+
+
+def assert_crashpad_upload(req):
+    multipart = gzip.decompress(req.get_data())
+    msg = email.message_from_bytes(bytes(str(req.headers), encoding="utf8") + multipart)
+    files = [part.get_filename() for part in msg.walk()]
+
+    # TODO:
+    # Actually assert that we get a correct event/breadcrumbs payload
+    assert "__sentry-breadcrumb1" in files
+    assert "__sentry-breadcrumb2" in files
+    assert "__sentry-event" in files
+
+    assert any(
+        b'name="upload_file_minidump"' in part.as_bytes()
+        and b"\n\nMDMP" in part.as_bytes()
+        for part in msg.walk()
+    )

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -8,8 +8,6 @@ from .assertions import assert_crashpad_upload, assert_session
 
 pytestmark = pytest.mark.skipif(not has_crashpad, reason="tests need crashpad backend")
 
-# TODO:
-# Actually assert that we get a correct event/breadcrumbs payload
 
 # Windows and Linux are currently able to flush all the state on crash
 flushes_state = sys.platform != "darwin"

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -4,7 +4,7 @@ import sys
 import time
 from . import make_dsn, run, Envelope
 from .conditions import has_crashpad
-from .assertions import assert_session
+from .assertions import assert_crashpad_upload, assert_session
 
 pytestmark = pytest.mark.skipif(not has_crashpad, reason="tests need crashpad backend")
 
@@ -56,17 +56,42 @@ def test_crashpad_crash(cmake, httpserver):
     run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
 
     assert len(httpserver.log) == 2
-    outputs = (httpserver.log[0][0].get_data(), httpserver.log[1][0].get_data())
+    outputs = (httpserver.log[0][0], httpserver.log[1][0])
     session, multipart = (
-        outputs if b'"type":"session"' in outputs[0] else (outputs[1], outputs[0])
+        (outputs[0].get_data(), outputs[1])
+        if b'"type":"session"' in outputs[0].get_data()
+        else (outputs[1].get_data(), outputs[0])
     )
 
     envelope = Envelope.deserialize(session)
     assert_session(envelope, {"status": "crashed", "errors": 1})
 
-    # TODO: crashpad actually sends a compressed multipart request,
-    # which we don’t parse / assert right now.
-    # Ideally, we would pull in a real relay to do all the http tests against.
+    assert_crashpad_upload(multipart)
+
+
+def test_crashpad_crash_after_shutdown(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        child = run(
+            tmp_path, "sentry_example", ["log", "crash-after-shutdown"], env=env,
+        )
+        assert child.returncode  # well, its a crash after all
+
+    assert waiting.result
+
+    # the session crash heuristic on mac uses timestamps, so make sure we have
+    # a small delay here
+    time.sleep(1)
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    assert len(httpserver.log) == 1
+
+    assert_crashpad_upload(httpserver.log[0][0])
 
 
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")


### PR DESCRIPTION
This way crashes that happen after shutdown can still get the correct scope
and breadcrumb info when using crashpad
