### PR TITLE
feat: Invoke before_send hook when using Crashpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Other important configuration options include:
 
 ## Known Limitations
 
-- The crashpad backend currently has no support for notifying the crashing
+- The crashpad backend on macOS currently has no support for notifying the crashing
   process, and can thus not properly terminate sessions or call the registered
   `before_send` hook. It will also lose any events that have been queued for
   sending at time of crash.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -530,7 +530,7 @@ typedef struct sentry_options_s sentry_options_t;
  *   In case of `false`, sentry will log an error, but continue with freeing the
  *   transport.
  * * `free_func`: Frees the transports `state`. This hook might be called even
- *   though `shudown_func` returned `false` previously.
+ *   though `shutdown_func` returned `false` previously.
  *
  * The transport interface might be extended in the future with hooks to flush
  * its internal queue without shutting down, and to dump its internal queue to

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -635,8 +635,12 @@ SENTRY_API void sentry_options_set_transport(
  * same event. In case the event should be discarded, the callback needs to
  * call `sentry_value_decref` on the provided event, and return a
  * `sentry_value_new_null()` instead.
+ *
  * This function may be invoked inside of a signal handler and must be safe for
  * that purpose, see https://man7.org/linux/man-pages/man7/signal-safety.7.html.
+ * On Windows, it may be called from inside of a `UnhandledExceptionFilter`, see
+ * the documentation on SEH (structured exception handling) for more information
+ * https://docs.microsoft.com/en-us/windows/win32/debug/structured-exception-handling
  */
 typedef sentry_value_t (*sentry_event_function_t)(
     sentry_value_t event, void *hint, void *closure);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -114,6 +114,14 @@ sentry__crashpad_handler(int UNUSED(signum), siginfo_t *UNUSED(info),
     SENTRY_WITH_OPTIONS (options) {
         sentry__write_crash_marker(options);
 
+        sentry_value_t event = sentry_value_new_event();
+        if (options->before_send_func) {
+            SENTRY_TRACE("invoking `before_send` hook");
+            event = options->before_send_func(
+                event, NULL, options->before_send_data);
+        }
+        sentry_value_decref(event);
+
         sentry__record_errors_on_current_session(1);
         sentry_session_t *session = sentry__end_current_session_with_status(
             SENTRY_SESSION_STATUS_CRASHED);


### PR DESCRIPTION
Fixes #250
