### PR TITLE
Fix building on ppc64 and ppc64le

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -377,7 +377,7 @@ try_append_module(sentry_value_t modules, const sentry_module_t *module)
 #if defined(__i386) || defined(__ARM_EABI__)                                   \
     || (defined(__mips__) && _MIPS_SIM == _ABIO32)
 typedef Elf32_auxv_t elf_aux_entry;
-#elif defined(__x86_64) || defined(__aarch64__)                                \
+#elif defined(__x86_64) || defined(__aarch64__) || defined(__powerpc64__)      \
     || (defined(__mips__) && _MIPS_SIM != _ABIO32)
 typedef Elf64_auxv_t elf_aux_entry;
 #endif


### PR DESCRIPTION
Fixes errors about missing type `elf_aux_entry`
Tested on ppc64le (POWER9).