### PR TITLE
fix: Read section names safely

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -318,19 +318,14 @@ get_code_id_from_text_fallback(const sentry_module_t *module)
             elf.e_shoff + elf.e_shentsize * elf.e_shstrndx,
             sizeof(Elf64_Shdr)));
 
-        const char *names = sentry__module_get_addr(
-            module, strheader.sh_offset, strheader.sh_entsize);
-        ENSURE(names);
         for (int i = 0; i < elf.e_shnum; i++) {
             Elf64_Shdr header;
             ENSURE(sentry__module_read_safely(&header, module,
                 elf.e_shoff + elf.e_shentsize * i, sizeof(Elf64_Shdr)));
 
             char name[6];
-            if (!sentry__module_read_safely(name, module,
-                    (uintptr_t)names + header.sh_name, sizeof(name))) {
-                continue;
-            }
+            ENSURE(sentry__module_read_safely(name, module,
+                strheader.sh_offset + header.sh_name, sizeof(name)));
             name[5] = '\0';
             if (header.sh_type == SHT_PROGBITS && strcmp(name, ".text") == 0) {
                 text = sentry__module_get_addr(
@@ -349,19 +344,14 @@ get_code_id_from_text_fallback(const sentry_module_t *module)
             elf.e_shoff + elf.e_shentsize * elf.e_shstrndx,
             sizeof(Elf32_Shdr)));
 
-        const char *names = sentry__module_get_addr(
-            module, strheader.sh_offset, strheader.sh_entsize);
-        ENSURE(names);
         for (int i = 0; i < elf.e_shnum; i++) {
             Elf32_Shdr header;
             ENSURE(sentry__module_read_safely(&header, module,
                 elf.e_shoff + elf.e_shentsize * i, sizeof(Elf32_Shdr)));
 
             char name[6];
-            if (!sentry__module_read_safely(name, module,
-                    (uintptr_t)names + header.sh_name, sizeof(name))) {
-                continue;
-            }
+            ENSURE(sentry__module_read_safely(name, module,
+                strheader.sh_offset + header.sh_name, sizeof(name)));
             name[5] = '\0';
             if (header.sh_type == SHT_PROGBITS && strcmp(name, ".text") == 0) {
                 text = sentry__module_get_addr(

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -327,7 +327,7 @@ get_code_id_from_text_fallback(const sentry_module_t *module)
                 elf.e_shoff + elf.e_shentsize * i, sizeof(Elf64_Shdr)));
 
             char name[6];
-            if (!sentry__module_read_safely(&name, module,
+            if (!sentry__module_read_safely(name, module,
                     (uintptr_t)names + header.sh_name, sizeof(name))) {
                 continue;
             }
@@ -358,7 +358,7 @@ get_code_id_from_text_fallback(const sentry_module_t *module)
                 elf.e_shoff + elf.e_shentsize * i, sizeof(Elf32_Shdr)));
 
             char name[6];
-            if (!sentry__module_read_safely(&name, module,
+            if (!sentry__module_read_safely(name, module,
                     (uintptr_t)names + header.sh_name, sizeof(name))) {
                 continue;
             }

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -327,8 +327,10 @@ get_code_id_from_text_fallback(const sentry_module_t *module)
                 elf.e_shoff + elf.e_shentsize * i, sizeof(Elf64_Shdr)));
 
             char name[6];
-            ENSURE(sentry__module_read_safely(&name, module,
-                (uintptr_t)names + header.sh_name, sizeof(name)));
+            if (!sentry__module_read_safely(&name, module,
+                    (uintptr_t)names + header.sh_name, sizeof(name))) {
+                continue;
+            }
             name[5] = '\0';
             if (header.sh_type == SHT_PROGBITS && strcmp(name, ".text") == 0) {
                 text = sentry__module_get_addr(
@@ -356,8 +358,10 @@ get_code_id_from_text_fallback(const sentry_module_t *module)
                 elf.e_shoff + elf.e_shentsize * i, sizeof(Elf32_Shdr)));
 
             char name[6];
-            ENSURE(sentry__module_read_safely(&name, module,
-                (uintptr_t)names + header.sh_name, sizeof(name)));
+            if (!sentry__module_read_safely(&name, module,
+                    (uintptr_t)names + header.sh_name, sizeof(name))) {
+                continue;
+            }
             name[5] = '\0';
             if (header.sh_type == SHT_PROGBITS && strcmp(name, ".text") == 0) {
                 text = sentry__module_get_addr(


### PR DESCRIPTION
Avoids a potential segfault reading the section names, and also falls back when
vm_readv lacks permissions.

Should fix #578