### PR TITLE
ci: Pin CodeChecker version and fix Linux dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,7 @@ jobs:
       - name: Installing CodeChecker
         if: ${{ contains(env['RUN_ANALYZER'], 'code-checker') }}
         run: |
-          sudo apt install clang-tidy curl doxygen gcc-multilib python3-dev python3-virtualenv
-          sudo apt-get build-dep python3-lxml
+          sudo apt install clang-tidy curl doxygen gcc-multilib libxml2-dev libxslt1-dev python3-dev python3-virtualenv
           git clone https://github.com/Ericsson/CodeChecker.git --depth 1 --branch v6.15.0
           cd CodeChecker
           BUILD_LOGGER_64_BIT_ONLY=YES make standalone_package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,14 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/focal llvm-toolchain-focal-10 main' -y
           sudo apt update
-          sudo apt install clang-10 clang-tools llvm kcov g++-10 valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang-10 clang-tools llvm kcov g++-10 valgrind zlib1g-dev libcurl4-openssl-dev
 
       - name: Installing Linux 32-bit Dependencies
         if: ${{ runner.os == 'Linux' && env['TEST_X86'] }}
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update
-          sudo apt install gcc-multilib g++-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
+          sudo apt install cmake gcc-multilib g++-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
 
       - name: Installing CodeChecker
         if: ${{ contains(env['RUN_ANALYZER'], 'code-checker') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/focal llvm-toolchain-focal-10 main' -y
           sudo apt update
-          sudo apt install clang-10 clang-tools llvm kcov g++-10 valgrind libcurl4-openssl-dev
+          sudo apt install clang-10 clang-tools llvm kcov g++-10 valgrind zlib1g-dev libcurl4-openssl-dev
 
       - name: Installing Linux 32-bit Dependencies
         if: ${{ runner.os == 'Linux' && env['TEST_X86'] }}
@@ -109,7 +109,8 @@ jobs:
         if: ${{ contains(env['RUN_ANALYZER'], 'code-checker') }}
         run: |
           sudo apt install clang-tidy curl doxygen gcc-multilib python3-dev python3-virtualenv
-          git clone https://github.com/Ericsson/CodeChecker.git --depth 1
+          sudo apt-get build-dep python3-lxml
+          git clone https://github.com/Ericsson/CodeChecker.git --depth 1 --branch v6.15.0
           cd CodeChecker
           BUILD_LOGGER_64_BIT_ONLY=YES make standalone_package
           echo "$PWD/build/CodeChecker/bin" >> $GITHUB_PATH

--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -489,7 +489,7 @@ sentry__path_read_to_buffer(const sentry_path_t *path, size_t *size_out)
 
     size_t remaining = len;
     size_t offset = 0;
-    while (true) {
+    while (remaining > 0) {
         size_t n = fread(rv + offset, 1, remaining, f);
         if (n == 0) {
             break;

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -145,13 +145,12 @@ def cmake(cwd, targets, options=None):
         cflags.append("-fanalyzer")
     if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
         cflags.append("-fprofile-instr-generate -fcoverage-mapping")
-    cflags = " ".join(cflags)
-    configcmd.append("-DCMAKE_C_FLAGS={}".format(cflags))
-    configcmd.append("-DCMAKE_CXX_FLAGS={}".format(cflags))
+    env = dict(os.environ)
+    env["CFLAGS"] = env["CXXFLAGS"] = " ".join(cflags)
 
     print("\n{} > {}".format(cwd, " ".join(configcmd)), flush=True)
     try:
-        subprocess.run(configcmd, cwd=cwd, check=True)
+        subprocess.run(configcmd, cwd=cwd, env=env, check=True)
     except subprocess.CalledProcessError:
         raise pytest.fail.Exception("cmake configure failed") from None
 

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -145,8 +145,9 @@ def cmake(cwd, targets, options=None):
         cflags.append("-fanalyzer")
     if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
         cflags.append("-fprofile-instr-generate -fcoverage-mapping")
-    configcmd.append('-DCMAKE_CFLAGS="{}"'.format(cflags))
-    configcmd.append('-DCMAKE_CXXFLAGS="{}"'.format(cflags))
+    cflags = " ".join(cflags)
+    configcmd.append("-DCMAKE_C_FLAGS={}".format(cflags))
+    configcmd.append("-DCMAKE_CXX_FLAGS={}".format(cflags))
 
     print("\n{} > {}".format(cwd, " ".join(configcmd)), flush=True)
     try:

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -145,12 +145,12 @@ def cmake(cwd, targets, options=None):
         cflags.append("-fanalyzer")
     if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
         cflags.append("-fprofile-instr-generate -fcoverage-mapping")
-    env = dict(os.environ)
-    env["CFLAGS"] = env["CXXFLAGS"] = " ".join(cflags)
+    configcmd.append('-DCMAKE_CFLAGS="{}"'.format(cflags))
+    configcmd.append('-DCMAKE_CXXFLAGS="{}"'.format(cflags))
 
     print("\n{} > {}".format(cwd, " ".join(configcmd)), flush=True)
     try:
-        subprocess.run(configcmd, cwd=cwd, env=env, check=True)
+        subprocess.run(configcmd, cwd=cwd, check=True)
     except subprocess.CalledProcessError:
         raise pytest.fail.Exception("cmake configure failed") from None
 

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -6,7 +6,7 @@ import time
 import itertools
 import json
 from . import make_dsn, check_output, run, Envelope
-from .conditions import is_asan, has_http, has_breakpad, has_files
+from .conditions import has_http, has_breakpad, has_files
 from .assertions import (
     assert_attachment,
     assert_meta,


### PR DESCRIPTION
Current `master` CI is failing because:

* CodeChecker added another dependency that is not installed. We now pin codechecker and make sure the needed dependency is there.

Plus some minor oneliners that slipped through.