### PR TITLE
ci: Make integration tests capable of reading the non-backwards compatible version number for Big Sur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,18 @@ jobs:
           - name: macOS (xcode llvm)
             os: macOs-latest
             ERROR_ON_WARNINGS: 1
+            SYSTEM_VERSION_COMPAT: 0
           - name: macOS (xcode llvm + universal)
             os: macOs-latest
             ERROR_ON_WARNINGS: 1
+            SYSTEM_VERSION_COMPAT: 0
             CMAKE_DEFINES: -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
           - name: macOS (clang 11 + asan + llvm-cov)
             os: macOs-latest
             CC: clang
             CXX: clang++
             ERROR_ON_WARNINGS: 1
+            SYSTEM_VERSION_COMPAT: 0
             RUN_ANALYZER: asan,llvm-cov
           - name: Windows (VS2017, 32bit)
             os: vs2017-win2016
@@ -98,6 +101,7 @@ jobs:
       ANDROID_API: ${{ matrix.ANDROID_API }}
       ANDROID_NDK: ${{ matrix.ANDROID_NDK }}
       CMAKE_DEFINES: ${{ matrix.CMAKE_DEFINES }}
+      SYSTEM_VERSION_COMPAT: ${{ matrix.SYSTEM_VERSION_COMPAT }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
tl;dr fix macos ci

We're using `macos-latest` in our integration tests, which has recently been bumped up from 10.15 to ~11.6 (see https://github.com/actions/virtual-environments/issues/4060 and reported operating system in https://github.com/getsentry/sentry-native/actions/runs/1575459945 after the bump was pushed).

Thankfully, the only thing that appears to have broken are our integration tests because of a versioning quirk. Python's `platform.mac_ver()` is reporting that it's on version 10.16 which is a backwards-compatible version number that represents Big Sur. Something else is using the non-backwards compatible version number with the major version bumped up to 11, causing an unintentional mismatch. More on this can be found in https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/ and https://stackoverflow.com/questions/65290242.

Long story short, it looks like a quick fix for this is to just simply specify an environment variable so that `platform.mac_ver()` returns `11.xx`. Some digging around suggests that building... Python? against the correct mac SDKs would fix this, but I'm not sure how exactly one would accomplish this in our CI. There's only one binary for darwin in https://github.com/actions/python-versions, and I would assume that if that binary doesn't solve the problem out of the box there isn't too much that we can personally do, assuming there is anything to be done.