### PR TITLE
fix: Avoid recursion when using `sentry_reinstall_backend`

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -154,6 +154,10 @@ main(int argc, char **argv)
         }
     }
 
+    if (has_arg(argc, argv, "reinstall")) {
+        sentry_reinstall_backend();
+    }
+
     if (has_arg(argc, argv, "sleep")) {
         sleep_s(10);
     }

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -44,6 +44,27 @@ extern "C" {
 #ifdef SENTRY_PLATFORM_LINUX
 #    define SIGNAL_STACK_SIZE 65536
 static stack_t g_signal_stack;
+
+#    include "util/posix/signals.h"
+
+// This list was taken from crashpad's util/posix/signals.cc file
+// and is used to know which signals we need to reset to default
+// when shutting down the backend
+constexpr int g_CrashSignals[] = {
+    SIGABRT,
+    SIGBUS,
+    SIGFPE,
+    SIGILL,
+    SIGQUIT,
+    SIGSEGV,
+    SIGSYS,
+    SIGTRAP,
+#    if defined(SIGEMT)
+    SIGEMT,
+#    endif // defined(SIGEMT)
+    SIGXCPU,
+    SIGXFSZ,
+};
 #endif
 
 typedef struct {
@@ -281,6 +302,15 @@ sentry__crashpad_backend_startup(
 static void
 sentry__crashpad_backend_shutdown(sentry_backend_t *backend)
 {
+#ifdef SENTRY_PLATFORM_LINUX
+    // restore signal handlers to their default state
+    for (const auto signal : g_CrashSignals) {
+        if (crashpad::Signals::IsCrashSignal(signal)) {
+            crashpad::Signals::InstallDefaultHandler(signal);
+        }
+    }
+#endif
+
     crashpad_state_t *data = (crashpad_state_t *)backend->data;
     delete data->db;
     data->db = nullptr;

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -111,6 +111,7 @@ shutdown_inproc_backend(sentry_backend_t *UNUSED(backend))
     sigaltstack(&g_signal_stack, 0);
     sentry_free(g_signal_stack.ss_sp);
     g_signal_stack.ss_sp = NULL;
+    reset_signal_handlers();
 }
 
 #elif defined SENTRY_PLATFORM_WINDOWS

--- a/src/sentry_session.c
+++ b/src/sentry_session.c
@@ -185,8 +185,8 @@ sentry__session_from_json(const char *buf, size_t buflen)
         sentry_value_get_by_key(value, "errors"));
     rv->started_ms = sentry__iso8601_to_msec(
         sentry_value_as_string(sentry_value_get_by_key(value, "started")));
-    rv->duration_ms = (uint64_t)(
-        sentry_value_as_double(sentry_value_get_by_key(value, "duration"))
+    rv->duration_ms = (uint64_t)(sentry_value_as_double(
+                                     sentry_value_get_by_key(value, "duration"))
         * 1000);
 
     sentry_value_decref(value);

--- a/src/sentry_session.c
+++ b/src/sentry_session.c
@@ -185,8 +185,8 @@ sentry__session_from_json(const char *buf, size_t buflen)
         sentry_value_get_by_key(value, "errors"));
     rv->started_ms = sentry__iso8601_to_msec(
         sentry_value_as_string(sentry_value_get_by_key(value, "started")));
-    rv->duration_ms = (uint64_t)(sentry_value_as_double(
-                                     sentry_value_get_by_key(value, "duration"))
+    rv->duration_ms = (uint64_t)(
+        sentry_value_as_double(sentry_value_get_by_key(value, "duration"))
         * 1000);
 
     sentry_value_decref(value);

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 black==19.10b0
 pytest==5.4.1
-pytest-httpserver==0.3.4
+pytest-httpserver==1.0.0

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -36,9 +36,7 @@ def test_crashpad_reinstall(cmake, httpserver):
     httpserver.expect_request("/api/123456/minidump/").respond_with_data("OK")
 
     with httpserver.wait(timeout=10) as waiting:
-        child = run(
-            tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env
-        )
+        child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env)
         assert child.returncode  # well, its a crash after all
 
     assert waiting.result
@@ -86,6 +84,9 @@ def test_crashpad_crash(cmake, httpserver):
     assert_crashpad_upload(multipart)
 
 
+@pytest.mark.skipif(
+    sys.platform == "linux", reason="linux clears the signal handlers on shutdown"
+)
 def test_crashpad_crash_after_shutdown(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -33,7 +33,7 @@ def test_crashpad_reinstall(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
-    httpserver.expect_request("/api/123456/minidump/").respond_with_data("OK")
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
 
     with httpserver.wait(timeout=10) as waiting:
         child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env)

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -29,6 +29,25 @@ def test_crashpad_capture(cmake, httpserver):
     assert len(httpserver.log) == 2
 
 
+def test_crashpad_reinstall(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_request("/api/123456/minidump/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        child = run(
+            tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env
+        )
+        assert child.returncode  # well, its a crash after all
+
+    assert waiting.result
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    assert len(httpserver.log) == 1
+
+
 def test_crashpad_crash(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -224,12 +224,7 @@ def test_inproc_reinstall(cmake, httpserver):
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
 
-    child = run(
-        tmp_path,
-        "sentry_example",
-        ["log", "reinstall", "crash"],
-        env=env,
-    )
+    child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env,)
     assert child.returncode  # well, its a crash after all
 
     run(
@@ -300,12 +295,7 @@ def test_breakpad_reinstall(cmake, httpserver):
         "/api/123456/envelope/", headers={"x-sentry-auth": auth_header},
     ).respond_with_data("OK")
 
-    child = run(
-        tmp_path,
-        "sentry_example",
-        ["log", "reinstall", "crash"],
-        env=env,
-    )
+    child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env,)
     assert child.returncode  # well, its a crash after all
 
     run(


### PR DESCRIPTION
Previously, the `inproc` and `crashpad` (on linux) backends didn’t correctly reset their signal handlers when doing `reinstall_backend` (or multiple `init` calls for that matter).
This has led to an infinite loop generating crashes.

The fix now correctly unregisters the inproc/crashpad signal handlers, and adds an integration test using `reinstall_backend` to make sure we do not end up in an infinite loop.

(this includes/supercedes #547)