### PR TITLE
fix: Read Windows Version from Registry

### DIFF
--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -11,13 +11,13 @@ void *
 sentry__try_file_version(LPCWSTR filename)
 {
 
-    DWORD size = GetFileVersionInfoSizeW(L"ntoskrnl.exe", NULL);
+    DWORD size = GetFileVersionInfoSizeW(filename, NULL);
     if (!size) {
         return NULL;
     }
 
     void *ffibuf = sentry_malloc(size);
-    if (!GetFileVersionInfoW(L"ntoskrnl.exe", 0, size, ffibuf)) {
+    if (!GetFileVersionInfoW(filename, 0, size, ffibuf)) {
         sentry_free(ffibuf);
         return NULL;
     }

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -19,13 +19,13 @@ sentry__get_os_context(void)
 
     void *ffibuf = NULL;
 
-    DWORD size = GetFileVersionInfoSizeW(L"kernel32.dll", NULL);
+    DWORD size = GetFileVersionInfoSizeW(L"ntoskrnl.exe", NULL);
     if (!size) {
         goto fail;
     }
 
     ffibuf = sentry_malloc(size);
-    if (!GetFileVersionInfoW(L"kernel32.dll", 0, size, ffibuf)) {
+    if (!GetFileVersionInfoW(L"ntoskrnl.exe", 0, size, ffibuf)) {
         goto fail;
     }
 


### PR DESCRIPTION
We were previously relying on the `kernel32.dll` version, as does
Crashpad. However that version can lag behind OS releases, which can
manifest itself as failing integration tests, as the version does not
match the one returned from python `platform.version()`.

CC @Mixaill as you suggested this back in https://github.com/getsentry/sentry-native/pull/467#pullrequestreview-578269776