### PR TITLE
fix: Update crashpad and suppress C5105

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,8 @@ if(MSVC)
 	endif()
 
 	# using `/Wall` is not feasible, as it spews tons of warnings from windows headers
-	target_compile_options(sentry PRIVATE $<BUILD_INTERFACE:/W4>)
+	# supress C5105, introduced in VS 16.8, which breaks on the Windows SDKs own `winbase.h` header
+	target_compile_options(sentry PRIVATE $<BUILD_INTERFACE:/W4 /wd5105>)
 	# ignore all warnings for mpack
 	set_source_files_properties(
 		"${PROJECT_SOURCE_DIR}/vendor/mpack.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,10 @@ if(SENTRY_BUILD_EXAMPLES)
 	add_executable(sentry_example examples/example.c)
 	target_link_libraries(sentry_example PRIVATE sentry)
 
+	if(MSVC)
+		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/wd5105>)
+	endif()
+
 	# set static runtime if enabled
 	if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
 		set_property(TARGET sentry_example PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/examples/example.c
+++ b/examples/example.c
@@ -1,3 +1,9 @@
+#ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define NOMINMAX
+#    define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "sentry.h"
 #include <stdbool.h>
 #include <stdio.h>
@@ -5,7 +11,7 @@
 #include <string.h>
 
 #ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
+#    include <synchapi.h>
 #    define sleep_s(SECONDS) Sleep((SECONDS)*1000)
 #else
 #    include <unistd.h>

--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -9,7 +9,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <io.h>
-#include <shlwapi.h>
 #include <stdlib.h>
 #include <sys/locking.h>
 #include <sys/stat.h>
@@ -125,7 +124,13 @@ sentry__path_dir(const sentry_path_t *path)
     if (!dir_path) {
         return NULL;
     }
-    PathRemoveFileSpecW(dir_path->path);
+
+    // find the filename part and truncate just in front of it if possible
+    sentry_pathchar_t *filename
+        = (sentry_pathchar_t *)sentry__path_filename(dir_path);
+    if (filename > dir_path->path) {
+        *(filename - 1) = L'\0';
+    }
     return dir_path;
 }
 
@@ -216,7 +221,7 @@ sentry__path_filename(const sentry_path_t *path)
     size_t idx = wcslen(s);
 
     while (true) {
-        if (s[idx] == L'/' || s[idx] == '\\') {
+        if (s[idx] == L'/' || s[idx] == L'\\') {
             ptr = s + idx + 1;
             break;
         }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -67,6 +67,10 @@ if(MINGW)
 	)
 endif()
 
+if(MSVC)
+	target_compile_options(sentry_test_unit PRIVATE $<BUILD_INTERFACE:/wd5105>)
+endif()
+
 # set static runtime if enabled
 if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
 	set_property(TARGET sentry_test_unit PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
This warning was newly introduced in VS 16.8, but breaks with the
Windows SDKs own `winbase.h` header. We will just suppress it for now.