### PR TITLE
Fix typo in `sentry_options_get_max_breadcrumbs`.

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -759,7 +759,7 @@ SENTRY_API void sentry_options_set_max_breadcrumbs(
     sentry_options_t *opts, size_t max_breadcrumbs);
 
 /**
- * Sets the number of breadcrumbs being tracked and attached to events.
+ * Gets the number of breadcrumbs being tracked and attached to events.
  */
 SENTRY_API size_t sentry_options_get_max_breadcrumbs(
     const sentry_options_t *opts);


### PR DESCRIPTION
Just found a small typo :wink:.
