### PR TITLE
feat: Introduce `sentry_close`

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ sentry_init(options);
 
 // your application code …
 
-sentry_shutdown();
+sentry_close();
 ```
 
 Other important configuration options include:

--- a/examples/example.c
+++ b/examples/example.c
@@ -186,7 +186,7 @@ main(int argc, char **argv)
     }
 
     // make sure everything flushes
-    sentry_shutdown();
+    sentry_close();
     if (has_arg(argc, argv, "sleep-after-shutdown")) {
         sleep_s(1);
     }

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -789,7 +789,7 @@ SENTRY_API void sentry_options_set_logger(
  * Automatic session tracking is enabled by default and is equivalent to calling
  * `sentry_start_session` after startup.
  * There can only be one running session, and the current session will always be
- * closed implicitly by `sentry_shutdown`, when starting a new session with
+ * closed implicitly by `sentry_close`, when starting a new session with
  * `sentry_start_session`, or manually by calling `sentry_end_session`.
  */
 SENTRY_API void sentry_options_set_auto_session_tracking(
@@ -939,6 +939,15 @@ SENTRY_API int sentry_init(sentry_options_t *options);
 
 /**
  * Shuts down the sentry client and forces transports to flush out.
+ *
+ * Returns 0 on success.
+ */
+SENTRY_API int sentry_close(void);
+
+/**
+ * Shuts down the sentry client and forces transports to flush out.
+ *
+ * This is a **deprecated** alias for `sentry_close`.
  *
  * Returns 0 on success.
  */

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -72,7 +72,7 @@ sentry__should_skip_upload(void)
 int
 sentry_init(sentry_options_t *options)
 {
-    sentry_shutdown();
+    sentry_close();
 
     sentry_logger_t logger = { NULL, NULL };
     if (options->debug) {
@@ -179,7 +179,7 @@ fail:
 }
 
 int
-sentry_shutdown(void)
+sentry_close(void)
 {
     sentry_end_session();
 
@@ -217,6 +217,12 @@ sentry_shutdown(void)
     sentry__scope_cleanup();
     sentry_clear_modulecache();
     return (int)dumped_envelopes;
+}
+
+int
+sentry_shutdown(void)
+{
+    return sentry_close();
 }
 
 int

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -82,7 +82,7 @@ SENTRY_TEST(lazy_attachments)
         != NULL);
     sentry_free(serialized);
 
-    sentry_shutdown();
+    sentry_close();
 
     sentry__path_remove(existing);
     sentry__path_remove(non_existing);

--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -57,7 +57,7 @@ SENTRY_TEST(basic_function_transport)
     sentry_capture_event(sentry_value_new_message_event(SENTRY_LEVEL_INFO,
         "root", "not captured either due to revoked consent"));
 
-    sentry_shutdown();
+    sentry_close();
 
     TEST_CHECK_INT_EQUAL(called, 2);
 }
@@ -90,7 +90,7 @@ SENTRY_TEST(sampling_before_send)
             sentry_value_new_message_event(SENTRY_LEVEL_INFO, NULL, "foo"));
     }
 
-    sentry_shutdown();
+    sentry_close();
 
     TEST_CHECK_INT_EQUAL(called_transport, 0);
     // well, its random after all

--- a/tests/unit/test_consent.c
+++ b/tests/unit/test_consent.c
@@ -25,19 +25,19 @@ SENTRY_TEST(basic_consent_tracking)
     init_consenting_sentry();
     TEST_CHECK_INT_EQUAL(
         sentry_user_consent_get(), SENTRY_USER_CONSENT_UNKNOWN);
-    sentry_shutdown();
+    sentry_close();
 
     init_consenting_sentry();
     sentry_user_consent_give();
     TEST_CHECK_INT_EQUAL(sentry_user_consent_get(), SENTRY_USER_CONSENT_GIVEN);
-    sentry_shutdown();
+    sentry_close();
     init_consenting_sentry();
     TEST_CHECK_INT_EQUAL(sentry_user_consent_get(), SENTRY_USER_CONSENT_GIVEN);
 
     sentry_user_consent_revoke();
     TEST_CHECK_INT_EQUAL(
         sentry_user_consent_get(), SENTRY_USER_CONSENT_REVOKED);
-    sentry_shutdown();
+    sentry_close();
     init_consenting_sentry();
     TEST_CHECK_INT_EQUAL(
         sentry_user_consent_get(), SENTRY_USER_CONSENT_REVOKED);
@@ -45,11 +45,11 @@ SENTRY_TEST(basic_consent_tracking)
     sentry_user_consent_reset();
     TEST_CHECK_INT_EQUAL(
         sentry_user_consent_get(), SENTRY_USER_CONSENT_UNKNOWN);
-    sentry_shutdown();
+    sentry_close();
     init_consenting_sentry();
     TEST_CHECK_INT_EQUAL(
         sentry_user_consent_get(), SENTRY_USER_CONSENT_UNKNOWN);
-    sentry_shutdown();
+    sentry_close();
 
     sentry__path_remove_all(path);
     sentry__path_free(path);

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -134,5 +134,5 @@ SENTRY_TEST(serialize_envelope)
     sentry_envelope_free(envelope);
     sentry_free(str);
 
-    sentry_shutdown();
+    sentry_close();
 }

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -39,12 +39,12 @@ SENTRY_TEST(custom_logger)
     SENTRY_WARNF("Oh this is %s", "bad");
     data.assert_now = false;
 
-    sentry_shutdown();
+    sentry_close();
 
     TEST_CHECK_INT_EQUAL(data.called, 1);
 
     // *really* clear the logger instance
     options = sentry_options_new();
     sentry_init(options);
-    sentry_shutdown();
+    sentry_close();
 }

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -78,7 +78,7 @@ SENTRY_TEST(session_basics)
         user, "username", sentry_value_new_string("swatinem"));
     sentry_set_user(user);
 
-    sentry_shutdown();
+    sentry_close();
 
     TEST_CHECK_INT_EQUAL(called, 2);
 }
@@ -138,7 +138,7 @@ SENTRY_TEST(count_sampled_events)
     }
 
     assertion.assert_session = true;
-    sentry_shutdown();
+    sentry_close();
 
     TEST_CHECK_INT_EQUAL(assertion.called, 1);
 }

--- a/tests/unit/test_uninit.c
+++ b/tests/unit/test_uninit.c
@@ -29,7 +29,7 @@ SENTRY_TEST(uninitialized)
     sentry_set_level(SENTRY_LEVEL_DEBUG);
     sentry_start_session();
     sentry_end_session();
-    sentry_shutdown();
+    sentry_close();
 }
 
 SENTRY_TEST(empty_transport)
@@ -44,7 +44,7 @@ SENTRY_TEST(empty_transport)
     sentry_uuid_t id = sentry_capture_event(event);
     TEST_CHECK(!sentry_uuid_is_nil(&id));
 
-    sentry_shutdown();
+    sentry_close();
 }
 
 SENTRY_TEST(invalid_dsn)
@@ -59,7 +59,7 @@ SENTRY_TEST(invalid_dsn)
     sentry_uuid_t id = sentry_capture_event(event);
     TEST_CHECK(!sentry_uuid_is_nil(&id));
 
-    sentry_shutdown();
+    sentry_close();
 }
 
 SENTRY_TEST(invalid_proxy)
@@ -74,5 +74,5 @@ SENTRY_TEST(invalid_proxy)
     sentry_uuid_t id = sentry_capture_event(event);
     TEST_CHECK(!sentry_uuid_is_nil(&id));
 
-    sentry_shutdown();
+    sentry_close();
 }


### PR DESCRIPTION
This replaces the former `sentry_shutdown`, which is being forwarded.

Fixes #474