### PR TITLE
feat: Add more Event Payload convenience methods

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -173,7 +173,7 @@ main(int argc, char **argv)
             sentry_value_set_by_key(exc, "stacktrace", stacktrace);
         }
         sentry_value_t event = sentry_value_new_event();
-        sentry_event_value_add_exception(event, exc);
+        sentry_event_add_exception(event, exc);
 
         sentry_capture_event(event);
     }

--- a/examples/example.c
+++ b/examples/example.c
@@ -166,21 +166,14 @@ main(int argc, char **argv)
         sentry_capture_event(event);
     }
     if (has_arg(argc, argv, "capture-exception")) {
-        // TODO: Create a convenience API to create a new exception object,
-        // and to attach a stacktrace to the exception.
-        // See also https://github.com/getsentry/sentry-native/issues/235
+        sentry_value_t exc = sentry_value_new_exception(
+            "ParseIntError", "invalid digit found in string");
+        if (has_arg(argc, argv, "add-stacktrace")) {
+            sentry_value_t stacktrace = sentry_value_new_stacktrace(NULL, 0);
+            sentry_value_set_by_key(exc, "stacktrace", stacktrace);
+        }
         sentry_value_t event = sentry_value_new_event();
-        sentry_value_t exception = sentry_value_new_object();
-        // for example:
-        sentry_value_set_by_key(
-            exception, "type", sentry_value_new_string("ParseIntError"));
-        sentry_value_set_by_key(exception, "value",
-            sentry_value_new_string("invalid digit found in string"));
-        sentry_value_t exceptions = sentry_value_new_list();
-        sentry_value_append(exceptions, exception);
-        sentry_value_t values = sentry_value_new_object();
-        sentry_value_set_by_key(values, "values", exceptions);
-        sentry_value_set_by_key(event, "exception", values);
+        sentry_event_value_add_exception(event, exc);
 
         sentry_capture_event(event);
     }

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -340,7 +340,9 @@ typedef enum sentry_level_e {
 /**
  * Creates a new empty Event value.
  *
- * See https://develop.sentry.dev/sdk/event-payloads/
+ * See https://docs.sentry.io/platforms/native/enriching-events/ for how to
+ * further work with events, and https://develop.sentry.dev/sdk/event-payloads/
+ * for a detailed overview of the possible properties of an Event.
  */
 SENTRY_API sentry_value_t sentry_value_new_event(void);
 
@@ -366,6 +368,10 @@ SENTRY_API sentry_value_t sentry_value_new_breadcrumb(
 
 /**
  * Creates a new Exception value.
+ *
+ * This is intended for capturing language-level exception, such as from a
+ * try-catch block. `type` and `value` here refer to the exception class and
+ * a possible description.
  *
  * See https://develop.sentry.dev/sdk/event-payloads/exception/
  *

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -338,12 +338,16 @@ typedef enum sentry_level_e {
 } sentry_level_t;
 
 /**
- * Creates a new empty event value.
+ * Creates a new empty Event value.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/
  */
 SENTRY_API sentry_value_t sentry_value_new_event(void);
 
 /**
- * Creates a new message event value.
+ * Creates a new Message Event value.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/message/
  *
  * `logger` can be NULL to omit the logger value.
  */
@@ -351,12 +355,68 @@ SENTRY_API sentry_value_t sentry_value_new_message_event(
     sentry_level_t level, const char *logger, const char *text);
 
 /**
- * Creates a new breadcrumb with a specific type and message.
+ * Creates a new Breadcrumb with a specific type and message.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
  *
  * Either parameter can be NULL in which case no such attributes is created.
  */
 SENTRY_API sentry_value_t sentry_value_new_breadcrumb(
     const char *type, const char *message);
+
+/**
+ * Creates a new Exception value.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/exception/
+ *
+ * The returned value needs to be attached to an event via
+ * `sentry_event_value_add_exception`.
+ */
+SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_exception(
+    const char *type, const char *value);
+
+/**
+ * Creates a new Thread value.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/threads/
+ *
+ * The returned value needs to be attached to an event via
+ * `sentry_event_value_add_thread`.
+ *
+ * `name` can be NULL.
+ */
+SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_thread(
+    uint64_t id, const char *name);
+
+/**
+ * Creates a new Stack Trace conforming to the Stack Trace Interface.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/stacktrace/
+ *
+ * The returned object needs to be attached to either an exception
+ * event, or a thread object.
+ *
+ * If `ips` is NULL the current stacktrace is captured, otherwise `len`
+ * stacktrace instruction pointers are attached to the event.
+ */
+SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_stacktrace(
+    void **ips, size_t len);
+
+/**
+ * Adds an Exception to an Event value.
+ *
+ * This takes ownership of the `exception`.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_event_value_add_exception(
+    sentry_value_t event, sentry_value_t exception);
+
+/**
+ * Adds a Thread to an Event value.
+ *
+ * This takes ownership of the `thread`.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_event_value_add_thread(
+    sentry_value_t event, sentry_value_t thread);
 
 /* -- Experimental APIs -- */
 
@@ -372,6 +432,11 @@ SENTRY_EXPERIMENTAL_API char *sentry_value_to_msgpack(
 
 /**
  * Adds a stacktrace to an event.
+ *
+ * The stacktrace is added as part of a new thread object.
+ * This function is **deprecated** in favor of using
+ * `sentry_value_new_stacktrace` in combination with `sentry_value_new_thread`
+ * and `sentry_event_value_add_thread`.
  *
  * If `ips` is NULL the current stacktrace is captured, otherwise `len`
  * stacktrace instruction pointers are attached to the event.
@@ -398,7 +463,7 @@ typedef struct sentry_ucontext_s {
  *
  * If the address is given in `addr` the stack is unwound form there.
  * Otherwise (NULL is passed) the current instruction pointer is used as
- * start address. The stacktrace is written to `stacktrace_out` with upt o
+ * start address. The stacktrace is written to `stacktrace_out` with up to
  * `max_len` frames being written.  The actual number of unwound stackframes
  * is returned.
  */
@@ -408,7 +473,7 @@ SENTRY_EXPERIMENTAL_API size_t sentry_unwind_stack(
 /**
  * Unwinds the stack from the given context.
  *
- * The stacktrace is written to `stacktrace_out` with upt o `max_len` frames
+ * The stacktrace is written to `stacktrace_out` with up to `max_len` frames
  * being written.  The actual number of unwound stackframes is returned.
  */
 SENTRY_EXPERIMENTAL_API size_t sentry_unwind_stack_from_ucontext(

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -370,7 +370,7 @@ SENTRY_API sentry_value_t sentry_value_new_breadcrumb(
  * See https://develop.sentry.dev/sdk/event-payloads/exception/
  *
  * The returned value needs to be attached to an event via
- * `sentry_event_value_add_exception`.
+ * `sentry_event_add_exception`.
  */
 SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_exception(
     const char *type, const char *value);
@@ -381,7 +381,7 @@ SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_exception(
  * See https://develop.sentry.dev/sdk/event-payloads/threads/
  *
  * The returned value needs to be attached to an event via
- * `sentry_event_value_add_thread`.
+ * `sentry_event_add_thread`.
  *
  * `name` can be NULL.
  */

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -396,8 +396,8 @@ SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_thread(
  * The returned object needs to be attached to either an exception
  * event, or a thread object.
  *
- * If `ips` is NULL the current stacktrace is captured, otherwise `len`
- * stacktrace instruction pointers are attached to the event.
+ * If `ips` is NULL the current stack trace is captured, otherwise `len`
+ * stack trace instruction pointers are attached to the event.
  */
 SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_stacktrace(
     void **ips, size_t len);
@@ -407,7 +407,7 @@ SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_stacktrace(
  *
  * This takes ownership of the `exception`.
  */
-SENTRY_EXPERIMENTAL_API void sentry_event_value_add_exception(
+SENTRY_EXPERIMENTAL_API void sentry_event_add_exception(
     sentry_value_t event, sentry_value_t exception);
 
 /**
@@ -415,7 +415,7 @@ SENTRY_EXPERIMENTAL_API void sentry_event_value_add_exception(
  *
  * This takes ownership of the `thread`.
  */
-SENTRY_EXPERIMENTAL_API void sentry_event_value_add_thread(
+SENTRY_EXPERIMENTAL_API void sentry_event_add_thread(
     sentry_value_t event, sentry_value_t thread);
 
 /* -- Experimental APIs -- */
@@ -431,15 +431,15 @@ SENTRY_EXPERIMENTAL_API char *sentry_value_to_msgpack(
     sentry_value_t value, size_t *size_out);
 
 /**
- * Adds a stacktrace to an event.
+ * Adds a stack trace to an event.
  *
- * The stacktrace is added as part of a new thread object.
+ * The stack trace is added as part of a new thread object.
  * This function is **deprecated** in favor of using
  * `sentry_value_new_stacktrace` in combination with `sentry_value_new_thread`
- * and `sentry_event_value_add_thread`.
+ * and `sentry_event_add_thread`.
  *
- * If `ips` is NULL the current stacktrace is captured, otherwise `len`
- * stacktrace instruction pointers are attached to the event.
+ * If `ips` is NULL the current stack trace is captured, otherwise `len`
+ * stack trace instruction pointers are attached to the event.
  */
 SENTRY_EXPERIMENTAL_API void sentry_event_value_add_stacktrace(
     sentry_value_t event, void **ips, size_t len);
@@ -463,7 +463,7 @@ typedef struct sentry_ucontext_s {
  *
  * If the address is given in `addr` the stack is unwound form there.
  * Otherwise (NULL is passed) the current instruction pointer is used as
- * start address. The stacktrace is written to `stacktrace_out` with up to
+ * start address. The stack trace is written to `stacktrace_out` with up to
  * `max_len` frames being written.  The actual number of unwound stackframes
  * is returned.
  */
@@ -473,7 +473,7 @@ SENTRY_EXPERIMENTAL_API size_t sentry_unwind_stack(
 /**
  * Unwinds the stack from the given context.
  *
- * The stacktrace is written to `stacktrace_out` with up to `max_len` frames
+ * The stack trace is written to `stacktrace_out` with up to `max_len` frames
  * being written.  The actual number of unwound stackframes is returned.
  */
 SENTRY_EXPERIMENTAL_API size_t sentry_unwind_stack_from_ucontext(

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -218,7 +218,7 @@ make_signal_event(
 
     sentry_value_set_by_key(exc, "stacktrace", stacktrace);
 
-    sentry_event_value_add_exception(event, exc);
+    sentry_event_add_exception(event, exc);
 
     return event;
 }

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -1054,7 +1054,8 @@ sentry_value_new_thread(uint64_t id, const char *name)
 
     // TODO: would be nice to be able to actually use a `u64` as value.
     char buf[100];
-    size_t written = (size_t)snprintf(buf, sizeof(buf), "%llu", id);
+    size_t written
+        = (size_t)snprintf(buf, sizeof(buf), "%llu", (unsigned long long)id);
     if (written < sizeof(buf)) {
         buf[written] = '\0';
         sentry_value_set_by_key(thread, "id", sentry_value_new_string(buf));

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -163,8 +163,7 @@ def assert_exception(envelope):
         "type": "ParseIntError",
         "value": "invalid digit found in string",
     }
-    expected = {"exception": {"values": [exception]}}
-    assert matches(event, expected)
+    assert matches(event["exception"]["values"][0], exception)
     assert_timestamp(event["timestamp"])
 
 

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -119,7 +119,7 @@ def test_exception_and_session_http(cmake, httpserver):
     run(
         tmp_path,
         "sentry_example",
-        ["log", "start-session", "capture-exception"],
+        ["log", "start-session", "capture-exception", "add-stacktrace"],
         check=True,
         env=env,
     )
@@ -129,6 +129,7 @@ def test_exception_and_session_http(cmake, httpserver):
     envelope = Envelope.deserialize(output)
 
     assert_exception(envelope)
+    assert_stacktrace(envelope, inside_exception=True)
     assert_session(envelope, {"init": True, "status": "ok", "errors": 1})
 
     output = httpserver.log[1][0].get_data()


### PR DESCRIPTION
Adds:
* `sentry_value_new_exception`
* `sentry_value_new_thread`
* `sentry_value_new_stacktrace`
* `sentry_event_value_add_exception`
* `sentry_event_value_add_thread`

Deprecates `sentry_event_value_add_stacktrace`

Fixes #235
Fixes #376
Fixes #503