### PR TITLE
feat(tracing): Add config options

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1198,6 +1198,34 @@ SENTRY_API void sentry_start_session(void);
  */
 SENTRY_API void sentry_end_session(void);
 
+/**
+ * Sets the maximum number of spans that can be attached to a
+ * transaction.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_options_set_max_spans(
+    sentry_options_t *opts, size_t max_spans);
+
+/**
+ * Gets the maximum number of spans that can be attached to a
+ * transaction.
+ */
+SENTRY_EXPERIMENTAL_API int sentry_options_get_max_spans(
+    sentry_options_t *opts);
+
+/**
+ * Sets the sample rate for transactions. Should be a double between
+ * `0.0` and `1.0`. Transactions will be randomly discarded during
+ * `sentry_transaction_finish` when the sample rate is < 1.0.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_options_set_traces_sample_rate(
+    sentry_options_t *opts, double sample_rate);
+
+/**
+ * Returns the sample rate for transactions.
+ */
+SENTRY_EXPERIMENTAL_API double sentry_options_get_traces_sample_rate(
+    sentry_options_t *opts);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1209,7 +1209,7 @@ SENTRY_EXPERIMENTAL_API void sentry_options_set_max_spans(
  * Gets the maximum number of spans that can be attached to a
  * transaction.
  */
-SENTRY_EXPERIMENTAL_API int sentry_options_get_max_spans(
+SENTRY_EXPERIMENTAL_API size_t sentry_options_get_max_spans(
     sentry_options_t *opts);
 
 /**

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -389,7 +389,7 @@ sentry_options_set_max_spans(sentry_options_t *opts, size_t max_spans)
  * Gets the maximum number of spans that can be attached to a
  * transaction.
  */
-int
+size_t
 sentry_options_get_max_spans(sentry_options_t *opts)
 {
     return opts->max_spans;

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -51,6 +51,9 @@ sentry_options_new(void)
     opts->sample_rate = 1.0;
     opts->refcount = 1;
     opts->shutdown_timeout = SENTRY_DEFAULT_SHUTDOWN_TIMEOUT;
+
+    opts->traces_sample_rate = 0;
+    opts->max_spans = 0;
     return opts;
 }
 
@@ -371,3 +374,50 @@ sentry_options_set_database_pathw(sentry_options_t *opts, const wchar_t *path)
     opts->database_path = sentry__path_from_wstr(path);
 }
 #endif
+
+/**
+ * Sets the maximum number of spans that can be attached to a
+ * transaction.
+ */
+void
+sentry_options_set_max_spans(sentry_options_t *opts, size_t max_spans)
+{
+    opts->max_spans = max_spans;
+}
+
+/**
+ * Gets the maximum number of spans that can be attached to a
+ * transaction.
+ */
+int
+sentry_options_get_max_spans(sentry_options_t *opts)
+{
+    return opts->max_spans;
+}
+
+/**
+ * Sets the sample rate for transactions. Should be a double between
+ * `0.0` and `1.0`. Transactions will be randomly discarded during
+ * `sentry_transaction_finish` when the sample rate is < 1.0.
+ */
+void
+sentry_options_set_traces_sample_rate(
+    sentry_options_t *opts, double sample_rate)
+{
+
+    if (sample_rate < 0.0) {
+        sample_rate = 0.0;
+    } else if (sample_rate > 1.0) {
+        sample_rate = 1.0;
+    }
+    opts->traces_sample_rate = sample_rate;
+}
+
+/**
+ * Returns the sample rate for transactions.
+ */
+double
+sentry_options_get_traces_sample_rate(sentry_options_t *opts)
+{
+    return opts->traces_sample_rate;
+}

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -52,7 +52,7 @@ sentry_options_new(void)
     opts->refcount = 1;
     opts->shutdown_timeout = SENTRY_DEFAULT_SHUTDOWN_TIMEOUT;
 
-    opts->traces_sample_rate = 0;
+    opts->traces_sample_rate = 0.0;
     opts->max_spans = 0;
     return opts;
 }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -55,6 +55,10 @@ typedef struct sentry_options_s {
     sentry_event_function_t before_send_func;
     void *before_send_data;
 
+    /* Experimentally exposed */
+    double traces_sample_rate;
+    size_t max_spans;
+
     /* everything from here on down are options which are stored here but
        not exposed through the options API */
     struct sentry_backend_s *backend;


### PR DESCRIPTION
This adds basic config values to sentry options that will be used by performance monitoring. The traces sampler is deliberately omitted from this due to its complexity.
