### PR TITLE
CMake: Link to the CURL::libcurl target when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,13 +250,17 @@ target_compile_definitions(sentry PRIVATE SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
 
 if(SENTRY_TRANSPORT_CURL)
 	find_package(CURL REQUIRED)
-	target_include_directories(sentry PRIVATE ${CURL_INCLUDE_DIR})
-	# The exported sentry target must not contain any path of the build machine, therefore use generator expressions
-	# FIXME: cmake 3.12 introduced the target CURL::libcurl
-	string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_LIBRARIES "${CURL_LIBRARIES}")
-	string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_COMPILE_DEFINITIONS "${CURL_COMPILE_DEFINITIONS}")
-	target_link_libraries(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_LIBRARIES}>)
-	target_compile_definitions(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_COMPILE_DEFINITIONS}>)
+	if(TARGET CURL::libcurl) # Only available in cmake 3.12+
+		target_link_libraries(sentry PRIVATE CURL::libcurl)
+	else()
+		# FIXME: Needed for cmake < 3.12 support (cmake 3.12 introduced the target CURL::libcurl)
+		target_include_directories(sentry PRIVATE ${CURL_INCLUDE_DIR})
+		# The exported sentry target must not contain any path of the build machine, therefore use generator expressions
+		string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_LIBRARIES "${CURL_LIBRARIES}")
+		string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_COMPILE_DEFINITIONS "${CURL_COMPILE_DEFINITIONS}")
+		target_link_libraries(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_LIBRARIES}>)
+		target_compile_definitions(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_COMPILE_DEFINITIONS}>)
+	endif()
 endif()
 
 set_property(TARGET sentry PROPERTY C_VISIBILITY_PRESET hidden)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ if(SENTRY_TRANSPORT_CURL)
 	if(TARGET CURL::libcurl) # Only available in cmake 3.12+
 		target_link_libraries(sentry PRIVATE CURL::libcurl)
 	else()
-		# FIXME: Needed for cmake < 3.12 support (cmake 3.12 introduced the target CURL::libcurl)
+		# Needed for cmake < 3.12 support (cmake 3.12 introduced the target CURL::libcurl)
 		target_include_directories(sentry PRIVATE ${CURL_INCLUDE_DIR})
 		# The exported sentry target must not contain any path of the build machine, therefore use generator expressions
 		string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_LIBRARIES "${CURL_LIBRARIES}")


### PR DESCRIPTION
Should remove the need for this vcpkg port patch: https://github.com/microsoft/vcpkg/blob/5f32a49551c6101d294c7e73806999abab806570/ports/sentry-native/fix-libcurl.patch

As well as fix some edge-case linking scenarios.

On CMake < 3.12, where `CURL::libcurl` is not defined, it will use the prior code.