### PR TITLE
fix: Address -Wundef warning for SENTRY_UNITTEST defines

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.h
+++ b/src/modulefinder/sentry_modulefinder_linux.h
@@ -29,7 +29,7 @@ typedef struct {
     uint8_t num_mappings;
 } sentry_module_t;
 
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 bool sentry__procmaps_read_ids_from_elf(
     sentry_value_t value, const sentry_module_t *module);
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -434,7 +434,7 @@ sentry_handle_exception(const sentry_ucontext_t *uctx)
 sentry_uuid_t
 sentry__new_event_id(void)
 {
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
     return sentry_uuid_from_string("4c035723-8638-4c3a-923f-2ab9d08b4018");
 #else
     return sentry_uuid_new_v4();

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -410,7 +410,7 @@ sentry_envelope_write_to_file(
     return rv;
 }
 
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 size_t
 sentry__envelope_get_item_count(const sentry_envelope_t *envelope)
 {

--- a/src/sentry_envelope.h
+++ b/src/sentry_envelope.h
@@ -86,7 +86,7 @@ MUST_USE int sentry_envelope_write_to_path(
     const sentry_envelope_t *envelope, const sentry_path_t *path);
 
 // these for now are only needed for tests
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 size_t sentry__envelope_get_item_count(const sentry_envelope_t *envelope);
 const sentry_envelope_item_t *sentry__envelope_get_item(
     const sentry_envelope_t *envelope, size_t idx);

--- a/src/sentry_ratelimiter.c
+++ b/src/sentry_ratelimiter.c
@@ -99,7 +99,7 @@ sentry__rate_limiter_free(sentry_rate_limiter_t *rl)
     sentry_free(rl);
 }
 
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 uint64_t
 sentry__rate_limiter_get_disabled_until(
     const sentry_rate_limiter_t *rl, int category)

--- a/src/sentry_ratelimiter.h
+++ b/src/sentry_ratelimiter.h
@@ -41,7 +41,7 @@ bool sentry__rate_limiter_update_from_http_retry_after(
 bool sentry__rate_limiter_is_disabled(
     const sentry_rate_limiter_t *rl, int category);
 
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 /**
  * The rate limiters state is completely opaque. Unless in tests, where we would
  * want to actually peek into the specific rate limiting `category`.

--- a/src/sentry_unix_pageallocator.c
+++ b/src/sentry_unix_pageallocator.c
@@ -125,7 +125,7 @@ sentry__page_allocator_alloc(size_t size)
     return rv;
 }
 
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 void
 sentry__page_allocator_disable(void)
 {

--- a/src/sentry_unix_pageallocator.h
+++ b/src/sentry_unix_pageallocator.h
@@ -21,7 +21,7 @@ void sentry__page_allocator_enable(void);
  */
 void *sentry__page_allocator_alloc(size_t size);
 
-#if SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
 /**
  * This disables the page allocator, which invalidates every allocation that was
  * done through it. Therefore it is only safe to use in unit tests


### PR DESCRIPTION
This matches other defines present in code already