### PR TITLE
feat: expose sentry-native version to CMake project and package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,17 @@ else()
 	cmake_minimum_required (VERSION 3.10)
 endif()
 
-project(Sentry-Native LANGUAGES C CXX ASM)
+#read sentry-native version
+file(READ "include/sentry.h" _SENTRY_HEADER_CONTENT)
+string(REGEX MATCH "#define SENTRY_SDK_VERSION \"([0-9\.]+)\"" _SENTRY_VERSION_MATCH "${_SENTRY_HEADER_CONTENT}")
+set(SENTRY_VERSION "${CMAKE_MATCH_1}")
+unset(_SENTRY_HEADER_CONTENT)
+unset(_SENTRY_VERSION_MATCH)
+
+project(Sentry-Native 
+	LANGUAGES C CXX ASM 
+	VERSION ${SENTRY_VERSION}
+)
 
 set(SENTRY_MAIN_PROJECT OFF)
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
@@ -443,6 +453,9 @@ endif()
 include(CMakePackageConfigHelpers)
 configure_package_config_file(sentry-config.cmake.in sentry-config.cmake
 	INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
+write_basic_package_version_file(sentry-config-version.cmake 
+	VERSION ${SENTRY_VERSION}
+	COMPATIBILITY AnyNewerVersion)
 
 sentry_install(TARGETS sentry EXPORT sentry
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -452,7 +465,10 @@ sentry_install(TARGETS sentry EXPORT sentry
 )
 sentry_install(EXPORT sentry NAMESPACE sentry:: FILE sentry-targets.cmake
 	DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
-sentry_install(FILES "${PROJECT_BINARY_DIR}/sentry-config.cmake"
+sentry_install(
+	FILES 
+		"${PROJECT_BINARY_DIR}/sentry-config.cmake"
+		"${PROJECT_BINARY_DIR}/sentry-config-version.cmake"
 	DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
 if(WIN32 AND MSVC AND SENTRY_BUILD_SHARED_LIBS)
 	sentry_install(FILES $<TARGET_PDB_FILE:sentry> 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,9 +453,18 @@ endif()
 include(CMakePackageConfigHelpers)
 configure_package_config_file(sentry-config.cmake.in sentry-config.cmake
 	INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
+
+# generate package version file
+# use semver behavior: SameMinorVersion for 0.x.x, SameMajorVersion for 1.x.x or greater
+if(${PROJECT_VERSION_MAJOR} EQUAL 0)
+	set(_SENTRY_VERSION_COMPATIBILITY SameMinorVersion)
+else()
+	message(AUTHOR_WARNING "sentry-native reaches 1.0.0, simplify this code")
+	set(_SENTRY_VERSION_COMPATIBILITY SameMajorVersion)
+endif()
 write_basic_package_version_file(sentry-config-version.cmake 
 	VERSION ${SENTRY_VERSION}
-	COMPATIBILITY AnyNewerVersion)
+	COMPATIBILITY ${_SENTRY_VERSION_COMPATIBILITY})
 
 sentry_install(TARGETS sentry EXPORT sentry
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"


### PR DESCRIPTION
* expose sentry-native version to CMake project, fixes #460 

* expose sentry-native version to CMake package, it allows things like

CMakeLists.txt
```
...
find_package(sentry 0.4.5)
...
```

CMake output
```
CMake Warning at CMakeLists.txt:4 (find_package):
  Could not find a configuration file for package "sentry" that is compatible with requested version "0.4.5".
  The following configuration files were considered but not accepted:
    D:/Projects/VCS/github/getsentry.sentry-native/~install/lib/cmake/sentry/sentry-config.cmake, version: 0.4.4
```