### PR TITLE
fix: Windows SDK Compiler Warning

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -98,4 +98,8 @@ target_link_libraries(sentry_fuzz_json PRIVATE
 	"$<$<PLATFORM_ID:Linux>:rt>"
 )
 
+if(MSVC)
+	target_compile_options(sentry_fuzz_json PRIVATE $<BUILD_INTERFACE:/wd5105>)
+endif()
+
 add_test(NAME sentry_fuzz_json COMMAND sentry_fuzz_json)

--- a/tests/unit/fuzz.c
+++ b/tests/unit/fuzz.c
@@ -18,10 +18,11 @@ afl-fuzz -i fuzzing-examples -o fuzzing-results -- fuzzing/sentry_fuzz_json @@
 
 #undef NDEBUG
 
+#include "sentry.h"
+
 #include <assert.h>
 #include <string.h>
 
-#include "sentry.h"
 #include "sentry_json.h"
 #include "sentry_path.h"
 #include "sentry_value.h"

--- a/tests/unit/fuzz.c
+++ b/tests/unit/fuzz.c
@@ -18,6 +18,12 @@ afl-fuzz -i fuzzing-examples -o fuzzing-results -- fuzzing/sentry_fuzz_json @@
 
 #undef NDEBUG
 
+#ifdef _WIN32
+#    define WIN32_LEAN_AND_MEAN
+#    define NOMINMAX
+#    define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "sentry.h"
 
 #include <assert.h>


### PR DESCRIPTION
Doing the same as in #428.
The Windows Compiler suddenly started tripping over its own SDK headers after a CI update.