### PR TITLE
meta: Update crashpad to 2021-07-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- The crashpad backend compiles with mingw again.
+- Build System improvements.
+
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@irov](https://github.com/irov)
+- [@past-due](https://github.com/past-due)
+
 ## 0.4.11
 
 **Fixes**:


### PR DESCRIPTION
Pick up this required fix for mingw: https://github.com/getsentry/crashpad/commit/7a31c8491ec771d7f7577c63585e2c4c4d49c03c