### PR TITLE
CMake: fix `SENTRY_BACKEND` defined in outer scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,10 @@ else()
 	set(SENTRY_DEFAULT_BACKEND "inproc")
 endif()
 
-set(SENTRY_BACKEND ${SENTRY_DEFAULT_BACKEND} CACHE STRING
-  "The sentry backend responsible for reporting crashes, can be either 'none', 'inproc', 'breakpad' or 'crashpad'.")
+if(NOT DEFINED SENTRY_BACKEND)
+	set(SENTRY_BACKEND ${SENTRY_DEFAULT_BACKEND} CACHE STRING
+		"The sentry backend responsible for reporting crashes, can be either 'none', 'inproc', 'breakpad' or 'crashpad'.")
+endif()
 
 if(SENTRY_BACKEND STREQUAL "crashpad")
 	set(SENTRY_BACKEND_CRASHPAD TRUE)


### PR DESCRIPTION
Fixes the situation where `SENTRY_BACKEND` was defined in outer scope.

```cmake
...
set(SENTRY_BACKEND "breakpad")
add_subdirectory(3rdparty/sentry-native)
...
```

before PR
```cmake
...
-- SENTRY_TRANSPORT=winhttp
-- SENTRY_BACKEND=crashpad
-- SENTRY_LIBRARY_TYPE=STATIC
...
```

after PR
```cmake
...
-- SENTRY_TRANSPORT=winhttp
-- SENTRY_BACKEND=breakpad
-- SENTRY_LIBRARY_TYPE=STATIC
...
```