### PR TITLE
meta: Bump python dependencies

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-black==19.10b0
-pytest==5.4.1
-pytest-httpserver==1.0.0
+black==21.9b0
+pytest==6.2.5
+pytest-httpserver==1.0.1


### PR DESCRIPTION
It seems like CI fails due to some kind of python/pytest errors. Lets try bumping these to the latest and see if that helps.
