### PR TITLE
Fix MinGW / Clang 'missing-field-initializers' warning

### DIFF
--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -127,7 +127,7 @@ static inline uint64_t
 sentry__monotonic_time(void)
 {
 #ifdef SENTRY_PLATFORM_WINDOWS
-    static LARGE_INTEGER qpc_frequency = { 0 };
+    static LARGE_INTEGER qpc_frequency = { {0,0} };
 
     if (!qpc_frequency.QuadPart) {
         QueryPerformanceFrequency(&qpc_frequency);

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -127,7 +127,7 @@ static inline uint64_t
 sentry__monotonic_time(void)
 {
 #ifdef SENTRY_PLATFORM_WINDOWS
-    static LARGE_INTEGER qpc_frequency = { {0,0} };
+    static LARGE_INTEGER qpc_frequency = { { 0, 0 } };
 
     if (!qpc_frequency.QuadPart) {
         QueryPerformanceFrequency(&qpc_frequency);


### PR DESCRIPTION
Fixes #454. 'Should have made that pull request a long time ago !