### PR TITLE
fix: Cancel slow winhttp requests on shutdown

### DIFF
--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -325,6 +325,7 @@ sentry__bgworker_shutdown(sentry_bgworker_t *bgw, uint64_t timeout)
 
         uint64_t now = sentry__monotonic_time();
         if (now > started && now - started > timeout) {
+            sentry__atomic_fetch_and_add(&bgw->running, -1);
             sentry__mutex_unlock(&bgw->task_lock);
             SENTRY_WARN(
                 "background thread failed to shut down cleanly within timeout");

--- a/src/transports/sentry_transport_winhttp.c
+++ b/src/transports/sentry_transport_winhttp.c
@@ -113,7 +113,8 @@ sentry__winhttp_transport_shutdown(uint64_t timeout, void *transport_state)
     sentry_bgworker_t *bgworker = (sentry_bgworker_t *)transport_state;
     winhttp_bgworker_state_t *state = sentry__bgworker_get_state(bgworker);
 
-    if (sentry__bgworker_shutdown(bgworker, timeout) != 0) {
+    int rv = sentry__bgworker_shutdown(bgworker, timeout);
+    if (rv != 0) {
         // Seems like some requests are taking too long/hanging
         // Just close them to make sure the background thread is exiting.
         if (state->connect) {
@@ -133,7 +134,7 @@ sentry__winhttp_transport_shutdown(uint64_t timeout, void *transport_state)
         }
     }
 
-    return sentry__bgworker_shutdown(bgworker, timeout);
+    return rv;
 }
 
 static void
@@ -262,7 +263,7 @@ sentry__winhttp_send_task(void *_envelope, void *_state)
 exit:
     if (state->request) {
         HINTERNET request = state->request;
-        state->request = 0;
+        state->request = NULL;
         WinHttpCloseHandle(request);
     }
     sentry_free(url);


### PR DESCRIPTION
This is essentially https://github.com/getsentry/sentry-native/pull/568 with a proper fix to continue dumping queued envelopes.
CC @smibe