### PR TITLE
fix: Make Linux modulefinder/unwinder safer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,14 @@ jobs:
             os: windows-latest
           # The Android emulator is currently only available on macos, see:
           # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/android?view=azure-devops#test-on-the-android-emulator
-          - name: Android (API 16, NDK 19)
+          - name: Android (API 16, NDK 20)
             os: macOs-latest
             ANDROID_API: 16
-            ANDROID_NDK: 19.2.5345600
-          - name: Android (API 30 NDK 21)
+            ANDROID_NDK: 20.1.5948944
+          - name: Android (API 30, NDK 22)
             os: macOs-latest
             ANDROID_API: 30
-            ANDROID_NDK: 21.3.6528147
+            ANDROID_NDK: 22.1.7171670
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -18,8 +18,7 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-#ifdef __ANDROID_API__
-#    if __ANDROID_API__ < 23
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 23
 static ssize_t
 process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
     unsigned long __local_iov_count, const struct iovec *__remote_iov,
@@ -28,7 +27,6 @@ process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
     return syscall(__NR_process_vm_readv, __pid, __local_iov, __local_iov_count,
         __remote_iov, __remote_iov_count, __flags);
 }
-#    endif
 #endif
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -91,7 +89,7 @@ read_safely(void *dst, void *src, size_t size)
 
     // The syscall is only available in Linux 3.2, meaning Android 17.
     // If that is the case, just fall back to an unsafe memcpy.
-#if __ANDROID_API__ < 17
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 17
     if (!rv && errno == EINVAL) {
         memcpy(dst, src, size);
         rv = true;

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -1,4 +1,6 @@
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+#    define _GNU_SOURCE 1
+#endif
 #include "sentry_modulefinder_linux.h"
 
 #include "sentry_core.h"

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -524,9 +524,11 @@ load_modules(sentry_value_t modules)
 
     // we have multiple memory maps per file, and we need to merge their offsets
     // based on the filename. Luckily, the maps are ordered by filename, so yay
-    sentry_module_t last_module = { 0 };
+    sentry_module_t last_module;
+    memset(&last_module, 0, sizeof(sentry_module_t));
     while (true) {
-        sentry_parsed_module_t module = { 0 };
+        sentry_parsed_module_t module;
+        memset(&module, 0, sizeof(sentry_parsed_module_t));
         int read = sentry__procmaps_parse_module_line(current_line, &module);
         current_line += read;
         if (!read) {

--- a/src/unwinder/sentry_unwinder_libunwindstack.cpp
+++ b/src/unwinder/sentry_unwinder_libunwindstack.cpp
@@ -39,7 +39,7 @@ sentry__unwind_stack_libunwindstack(
     }
 
     const std::shared_ptr<unwindstack::Memory> process_memory
-        = unwindstack::Memory::CreateProcessMemoryCached(getpid());
+        = unwindstack::Memory::CreateProcessMemory(getpid());
 
     unwindstack::Unwinder unwinder(
         max_frames, &maps, regs.get(), process_memory);

--- a/src/unwinder/sentry_unwinder_libunwindstack.cpp
+++ b/src/unwinder/sentry_unwinder_libunwindstack.cpp
@@ -39,7 +39,7 @@ sentry__unwind_stack_libunwindstack(
     }
 
     const std::shared_ptr<unwindstack::Memory> process_memory
-        = unwindstack::Memory::CreateProcessMemory(getpid());
+        = unwindstack::Memory::CreateProcessMemoryCached(getpid());
 
     unwindstack::Unwinder unwinder(
         max_frames, &maps, regs.get(), process_memory);


### PR DESCRIPTION
This is using the `process_vm_read` call to safely poke at random memory. It also makes sure to shim the libc provided call with a direct syscall for older Android devices.

Waiting for https://github.com/getsentry/libunwindstack-ndk/pull/4