### PR TITLE
build+install breakpad's dump_syms executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,14 @@ elseif(SENTRY_BACKEND_BREAKPAD)
 		target_link_libraries(sentry PRIVATE
 			breakpad_client
 		)
+		set(breakpad_exes dump_syms)
+		if(TARGET macho_dump)
+			list(APPEND breakpad_exes macho_dump)
+		endif()
+		sentry_install(TARGETS ${breakpad_exes} EXPORT sentry
+			BUNDLE DESTINATION "${CMAKE_INSTALL_BINDIR}"
+			RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+		)
 		if(NOT SENTRY_BUILD_SHARED_LIBS)
 			sentry_install(TARGETS breakpad_client EXPORT sentry
 				LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,26 @@
 # The list of files is drived from: breakpad/Makefile.am
+cmake_minimum_required(VERSION 3.12)
+project(sentry_breakpad)
+
+set(CMAKE_CXX_STANDARD 11)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(LINUX TRUE)
+endif()
+
+# set static runtime, if enabled
+if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
+if(LINUX)
+    option(BREAKPAD_PIC "Build breakpad as position independent code" ON)
+else()
+    set(BREAKPAD_PIC ON)
+endif()
+if(BREAKPAD_PIC)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 set(BREAKPAD_SOURCES_COMMON
     breakpad/src/common/convert_UTF.cc
@@ -7,6 +29,38 @@ set(BREAKPAD_SOURCES_COMMON
     breakpad/src/common/md5.h
     breakpad/src/common/string_conversion.cc
     breakpad/src/common/string_conversion.h
+)
+
+set(BREAKPAD_SOURCES_COMMON_EXTRA
+)
+
+set(BREAKPAD_SOURCES_COMMON_EXTRA_UNIX
+    breakpad/src/common/dwarf/bytereader.cc
+    breakpad/src/common/dwarf/bytereader.h
+    breakpad/src/common/dwarf/dwarf2diehandler.cc
+    breakpad/src/common/dwarf/dwarf2diehandler.h
+    breakpad/src/common/dwarf/dwarf2reader.cc
+    breakpad/src/common/dwarf/dwarf2reader.h
+    breakpad/src/common/dwarf/elf_reader.cc
+    breakpad/src/common/dwarf/elf_reader.h
+    breakpad/src/common/dwarf_cfi_to_module.cc
+    breakpad/src/common/dwarf_cfi_to_module.h
+    breakpad/src/common/dwarf_cu_to_module.cc
+    breakpad/src/common/dwarf_cu_to_module.h
+    breakpad/src/common/dwarf_line_to_module.cc
+    breakpad/src/common/dwarf_line_to_module.h
+    breakpad/src/common/dwarf_range_list_handler.cc
+    breakpad/src/common/dwarf_range_list_handler.h
+    breakpad/src/common/path_helper.cc
+    breakpad/src/common/path_helper.h
+    breakpad/src/common/language.cc
+    breakpad/src/common/language.h
+    breakpad/src/common/module.cc
+    breakpad/src/common/module.h
+    breakpad/src/common/stabs_to_module.cc
+    breakpad/src/common/stabs_to_module.h
+    breakpad/src/common/stabs_reader.cc
+    breakpad/src/common/stabs_reader.h
 )
 
 set(BREAKPAD_SOURCES_COMMON_LINUX
@@ -22,6 +76,15 @@ set(BREAKPAD_SOURCES_COMMON_LINUX
     breakpad/src/common/linux/safe_readlink.cc
 )
 
+set(BREAKPAD_SOURCES_COMMON_EXTRA_LINUX
+    breakpad/src/common/linux/crc32.h
+    breakpad/src/common/linux/crc32.cc
+    breakpad/src/common/linux/dump_symbols.h
+    breakpad/src/common/linux/dump_symbols.cc
+    breakpad/src/common/linux/elf_symbols_to_module.cc
+    breakpad/src/common/linux/elf_symbols_to_module.h
+)
+
 set(BREAKPAD_SOURCES_COMMON_LINUX_GETCONTEXT
     breakpad/src/common/linux/breakpad_getcontext.S
 )
@@ -33,6 +96,21 @@ set(BREAKPAD_SOURCES_COMMON_ANDROID
 set(BREAKPAD_SOURCES_COMMON_WINDOWS
     breakpad/src/common/windows/guid_string.cc
     breakpad/src/common/windows/guid_string.h
+)
+
+set(BREAKPAD_SOURCES_COMMON_EXTRA_WINDOWS
+    breakpad/src/common/windows/dia_util.cc
+    breakpad/src/common/windows/dia_util.h
+    breakpad/src/common/windows/omap.cc
+    breakpad/src/common/windows/omap.h
+    breakpad/src/common/windows/pdb_source_line_writer.cc
+    breakpad/src/common/windows/pdb_source_line_writer.h
+    breakpad/src/common/windows/pe_source_line_writer.cc
+    breakpad/src/common/windows/pe_source_line_writer.h
+    breakpad/src/common/windows/pe_util.cc
+    breakpad/src/common/windows/pe_util.h
+    breakpad/src/common/windows/string_utils.cc
+    breakpad/src/common/windows/string_utils-inl.h
 )
 
 set(BREAKPAD_SOURCES_COMMON_APPLE
@@ -52,6 +130,15 @@ set(BREAKPAD_SOURCES_COMMON_MAC
     breakpad/src/common/mac/MachIPC.mm
     breakpad/src/common/mac/bootstrap_compat.cc
     breakpad/src/common/mac/bootstrap_compat.h
+)
+
+set(BREAKPAD_SOURCES_COMMON_EXTRA_APPLE
+    breakpad/src/common/mac/arch_utilities.cc
+    breakpad/src/common/mac/arch_utilities.h
+    breakpad/src/common/mac/dump_syms.cc
+    breakpad/src/common/mac/dump_syms.h
+    breakpad/src/common/mac/macho_reader.cc
+    breakpad/src/common/mac/macho_reader.h
 )
 
 set(BREAKPAD_SOURCES_CLIENT_LINUX
@@ -115,60 +202,117 @@ set(BREAKPAD_SOURCES_CLIENT_IOS
     breakpad/src/client/mac/handler/ucontext_compat.h
 )
 
+set(BREAKPAD_SOURCES_DUMPSYMS_LINUX
+    breakpad/src/tools/linux/dump_syms/dump_syms.cc
+)
 
+set(BREAKPAD_SOURCES_DUMPSYMS_WINDOWS
+    breakpad/src/tools/windows/dump_syms/dump_syms.cc
+)
+
+set(BREAKPAD_SOURCES_DUMPSYMS_MAC
+    breakpad/src/tools/mac/dump_syms/dump_syms_tool.cc
+)
+
+set(BREAKPAD_SOURCES_MACHODUMP_MAC
+    breakpad/src/tools/mac/dump_syms/macho_dump.cc
+)
+
+add_library(breakpad_common OBJECT)
+add_library(breakpad_common_extra OBJECT EXCLUDE_FROM_ALL)
 add_library(breakpad_client STATIC)
-target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON})
+add_executable(dump_syms)
+
+target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON})
+target_link_libraries(breakpad_client PRIVATE $<BUILD_INTERFACE:breakpad_common>)
+
+target_sources(breakpad_common_extra PRIVATE ${BREAKPAD_SOURCES_COMMON_EXTRA})
+target_link_libraries(breakpad_common_extra PUBLIC breakpad_common)
+
+target_link_libraries(dump_syms PRIVATE breakpad_common breakpad_common_extra)
 
 if(LINUX OR ANDROID)
-    target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON_LINUX} ${BREAKPAD_SOURCES_CLIENT_LINUX})
+    target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON_LINUX})
+    target_sources(breakpad_common_extra PRIVATE ${BREAKPAD_SOURCES_COMMON_EXTRA_UNIX} ${BREAKPAD_SOURCES_COMMON_EXTRA_LINUX})
+    target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_CLIENT_LINUX})
+    target_sources(dump_syms PRIVATE ${BREAKPAD_SOURCES_DUMPSYMS_LINUX})
     if(ANDROID)
-        target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON_ANDROID})
-        target_include_directories(breakpad_client PRIVATE breakpad/src/common/android/include)
-    endif(ANDROID)
+        target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON_ANDROID})
+        target_include_directories(breakpad_common PUBLIC src/common/android/include)
+    endif()
+        if(LINUX)
+            find_package(Threads REQUIRED)
+            target_link_libraries(breakpad_common_extra PRIVATE Threads::Threads)
+        endif()
 
     include(CheckFunctionExists)
     check_function_exists(getcontext HAVE_GETCONTEXT)
     if(HAVE_GETCONTEXT)
-        target_compile_definitions(breakpad_client PRIVATE HAVE_GETCONTEXT)
-    else()
-        target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON_LINUX_GETCONTEXT})
+        target_compile_definitions(breakpad_common PUBLIC HAVE_GETCONTEXT)
+        target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON_LINUX_GETCONTEXT})
     endif()
-
-    set_property(TARGET breakpad_client PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if(APPLE)
-    target_sources(breakpad_client PRIVATE
-        ${BREAKPAD_SOURCES_COMMON_APPLE}
-        ${BREAKPAD_SOURCES_CLIENT_APPLE})
+    target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON_APPLE})
+    target_sources(breakpad_common_extra PRIVATE ${BREAKPAD_SOURCES_COMMON_EXTRA_UNIX} ${BREAKPAD_SOURCES_COMMON_EXTRA_APPLE})
+    target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_CLIENT_APPLE})
+    target_sources(dump_syms PRIVATE ${BREAKPAD_SOURCES_DUMPSYMS_MAC})
+    add_executable(macho_dump ${BREAKPAD_SOURCES_MACHODUMP_MAC})
+    target_link_libraries(macho_dump PRIVATE breakpad_common breakpad_common_extra)
+        target_compile_definitions(breakpad_common PRIVATE HAVE_MACH_O_NLIST_H)
+        target_compile_definitions(breakpad_common_extra PRIVATE HAVE_MACH_O_NLIST_H)
     if(NOT IOS)
-        target_sources(breakpad_client PRIVATE
-            ${BREAKPAD_SOURCES_COMMON_MAC}
-            ${BREAKPAD_SOURCES_CLIENT_MAC})
+        target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON_MAC})
+        target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_CLIENT_MAC})
     else()
-        target_sources(breakpad_client PRIVATE
-            ${BREAKPAD_SOURCES_CLIENT_IOS})
+        target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_CLIENT_IOS})
     endif()
 
-    target_link_libraries(breakpad_client PRIVATE "-framework CoreFoundation")
+    target_link_libraries(breakpad_common PRIVATE "-framework CoreFoundation")
 endif()
 
 if(WIN32)
-    target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON_WINDOWS} ${BREAKPAD_SOURCES_CLIENT_WINDOWS})
-    target_compile_definitions(breakpad_client PRIVATE _UNICODE UNICODE)
+    target_sources(breakpad_common PRIVATE ${BREAKPAD_SOURCES_COMMON_WINDOWS})
+    target_sources(breakpad_common_extra PRIVATE ${BREAKPAD_SOURCES_COMMON_EXTRA_WINDOWS})
+    target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_CLIENT_WINDOWS})
+    target_sources(dump_syms PRIVATE ${BREAKPAD_SOURCES_DUMPSYMS_WINDOWS})
 
-    # set static runtime if enabled
-    if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
-        set_property(TARGET breakpad_client PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    target_compile_definitions(breakpad_common PUBLIC _UNICODE UNICODE)
+
+    target_compile_options(breakpad_common_extra PUBLIC
+        "-I$(VsInstallDir)/DIA SDK/include"
+    )
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^([xX]86(_64)?|amd64|AMD64|[iI]?[3-7]86|intel|INTEL)$")
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(diaguids_libsubdir "/amd64")
+        else()
+            set(diaguids_libsubdir "")
+        endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|AARCH64|arm.*)$")
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(diaguids_libsubdir "/arm64")
+        else()
+            set(diaguids_libsubdir "/arm")
+        endif()
+    else()
+        message(FATAL_ERROR "Unknown CMAKE_SYSTEM_PROCESSOR (${CMAKE_SYSTEM_PROCESSOR}). Don't know where diaguids library lives.")
     endif()
+    target_link_options(breakpad_common_extra PUBLIC
+        "-LIBPATH:$(VsInstallDir)/DIA SDK/lib${diaguids_libsubdir}"
+    )
+    target_link_libraries(breakpad_common_extra PRIVATE dbghelp diaguids imagehlp)
 endif()
 
 # breakpad has includes directly to `third_party/lss/...`,
 # which are being resolved correctly when we add the current directory to
 # the include directories. A giant hack, yes, but it works
+target_include_directories(breakpad_common
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/breakpad/src/>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+)
 target_include_directories(breakpad_client
-	PRIVATE
-		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/breakpad/src/>"
-	PUBLIC
-		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
 )


### PR DESCRIPTION
Part of the build process when using the breakpad backend, is dumping all symbols from an executable (that contains debug symbols).
This pr adds support to the cmake script for building it.

- [ ] This pr needs https://github.com/getsentry/breakpad/pull/17 because there are some breakpad compile errors
- [ ] The sentry-native unit tests do not trigger building `dump_syms` because it only builds the bare minimum
- [ ] Right now, it will build `dump_syms` unconditionally when using the `breakpad` backend.
I did not add exceptions for e.g. Android/iOS/... .
- [ ] Untested on mingw

Some feedback would be appreciated.