### PR TITLE
feat: cleanup platform libraries linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ option(SENTRY_PIC "Build sentry (and dependent) libraries as position independen
 option(SENTRY_BUILD_TESTS "Build sentry-native tests" "${SENTRY_MAIN_PROJECT}")
 option(SENTRY_BUILD_EXAMPLES "Build sentry-native example(s)" "${SENTRY_MAIN_PROJECT}")
 
+option(SENTRY_LINK_THREADS "Link platform threads library" ON) 
+if(SENTRY_LINK_THREADS)
+	find_package(Threads REQUIRED)
+endif()
+
 if(MSVC)
 	option(SENTRY_BUILD_RUNTIMESTATIC "Build sentry-native with static runtime" OFF)
 endif()
@@ -340,19 +345,29 @@ if(WIN32)
 	endif()
 endif()
 
-if(LINUX)
-	option(SENTRY_LINK_PTHREAD "Link Sentry with pthread" ON)
-	if(SENTRY_LINK_PTHREAD)
-		target_link_libraries(sentry PRIVATE pthread)
-	endif()
-	target_link_libraries(sentry PRIVATE dl)
-	target_link_libraries(sentry PRIVATE rt)
-elseif(ANDROID)
-	target_link_libraries(sentry PRIVATE dl log)
-elseif(MSVC)
-	target_link_libraries(sentry PRIVATE dbghelp version)
-elseif(MINGW)
-	target_link_libraries(sentry PRIVATE dbghelp version)
+#handle platform libraries
+if(ANDROID)
+    set(_SENTRY_PLATFORM_LIBS "dl" "log")
+elseif(LINUX) 
+    set(_SENTRY_PLATFORM_LIBS "dl" "rt")
+elseif(WIN32)
+    set(_SENTRY_PLATFORM_LIBS "dbghelp" "version")
+endif()
+
+#handle platform threads library
+if(SENTRY_LINK_THREADS)
+	list(APPEND _SENTRY_PLATFORM_LIBS "Threads::Threads")
+endif()
+
+#apply platform libraries to sentry library
+if(SENTRY_LIBRARY_TYPE STREQUAL "static")
+    target_link_libraries(sentry PUBLIC ${_SENTRY_PLATFORM_LIBS}) 
+else()
+    target_link_libraries(sentry PRIVATE ${_SENTRY_PLATFORM_LIBS})
+endif()
+
+#suppress some errors and warnings for MinGW target
+if(MINGW)
 	target_compile_options(sentry PRIVATE
 		-Wno-unused-variable
 		-Wno-unused-parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ option(SENTRY_PIC "Build sentry (and dependent) libraries as position independen
 option(SENTRY_BUILD_TESTS "Build sentry-native tests" "${SENTRY_MAIN_PROJECT}")
 option(SENTRY_BUILD_EXAMPLES "Build sentry-native example(s)" "${SENTRY_MAIN_PROJECT}")
 
-option(SENTRY_LINK_THREADS "Link platform threads library" ON) 
-if(SENTRY_LINK_THREADS)
+option(SENTRY_LINK_PTHREAD "Link platform threads library" ON)
+if(SENTRY_LINK_PTHREAD)
 	find_package(Threads REQUIRED)
 endif()
 
@@ -345,28 +345,28 @@ if(WIN32)
 	endif()
 endif()
 
-#handle platform libraries
+# handle platform libraries
 if(ANDROID)
     set(_SENTRY_PLATFORM_LIBS "dl" "log")
-elseif(LINUX) 
+elseif(LINUX)
     set(_SENTRY_PLATFORM_LIBS "dl" "rt")
 elseif(WIN32)
     set(_SENTRY_PLATFORM_LIBS "dbghelp" "version")
 endif()
 
-#handle platform threads library
-if(SENTRY_LINK_THREADS)
+# handle platform threads library
+if(SENTRY_LINK_PTHREAD)
 	list(APPEND _SENTRY_PLATFORM_LIBS "Threads::Threads")
 endif()
 
-#apply platform libraries to sentry library
+# apply platform libraries to sentry library
 if(SENTRY_LIBRARY_TYPE STREQUAL "static")
-    target_link_libraries(sentry PUBLIC ${_SENTRY_PLATFORM_LIBS}) 
+    target_link_libraries(sentry PUBLIC ${_SENTRY_PLATFORM_LIBS})
 else()
     target_link_libraries(sentry PRIVATE ${_SENTRY_PLATFORM_LIBS})
 endif()
 
-#suppress some errors and warnings for MinGW target
+# suppress some errors and warnings for MinGW target
 if(MINGW)
 	target_compile_options(sentry PRIVATE
 		-Wno-unused-variable

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 - `SENTRY_BUILD_RUNTIMESTATIC` (Default: OFF):
   Enables linking with the static MSVC runtime. Has no effect if the compiler is not MSVC.
 
-- `SENTRY_LINK_PTHREAD` (Default: ON):
-  Links to the `pthread` library on unix targets.
+- `SENTRY_LINK_THREADS` (Default: ON):
+  Links platform threads library like `pthread` on unix targets.
 
 - `SENTRY_BUILD_FORCE32` (Default: OFF):
   Forces cross-compilation from 64-bit host to 32-bit target. Only has an effect on Linux.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 - `SENTRY_BUILD_RUNTIMESTATIC` (Default: OFF):
   Enables linking with the static MSVC runtime. Has no effect if the compiler is not MSVC.
 
-- `SENTRY_LINK_THREADS` (Default: ON):
+- `SENTRY_LINK_PTHREAD` (Default: ON):
   Links platform threads library like `pthread` on unix targets.
 
 - `SENTRY_BUILD_FORCE32` (Default: OFF):


### PR DESCRIPTION
Fixes possible issues with static sentry-native library.

References https://github.com/getsentry/sentry-native/issues/477