### PR TITLE
feat(tracing): Introduce a helper that identifies events that are transactions

### DIFF
--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -422,8 +422,6 @@ sentry__should_skip_transaction(sentry_value_t tx_cxt)
 bool
 sentry__should_skip_event(const sentry_options_t *options, sentry_value_t event)
 {
-    sentry_value_t event_type = sentry_value_get_by_key(event, "type");
-    // Not a transaction
     if (sentry__event_is_transaction(event)) {
         // The sampling decision should already be made for transactions
         // during their construction. No need to recalculate here.

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -353,6 +353,16 @@ event_is_considered_error(sentry_value_t event)
     return false;
 }
 
+bool
+sentry__event_is_transaction(sentry_value_t event)
+{
+    sentry_value_t event_type = sentry_value_get_by_key(event, "type");
+    if (sentry__string_eq("transaction", sentry_value_as_string(event_type))) {
+        return true;
+    }
+    return false;
+}
+
 sentry_uuid_t
 sentry_capture_event(sentry_value_t event)
 {
@@ -414,13 +424,13 @@ sentry__should_skip_event(const sentry_options_t *options, sentry_value_t event)
 {
     sentry_value_t event_type = sentry_value_get_by_key(event, "type");
     // Not a transaction
-    if (sentry_value_is_null(event_type)) {
-        return !sentry__roll_dice(options->sample_rate);
-    } else {
+    if (sentry__event_is_transaction(event)) {
         // The sampling decision should already be made for transactions
         // during their construction. No need to recalculate here.
         // See `sentry__should_skip_transaction`.
         return !sentry_value_is_true(sentry_value_get_by_key(event, "sampled"));
+    } else {
+        return !sentry__roll_dice(options->sample_rate);
     }
 }
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -357,10 +357,7 @@ bool
 sentry__event_is_transaction(sentry_value_t event)
 {
     sentry_value_t event_type = sentry_value_get_by_key(event, "type");
-    if (sentry__string_eq("transaction", sentry_value_as_string(event_type))) {
-        return true;
-    }
-    return false;
+    return sentry__string_eq("transaction", sentry_value_as_string(event_type));
 }
 
 sentry_uuid_t

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -29,6 +29,12 @@
 bool sentry__should_skip_upload(void);
 
 /**
+ * Given a well-formed event, returns whether an event is a transaction or not.
+ * Defaults to false, which will also be returned if the event is malformed.
+ */
+bool sentry__event_is_transaction(sentry_value_t event);
+
+/**
  * Convert the given event into an envelope.
  *
  * More specifically, it will do the following things:


### PR DESCRIPTION
Does what it says on the tin. There are a few places that need to know this, so pull this out into a helper to avoid duplicating logic. This isn't `static` because it does get used in a different file later.

relates to #601 