### PR TITLE
Fix `SENTRY_BUILD_RUNTIMESTATIC` for `sentry_fuzz_json` unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if(SENTRY_BACKEND_CRASHPAD)
 		endif()
 		add_subdirectory(external/crashpad crashpad_build)
 
-		# set static runime if enabled
+		# set static runtime if enabled
 		if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
 			set_property(TARGET crashpad_client PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 			set_property(TARGET crashpad_compat PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -103,4 +103,9 @@ if(MSVC)
 	target_compile_options(sentry_fuzz_json PRIVATE $<BUILD_INTERFACE:/wd5105>)
 endif()
 
+# set static runtime if enabled
+if (SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
+    set_property(TARGET sentry_fuzz_json PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 add_test(NAME sentry_fuzz_json COMMAND sentry_fuzz_json)


### PR DESCRIPTION
<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
I noticed that building
```cmd
cmake -S . -B build -D BUILD_SHARED_LIBS=[ON/OFF] -D SENTRY_BACKEND=crashpad -D SENTRY_BUILD_RUNTIMESTATIC=ON -G ninja
ninja -C build
```
was failing on Windows with errors exactly like in #357 -- I was curious to see the cause of the regression, so I bisected until I found the offending PR #502. I guess in my previous setup and in most people's tests, we set `-D SENTRY_BUILD_TESTS=OFF` and therefore never run into this!

This PR adds the relevant fix to `tests/unit/CMakeLists.txt` to fix the error from #357. I'm not at all familiar with your testing setup, but I'd really recommend setting up a regression test for this.

And to anyone who is running into this, again, the workaround is to set `-D SENTRY_BUILD_TESTS=OFF`. 
