### PR TITLE
feat(tracing): Restrict `sentry_capture_event` so it only sends non-transaction events

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1103,7 +1103,8 @@ SENTRY_API void sentry_user_consent_reset(void);
 SENTRY_API sentry_user_consent_t sentry_user_consent_get(void);
 
 /**
- * Sends a sentry event.
+ * Sends a sentry event. Returns a nil UUID if the event being passed in is a
+ * transaction; `sentry_transaction_finish` should be used to send transactions.
  */
 SENTRY_API sentry_uuid_t sentry_capture_event(sentry_value_t event);
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -366,13 +366,27 @@ sentry__event_is_transaction(sentry_value_t event)
 sentry_uuid_t
 sentry_capture_event(sentry_value_t event)
 {
+    if (sentry__event_is_transaction(event)) {
+        return sentry_uuid_nil();
+    } else {
+        return sentry__capture_event(event);
+    }
+}
+
+sentry_uuid_t
+sentry__capture_event(sentry_value_t event)
+{
     sentry_uuid_t event_id;
     sentry_envelope_t *envelope = NULL;
 
     bool was_captured = false;
     SENTRY_WITH_OPTIONS (options) {
         was_captured = true;
-        envelope = sentry__prepare_event(options, event, &event_id);
+        if (sentry__event_is_transaction(event)) {
+            return sentry_uuid_nil();
+        } else {
+            envelope = sentry__prepare_event(options, event, &event_id);
+        }
         if (envelope) {
             if (options->session) {
                 SENTRY_WITH_OPTIONS_MUT (mut_options) {

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -422,8 +422,6 @@ sentry__should_skip_transaction(sentry_value_t tx_cxt)
 bool
 sentry__should_skip_event(const sentry_options_t *options, sentry_value_t event)
 {
-    sentry_value_t event_type = sentry_value_get_by_key(event, "type");
-    // Not a transaction
     if (sentry__event_is_transaction(event)) {
         // The sampling decision should already be made for transactions
         // during their construction. No need to recalculate here.

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -353,6 +353,16 @@ event_is_considered_error(sentry_value_t event)
     return false;
 }
 
+bool
+sentry__event_is_transaction(sentry_value_t event)
+{
+    sentry_value_t event_type = sentry_value_get_by_key(event, "type");
+    if (sentry__string_eq("transaction", sentry_value_as_string(event_type))) {
+        return true;
+    }
+    return false;
+}
+
 sentry_uuid_t
 sentry_capture_event(sentry_value_t event)
 {
@@ -414,13 +424,13 @@ sentry__should_skip_event(const sentry_options_t *options, sentry_value_t event)
 {
     sentry_value_t event_type = sentry_value_get_by_key(event, "type");
     // Not a transaction
-    if (sentry_value_is_null(event_type)) {
-        return !sentry__roll_dice(options->sample_rate);
-    } else {
+    if (sentry__event_is_transaction(event)) {
         // The sampling decision should already be made for transactions
         // during their construction. No need to recalculate here.
         // See `sentry__should_skip_transaction`.
         return !sentry_value_is_true(sentry_value_get_by_key(event, "sampled"));
+    } else {
+        return !sentry__roll_dice(options->sample_rate);
     }
 }
 

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -52,6 +52,11 @@ sentry_envelope_t *sentry__prepare_event(const sentry_options_t *options,
     sentry_value_t event, sentry_uuid_t *event_id);
 
 /**
+ * Sends a sentry event, regardless of its type.
+ */
+sentry_uuid_t sentry__capture_event(sentry_value_t event);
+
+/**
  * This function will submit the `envelope` to the given `transport`, first
  * checking for consent.
  */

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -29,6 +29,12 @@
 bool sentry__should_skip_upload(void);
 
 /**
+ * Given a well-formed event, returns whether an event is a transaction or not.
+ * Defaults to false, which will also be returned if the event is malformed.
+ */
+bool sentry__event_is_transaction(sentry_value_t event);
+
+/**
  * Convert the given event into an envelope.
  *
  * More specifically, it will do the following things:


### PR DESCRIPTION
Transactions will want to piggyback on most of what the original `sentry_capture_event` already does, but this means that it'll be possible to pass in transactions in to that function. This deliberately prevents users from being able to inadvertently finish transactions with this function.

relates to #601 