### PR TITLE
fix: Better macOS availability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Build fixes for PPC and universal macOS.
 - Fixes to build using musl libc.
 - Correctness fixes around printf and strftime usage.
+- Allow building and running on older macOS versions.
 
 **Internal**:
 

--- a/src/sentry_boot.h
+++ b/src/sentry_boot.h
@@ -33,6 +33,10 @@
 #    include <windows.h>
 #endif
 
+#ifndef __has_builtin
+#    define __has_builtin(x) 0
+#endif
+
 #include <sentry.h>
 #include <stdbool.h>
 

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef SENTRY_PLATFORM_MACOS
+#ifdef SENTRY_PLATFORM_DARWIN
 #    include <xlocale.h>
 #elif defined(SENTRY_PLATFORM_LINUX) && !defined(SENTRY_PLATFORM_ANDROID)
 #    include "../vendor/stb_sprintf.h"
@@ -493,7 +493,7 @@ sentry__snprintf_c(char *buf, size_t buf_size, const char *fmt, ...)
     rv = _vsnprintf_l(buf, buf_size, fmt, c_locale(), args);
 #elif defined(SENTRY_PLATFORM_ANDROID) || defined(SENTRY_PLATFORM_IOS)
     rv = vsnprintf(buf, buf_size, fmt, args);
-#elif defined(SENTRY_PLATFORM_MACOS)
+#elif defined(SENTRY_PLATFORM_DARWIN)
     rv = vsnprintf_l(buf, buf_size, c_locale(), fmt, args);
 #else
     rv = stbsp_vsnprintf(buf, buf_size, fmt, args);

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -1,13 +1,13 @@
 // According to http://lua-users.org/lists/lua-l/2016-04/msg00216.html we can
 // use `stdtod_l` on all platforms when defining `_GNU_SOURCE`.
 
-#define _GNU_SOURCE
+#include "sentry_boot.h"
 
-#include "sentry_utils.h"
 #include "sentry_alloc.h"
 #include "sentry_core.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
+#include "sentry_utils.h"
 #include <locale.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -3,7 +3,7 @@
 
 #include "sentry_boot.h"
 
-#ifdef SENTRY_PLATFORM_MACOS
+#ifdef SENTRY_PLATFORM_DARWIN
 #    include <mach/clock.h>
 #    include <mach/mach.h>
 #endif
@@ -149,7 +149,7 @@ sentry__monotonic_time(void)
     LARGE_INTEGER qpc_counter;
     QueryPerformanceCounter(&qpc_counter);
     return qpc_counter.QuadPart * 1000 / qpc_frequency.QuadPart;
-#elif defined(SENTRY_PLATFORM_MACOS)
+#elif defined(SENTRY_PLATFORM_DARWIN)
 
 // try `clock_gettime` first if available,
 // fall back to `host_get_clock_service` otherwise

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -3,6 +3,10 @@
 
 #include "sentry_boot.h"
 
+#ifdef SENTRY_PLATFORM_MACOS
+#    include <mach/clock.h>
+#    include <mach/mach.h>
+#endif
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <winnt.h>
 #else
@@ -145,6 +149,25 @@ sentry__monotonic_time(void)
     LARGE_INTEGER qpc_counter;
     QueryPerformanceCounter(&qpc_counter);
     return qpc_counter.QuadPart * 1000 / qpc_frequency.QuadPart;
+#elif defined(SENTRY_PLATFORM_MACOS)
+
+// try `clock_gettime` first if available,
+// fall back to `host_get_clock_service` otherwise
+#    if defined(MAC_OS_X_VERSION_10_12) && __has_builtin(__builtin_available)
+    if (__builtin_available(macOS 10.12, *)) {
+        struct timespec tv;
+        return (clock_gettime(CLOCK_MONOTONIC, &tv) == 0)
+            ? (uint64_t)tv.tv_sec * 1000 + tv.tv_nsec / 1000000
+            : 0;
+    }
+#    endif
+
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    return (uint64_t)mts.tv_sec * 1000 + mts.tv_nsec / 1000000;
 #else
     struct timespec tv;
     return (clock_gettime(CLOCK_MONOTONIC, &tv) == 0)

--- a/src/unwinder/sentry_unwinder_libbacktrace.c
+++ b/src/unwinder/sentry_unwinder_libbacktrace.c
@@ -4,18 +4,15 @@
 #    include <execinfo.h>
 #endif
 
-#ifndef __has_builtin
-#    define __has_builtin(x) 0
-#endif
-
 size_t
 sentry__unwind_stack_libbacktrace(
     void *addr, const sentry_ucontext_t *uctx, void **ptrs, size_t max_frames)
 {
     if (addr) {
-#if defined(SENTRY_PLATFORM_MACOS) && __has_builtin(__builtin_available)
-        if (__builtin_available(macOS 10.14, *))
+#if defined(MAC_OS_X_VERSION_10_14) && __has_builtin(__builtin_available)
+        if (__builtin_available(macOS 10.14, *)) {
             return (size_t)backtrace_from_fp(addr, ptrs, (int)max_frames);
+        }
 #endif
         return 0;
     } else if (uctx) {

--- a/src/unwinder/sentry_unwinder_libbacktrace.c
+++ b/src/unwinder/sentry_unwinder_libbacktrace.c
@@ -1,6 +1,6 @@
 #include "sentry_boot.h"
 
-#if defined(SENTRY_PLATFORM_MACOS) || defined(__GLIBC__)
+#if defined(SENTRY_PLATFORM_DARWIN) || defined(__GLIBC__)
 #    include <execinfo.h>
 #endif
 
@@ -9,7 +9,8 @@ sentry__unwind_stack_libbacktrace(
     void *addr, const sentry_ucontext_t *uctx, void **ptrs, size_t max_frames)
 {
     if (addr) {
-#if defined(MAC_OS_X_VERSION_10_14) && __has_builtin(__builtin_available)
+#if defined(SENTRY_PLATFORM_MACOS) && defined(MAC_OS_X_VERSION_10_14)          \
+    && __has_builtin(__builtin_available)
         if (__builtin_available(macOS 10.14, *)) {
             return (size_t)backtrace_from_fp(addr, ptrs, (int)max_frames);
         }
@@ -18,7 +19,7 @@ sentry__unwind_stack_libbacktrace(
     } else if (uctx) {
         return 0;
     }
-#if defined(SENTRY_PLATFORM_MACOS) || defined(__GLIBC__)
+#if defined(SENTRY_PLATFORM_DARWIN) || defined(__GLIBC__)
     return (size_t)backtrace(ptrs, (int)max_frames);
 #else
     (void)ptrs;


### PR DESCRIPTION
This should allow building on older macOS versions as well as
running on older versions by fixing the usage of __builtin_available,
and adding a different clock source for older macOS versions.

Fixes #495
Fixes #497
Hopefully also fixes #228