### PR TITLE
fix: Use valgrind correctly and fix a leak

### DIFF
--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -328,6 +328,7 @@ sentry__bgworker_shutdown(sentry_bgworker_t *bgw, uint64_t timeout)
             sentry__mutex_unlock(&bgw->task_lock);
             SENTRY_WARN(
                 "background thread failed to shut down cleanly within timeout");
+            sentry__thread_detach(bgw->thread_id);
             return 1;
         }
 

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -163,6 +163,7 @@ typedef struct sentry__winmutex_s sentry_mutex_t;
             *ThreadId == INVALID_HANDLE_VALUE ? 1 : 0)
 #    define sentry__thread_join(ThreadId)                                      \
         WaitForSingleObject(ThreadId, INFINITE)
+#    define sentry__thread_detach(ThreadId) (void)ThreadId
 #    define sentry__thread_free(ThreadId)                                      \
         do {                                                                   \
             if (*ThreadId != INVALID_HANDLE_VALUE) {                           \
@@ -257,6 +258,7 @@ typedef pthread_cond_t sentry_cond_t;
 #    define sentry__thread_spawn(ThreadId, Func, Data)                         \
         (pthread_create(ThreadId, NULL, Func, Data) == 0 ? 0 : 1)
 #    define sentry__thread_join(ThreadId) pthread_join(ThreadId, NULL)
+#    define sentry__thread_detach(ThreadId) pthread_detach(ThreadId)
 #    define sentry__thread_free sentry__thread_init
 #    define sentry__threadid_equal pthread_equal
 #    define sentry__current_thread pthread_self

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -80,7 +80,15 @@ def run(cwd, exe, args, env=dict(os.environ), **kwargs):
             *cmd,
         ]
     if "valgrind" in os.environ.get("RUN_ANALYZER", ""):
-        cmd = ["valgrind", "--leak-check=yes", *cmd]
+        cmd = [
+            "valgrind",
+            "--suppressions={}".format(
+                os.path.join(sourcedir, "tests", "valgrind.txt")
+            ),
+            "--error-exitcode=33",
+            "--leak-check=yes",
+            *cmd,
+        ]
     try:
         return subprocess.run([*cmd, *args], cwd=cwd, env=env, **kwargs)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
It seems pthreads are cleaned up in `join`, except when they are
`detached`, in which case they clean up after themselves.