### PR TITLE
Add minimal Qt integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,6 +434,12 @@ elseif(SENTRY_BACKEND_INPROC)
 	target_compile_definitions(sentry PRIVATE SENTRY_WITH_INPROC_BACKEND)
 endif()
 
+option(SENTRY_INTEGRATION_QT "Build Qt integration")
+if(SENTRY_INTEGRATION_QT)
+	find_package(Qt5 COMPONENTS Core REQUIRED)
+	target_link_libraries(sentry PRIVATE Qt5::Core)
+endif()
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(sentry-config.cmake.in sentry-config.cmake
 	INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
   - **none**: This builds `sentry-native` without a backend, so it does not handle
     crashes at all. It is primarily used for tests.
 
+- `SENTRY_INTEGRATION_QT` (Default: OFF):
+  Builds the Qt integration, which turns Qt log messages into breadcrumbs.
+
 - `SENTRY_BREAKPAD_SYSTEM` / `SENTRY_CRASHPAD_SYSTEM` (Default: OFF):
   This instructs the build system to use system-installed breakpad or crashpad
   libraries instead of using the in-tree version. This is generally not recommended

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,3 +136,12 @@ if(WIN32)
 		unwinder/sentry_unwinder_dbghelp.c
 	)
 endif()
+
+# integrations
+if(SENTRY_INTEGRATION_QT)
+	target_compile_definitions(sentry PRIVATE SENTRY_INTEGRATION_QT)
+	sentry_target_sources_cwd(sentry
+		integrations/sentry_integration_qt.cpp
+		integrations/sentry_integration_qt.h
+	)
+endif()

--- a/src/integrations/sentry_integration_qt.cpp
+++ b/src/integrations/sentry_integration_qt.cpp
@@ -1,0 +1,59 @@
+#include "sentry_integration_qt.h"
+#include "sentry_boot.h"
+
+#include <QtCore/qglobal.h>
+#include <QtCore/qstring.h>
+
+static QtMessageHandler originalMessageHandler = nullptr;
+
+static const char *
+logLevelForMessageType(QtMsgType msgType)
+{
+    switch (msgType) {
+    case QtDebugMsg:
+        return "debug";
+    case QtWarningMsg:
+        return "warning";
+    case QtCriticalMsg:
+        return "error";
+    case QtFatalMsg:
+        return "fatal";
+    case QtInfoMsg:
+        Q_FALLTHROUGH();
+    default:
+        return "info";
+    }
+}
+
+static void
+sentry_qt_messsage_handler(
+    QtMsgType type, const QMessageLogContext &context, const QString &message)
+{
+    sentry_value_t crumb
+        = sentry_value_new_breadcrumb("default", qUtf8Printable(message));
+
+    sentry_value_set_by_key(
+        crumb, "category", sentry_value_new_string(context.category));
+    sentry_value_set_by_key(
+        crumb, "level", sentry_value_new_string(logLevelForMessageType(type)));
+
+    sentry_value_t location = sentry_value_new_object();
+    sentry_value_set_by_key(
+        location, "file", sentry_value_new_string(context.file));
+    sentry_value_set_by_key(
+        location, "line", sentry_value_new_int32(context.line));
+    sentry_value_set_by_key(crumb, "data", location);
+
+    sentry_add_breadcrumb(crumb);
+
+    // Don't interfere with normal logging, by forwarding
+    // to any existing message handlers.
+    if (originalMessageHandler)
+        originalMessageHandler(type, context, message);
+}
+
+void
+sentry_integration_setup_qt(void)
+{
+    originalMessageHandler = qInstallMessageHandler(sentry_qt_messsage_handler);
+}

--- a/src/integrations/sentry_integration_qt.h
+++ b/src/integrations/sentry_integration_qt.h
@@ -1,0 +1,15 @@
+#ifndef SENTRY_INTEGRATION_QT_H_INCLUDED
+#define SENTRY_INTEGRATION_QT_H_INCLUDED
+
+#ifdef __cplusplus
+#    define C_API extern "C"
+#else
+#    define C_API
+#endif
+
+/**
+ * This sets up the Qt integration.
+ */
+C_API void sentry_integration_setup_qt(void);
+
+#endif

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -19,6 +19,10 @@
 #include "sentry_transport.h"
 #include "sentry_value.h"
 
+#ifdef SENTRY_INTEGRATION_QT
+#    include "integrations/sentry_integration_qt.h"
+#endif
+
 static sentry_options_t *g_options = NULL;
 static sentry_mutex_t g_options_lock = SENTRY__MUTEX_INIT;
 
@@ -149,6 +153,11 @@ sentry_init(sentry_options_t *options)
     if (backend && backend->user_consent_changed_func) {
         backend->user_consent_changed_func(backend);
     }
+
+#ifdef SENTRY_INTEGRATION_QT
+    SENTRY_TRACE("setting up Qt integration");
+    sentry_integration_setup_qt();
+#endif
 
     // after initializing the transport, we will submit all the unsent envelopes
     // and handle remaining sessions.


### PR DESCRIPTION
The integration turns Qt logging via e.g. qDebug() into breadcrumbs.

Enable the integration by passing -DSENTRY_INTEGRATION_QT=ON during
configure time. This will add a runtime dependency on the QtCore
library to sentry.
