### PR TITLE
ci(codechecker): Workaround for code checker not building due to node issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           sudo apt install clang-tidy curl doxygen gcc-multilib libxml2-dev libxslt1-dev python3-dev python3-virtualenv
           git clone https://github.com/Ericsson/CodeChecker.git --depth 1 --branch v6.15.0
           cd CodeChecker
-          BUILD_LOGGER_64_BIT_ONLY=YES make standalone_package
+          BUILD_LOGGER_64_BIT_ONLY=YES BUILD_UI_DIST=NO make standalone_package
           echo "$PWD/build/CodeChecker/bin" >> $GITHUB_PATH
 
       - name: Expose llvm PATH for Mac


### PR DESCRIPTION
It looks like codechecker's using a node feature (node-fibers) that is no longer supported on the version of node on our ubuntu image. I've used the workaround suggested in https://github.com/Ericsson/codechecker/issues/3353. It doesn't look like it should have a negative impact on our runs in CI as I would assume that it shouldn't care for UI builds by design, but I could be misinterpreting the flag.