### PR TITLE
fix: Restore default Linux signal handlers when shutting down crashpad backend

### DIFF
--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -44,6 +44,27 @@ extern "C" {
 #ifdef SENTRY_PLATFORM_LINUX
 #    define SIGNAL_STACK_SIZE 65536
 static stack_t g_signal_stack;
+
+#    include "util/posix/signals.h"
+
+// This list was taken from crashpad's util/posix/signals.cc file
+// and is used to know which signals we need to reset to default
+// when shutting down the backend
+constexpr int g_CrashSignals[] = {
+    SIGABRT,
+    SIGBUS,
+    SIGFPE,
+    SIGILL,
+    SIGQUIT,
+    SIGSEGV,
+    SIGSYS,
+    SIGTRAP,
+#    if defined(SIGEMT)
+    SIGEMT,
+#    endif // defined(SIGEMT)
+    SIGXCPU,
+    SIGXFSZ,
+};
 #endif
 
 typedef struct {
@@ -281,6 +302,15 @@ sentry__crashpad_backend_startup(
 static void
 sentry__crashpad_backend_shutdown(sentry_backend_t *backend)
 {
+#ifdef SENTRY_PLATFORM_LINUX
+    // restore signal handlers to their default state
+    for (const auto signal : g_CrashSignals) {
+        if (crashpad::Signals::IsCrashSignal(signal)) {
+            crashpad::Signals::InstallDefaultHandler(signal);
+        }
+    }
+#endif
+
     crashpad_state_t *data = (crashpad_state_t *)backend->data;
     delete data->db;
     data->db = nullptr;


### PR DESCRIPTION
This fixes (on Linux) a bug we were experiencing after calling
`sentry_reinstall_backend` while using the crashpad backend. All
crashes were getting reported in an infinite loop until our server
orchestration killed the process, consuming all of our event budget!

Let me know how I can add a regression test for this.