### PR TITLE
fix: Tighten up a few snprintf usages

### DIFF
--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -367,21 +367,22 @@ sentry__msec_time_to_iso8601(uint64_t time)
     struct tm tm_buf;
     tm = gmtime_r(&secs, &tm_buf);
 #endif
-    size_t written = strftime(buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", tm);
+    size_t written = strftime(buf, buf_len, "%Y-%m-%dT%H:%M:%S", tm);
     if (written == 0) {
         return NULL;
     }
 
     int msecs = time % 1000;
     if (msecs) {
-        int rv = snprintf(buf + written, buf_len - written, ".%03d", msecs);
-        if (rv < 0 || rv >= buf_len - written) {
+        size_t rv = (size_t)snprintf(
+            buf + written, buf_len - written, ".%03d", msecs);
+        if (rv >= buf_len - written) {
             return NULL;
         }
         written += rv;
     }
 
-    if (buf_len - written < 2) {
+    if (written + 2 > buf_len) {
         return NULL;
     }
     buf[written] = 'Z';

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -358,6 +358,7 @@ char *
 sentry__msec_time_to_iso8601(uint64_t time)
 {
     char buf[255];
+    size_t buf_len = sizeof(buf);
     time_t secs = time / 1000;
     struct tm *tm;
 #ifdef SENTRY_PLATFORM_WINDOWS
@@ -366,14 +367,25 @@ sentry__msec_time_to_iso8601(uint64_t time)
     struct tm tm_buf;
     tm = gmtime_r(&secs, &tm_buf);
 #endif
-    size_t end = strftime(buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", tm);
+    size_t written = strftime(buf, sizeof buf, "%Y-%m-%dT%H:%M:%S", tm);
+    if (written == 0) {
+        return NULL;
+    }
 
     int msecs = time % 1000;
     if (msecs) {
-        snprintf(buf + end, 10, ".%03d", msecs);
+        int rv = snprintf(buf + written, buf_len - written, ".%03d", msecs);
+        if (rv < 0 || rv >= buf_len - written) {
+            return NULL;
+        }
+        written += rv;
     }
 
-    strcat(buf, "Z");
+    if (buf_len - written < 2) {
+        return NULL;
+    }
+    buf[written] = 'Z';
+    buf[written + 1] = '\0';
     return sentry__string_clone(buf);
 }
 

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -545,7 +545,12 @@ sentry__value_stringify(sentry_value_t value)
         return sentry__string_clone(sentry_value_as_string(value));
     default: {
         char buf[50];
-        snprintf(buf, sizeof(buf), "%g", sentry_value_as_double(value));
+        int written = sentry__snprintf_c(
+            buf, sizeof(buf), "%g", sentry_value_as_double(value));
+        if (written < 0 || written >= sizeof(buf)) {
+            return sentry__string_clone("");
+        }
+        buf[written] = '\0';
         return sentry__string_clone(buf);
     }
     }
@@ -927,21 +932,34 @@ sentry_value_t
 sentry__value_new_addr(uint64_t addr)
 {
     char buf[100];
-    snprintf(buf, sizeof(buf), "0x%llx", (unsigned long long)addr);
+    int written
+        = snprintf(buf, sizeof(buf), "0x%llx", (unsigned long long)addr);
+    if (written < 0 || written >= sizeof(buf)) {
+        return sentry_value_new_null();
+    }
+    buf[written] = '\0';
     return sentry_value_new_string(buf);
 }
 
 sentry_value_t
 sentry__value_new_hexstring(const uint8_t *bytes, size_t len)
 {
-    char *buf = sentry_malloc(len * 2 + 1);
+    size_t buf_len = len * 2 + 1;
+    char *buf = sentry_malloc(buf_len);
     if (!buf) {
         return sentry_value_new_null();
     }
-    char *ptr = buf;
+    size_t written = 0;
+
     for (size_t i = 0; i < len; i++) {
-        ptr += snprintf(ptr, 3, "%02hhx", bytes[i]);
+        int rv = snprintf(buf + written, buf_len - written, "%02hhx", bytes[i]);
+        if (rv < 0 || rv >= buf_len - written) {
+            sentry_free(buf);
+            return sentry_value_new_null();
+        }
+        written += rv;
     }
+    buf[written] = '\0';
     return sentry__value_new_string_owned(buf);
 }
 
@@ -953,6 +971,7 @@ sentry__value_new_uuid(const sentry_uuid_t *uuid)
         return sentry_value_new_null();
     }
     sentry_uuid_as_string(uuid, buf);
+    buf[36] = '\0';
     return sentry__value_new_string_owned(buf);
 }
 

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -545,9 +545,9 @@ sentry__value_stringify(sentry_value_t value)
         return sentry__string_clone(sentry_value_as_string(value));
     default: {
         char buf[50];
-        int written = sentry__snprintf_c(
+        size_t written = (size_t)sentry__snprintf_c(
             buf, sizeof(buf), "%g", sentry_value_as_double(value));
-        if (written < 0 || written >= sizeof(buf)) {
+        if (written >= sizeof(buf)) {
             return sentry__string_clone("");
         }
         buf[written] = '\0';
@@ -932,9 +932,9 @@ sentry_value_t
 sentry__value_new_addr(uint64_t addr)
 {
     char buf[100];
-    int written
-        = snprintf(buf, sizeof(buf), "0x%llx", (unsigned long long)addr);
-    if (written < 0 || written >= sizeof(buf)) {
+    size_t written = (size_t)snprintf(
+        buf, sizeof(buf), "0x%llx", (unsigned long long)addr);
+    if (written >= sizeof(buf)) {
         return sentry_value_new_null();
     }
     buf[written] = '\0';
@@ -952,8 +952,9 @@ sentry__value_new_hexstring(const uint8_t *bytes, size_t len)
     size_t written = 0;
 
     for (size_t i = 0; i < len; i++) {
-        int rv = snprintf(buf + written, buf_len - written, "%02hhx", bytes[i]);
-        if (rv < 0 || rv >= buf_len - written) {
+        size_t rv = (size_t)snprintf(
+            buf + written, buf_len - written, "%02hhx", bytes[i]);
+        if (rv >= buf_len - written) {
             sentry_free(buf);
             return sentry_value_new_null();
         }

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -144,8 +144,11 @@ sentry__curl_send_task(void *_envelope, void *_state)
     headers = curl_slist_append(headers, "expect:");
     for (size_t i = 0; i < req->headers_len; i++) {
         char buf[255];
-        snprintf(buf, sizeof(buf), "%s:%s", req->headers[i].key,
+        int written = snprintf(buf, sizeof(buf), "%s:%s", req->headers[i].key,
             req->headers[i].value);
+        if (written < 0 || written >= sizeof(buf)) {
+            continue;
+        }
         headers = curl_slist_append(headers, buf);
     }
 

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -144,11 +144,12 @@ sentry__curl_send_task(void *_envelope, void *_state)
     headers = curl_slist_append(headers, "expect:");
     for (size_t i = 0; i < req->headers_len; i++) {
         char buf[255];
-        int written = snprintf(buf, sizeof(buf), "%s:%s", req->headers[i].key,
-            req->headers[i].value);
-        if (written < 0 || written >= sizeof(buf)) {
+        size_t written = (size_t)snprintf(buf, sizeof(buf), "%s:%s",
+            req->headers[i].key, req->headers[i].value);
+        if (written >= sizeof(buf)) {
             continue;
         }
+        buf[written] = '\0';
         headers = curl_slist_append(headers, buf);
     }
 


### PR DESCRIPTION
Check the return value in more places, and handle errors better.
Also, explicitly null-terminate in more places as some implementations
might not be well behaved.