### PR TITLE
CMake: Check whether libcurl was already found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
 endif()
 
 if(SENTRY_TRANSPORT_CURL)
-	find_package(CURL REQUIRED)
+	if(NOT CURL_FOUND) # Some other lib might bring libcurl already
+		find_package(CURL REQUIRED)
+	endif()
+
 	if(TARGET CURL::libcurl) # Only available in cmake 3.12+
 		target_link_libraries(sentry PRIVATE CURL::libcurl)
 	else()


### PR DESCRIPTION
Currently when there is any other project that brings libcurl as a dependency,
the build fails with “Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)“,
even though libcurl has already added as CURL::libcurl library.

This patch adds a check for CURL_FOUND, to indicate that the library was already
found, if set by another project. It also skips the additional find_package()
step so it does not fail.

Signed-off-by: Ladislav Macoun <ladislavmacoun@gmail.com>

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
