### PR TITLE
ref: Optimize jsonwriter to allocate less in some cases

### DIFF
--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -108,7 +108,7 @@ bool
 sentry__run_write_session(
     const sentry_run_t *run, const sentry_session_t *session)
 {
-    sentry_jsonwriter_t *jw = sentry__jsonwriter_new_in_memory();
+    sentry_jsonwriter_t *jw = sentry__jsonwriter_new(NULL);
     if (!jw) {
         return false;
     }

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -212,11 +212,17 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
         return NULL;
     }
 
+    sentry_jsonwriter_t *jw = sentry__jsonwriter_new(NULL);
+    if (!jw) {
+        return NULL;
+    }
+
     sentry_value_t event_id = sentry__ensure_event_id(event, NULL);
 
     item->event = event;
-    item->payload = sentry_value_to_json(event);
-    item->payload_len = strlen(item->payload);
+    sentry__value_write_into_jsonwriter(jw, event);
+    item->payload = sentry__jsonwriter_into_string(jw, &item->payload_len);
+
     sentry__envelope_item_set_header(
         item, "type", sentry_value_new_string("event"));
     sentry_value_t length = sentry_value_new_int32((int32_t)item->payload_len);
@@ -235,7 +241,7 @@ sentry__envelope_add_session(
     if (!envelope || !session) {
         return NULL;
     }
-    sentry_jsonwriter_t *jw = sentry__jsonwriter_new_in_memory();
+    sentry_jsonwriter_t *jw = sentry__jsonwriter_new(NULL);
     if (!jw) {
         return NULL;
     }
@@ -281,20 +287,28 @@ static void
 sentry__envelope_serialize_headers_into_stringbuilder(
     const sentry_envelope_t *envelope, sentry_stringbuilder_t *sb)
 {
-    char *buf = sentry_value_to_json(envelope->contents.items.headers);
-    sentry__stringbuilder_append(sb, buf);
-    sentry_free(buf);
+    sentry_jsonwriter_t *jw = sentry__jsonwriter_new(sb);
+    if (jw) {
+        sentry__value_write_into_jsonwriter(
+            jw, envelope->contents.items.headers);
+        sentry__jsonwriter_free(jw);
+    }
 }
 
 static void
 sentry__envelope_serialize_item_into_stringbuilder(
     const sentry_envelope_item_t *item, sentry_stringbuilder_t *sb)
 {
+    sentry_jsonwriter_t *jw = sentry__jsonwriter_new(sb);
+    if (!jw) {
+        return;
+    }
     sentry__stringbuilder_append_char(sb, '\n');
-    char *buf = sentry_value_to_json(item->headers);
-    sentry__stringbuilder_append(sb, buf);
+
+    sentry__value_write_into_jsonwriter(jw, item->headers);
+    sentry__jsonwriter_free(jw);
+
     sentry__stringbuilder_append_char(sb, '\n');
-    sentry_free(buf);
 
     sentry__stringbuilder_append_buf(sb, item->payload, item->payload_len);
 }

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -220,7 +220,7 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
     sentry_value_t event_id = sentry__ensure_event_id(event, NULL);
 
     item->event = event;
-    sentry__value_write_into_jsonwriter(jw, event);
+    sentry__jsonwriter_write_value(jw, event);
     item->payload = sentry__jsonwriter_into_string(jw, &item->payload_len);
 
     sentry__envelope_item_set_header(
@@ -289,8 +289,7 @@ sentry__envelope_serialize_headers_into_stringbuilder(
 {
     sentry_jsonwriter_t *jw = sentry__jsonwriter_new(sb);
     if (jw) {
-        sentry__value_write_into_jsonwriter(
-            jw, envelope->contents.items.headers);
+        sentry__jsonwriter_write_value(jw, envelope->contents.items.headers);
         sentry__jsonwriter_free(jw);
     }
 }
@@ -305,7 +304,7 @@ sentry__envelope_serialize_item_into_stringbuilder(
     }
     sentry__stringbuilder_append_char(sb, '\n');
 
-    sentry__value_write_into_jsonwriter(jw, item->headers);
+    sentry__jsonwriter_write_value(jw, item->headers);
     sentry__jsonwriter_free(jw);
 
     sentry__stringbuilder_append_char(sb, '\n');

--- a/src/sentry_json.h
+++ b/src/sentry_json.h
@@ -3,13 +3,16 @@
 
 #include "sentry_boot.h"
 
-struct sentry_jsonwriter_s;
+typedef struct sentry_stringbuilder_s sentry_stringbuilder_t;
 typedef struct sentry_jsonwriter_s sentry_jsonwriter_t;
 
 /**
- * This creates a new in-memory JSON writer, based on `sentry_stringbuilder_s`.
+ * This creates a new JSON writer.
+ *
+ * It will use an existing `sentry_stringbuilder_t` as its output if one is
+ * provided, otherwise it will allocate a new one.
  */
-sentry_jsonwriter_t *sentry__jsonwriter_new_in_memory(void);
+sentry_jsonwriter_t *sentry__jsonwriter_new(sentry_stringbuilder_t *sb);
 
 /**
  * Deallocates a JSON writer.

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -795,8 +795,7 @@ sentry_value_is_null(sentry_value_t value)
 }
 
 void
-sentry__value_write_into_jsonwriter(
-    sentry_jsonwriter_t *jw, sentry_value_t value)
+sentry__jsonwriter_write_value(sentry_jsonwriter_t *jw, sentry_value_t value)
 {
     switch (sentry_value_get_type(value)) {
     case SENTRY_VALUE_TYPE_NULL:
@@ -818,7 +817,7 @@ sentry__value_write_into_jsonwriter(
         const list_t *l = value_as_thing(value)->payload._ptr;
         sentry__jsonwriter_write_list_start(jw);
         for (size_t i = 0; i < l->len; i++) {
-            sentry__value_write_into_jsonwriter(jw, l->items[i]);
+            sentry__jsonwriter_write_value(jw, l->items[i]);
         }
         sentry__jsonwriter_write_list_end(jw);
         break;
@@ -828,7 +827,7 @@ sentry__value_write_into_jsonwriter(
         sentry__jsonwriter_write_object_start(jw);
         for (size_t i = 0; i < o->len; i++) {
             sentry__jsonwriter_write_key(jw, o->pairs[i].k);
-            sentry__value_write_into_jsonwriter(jw, o->pairs[i].v);
+            sentry__jsonwriter_write_value(jw, o->pairs[i].v);
         }
         sentry__jsonwriter_write_object_end(jw);
         break;
@@ -843,7 +842,7 @@ sentry_value_to_json(sentry_value_t value)
     if (!jw) {
         return NULL;
     }
-    sentry__value_write_into_jsonwriter(jw, value);
+    sentry__jsonwriter_write_value(jw, value);
     return sentry__jsonwriter_into_string(jw, NULL);
 }
 

--- a/src/sentry_value.h
+++ b/src/sentry_value.h
@@ -85,7 +85,7 @@ typedef struct sentry_jsonwriter_s sentry_jsonwriter_t;
 /**
  * Writes the given `value` into the `jsonwriter`.
  */
-void sentry__value_write_into_jsonwriter(
+void sentry__jsonwriter_write_value(
     sentry_jsonwriter_t *jw, sentry_value_t value);
 
 #endif

--- a/src/sentry_value.h
+++ b/src/sentry_value.h
@@ -80,4 +80,12 @@ int sentry__value_append_bounded(
  */
 sentry_value_t sentry__value_from_json(const char *buf, size_t buflen);
 
+typedef struct sentry_jsonwriter_s sentry_jsonwriter_t;
+
+/**
+ * Writes the given `value` into the `jsonwriter`.
+ */
+void sentry__value_write_into_jsonwriter(
+    sentry_jsonwriter_t *jw, sentry_value_t value);
+
 #endif


### PR DESCRIPTION
Refactors the jsonwriter a bit, taking an existing stringwrite where possible to avoid intermediate allocations.