### PR TITLE
feat(tracing): Move all performance monitoring code behind a compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,7 @@ set_target_properties(sentry PROPERTIES PUBLIC_HEADER "include/sentry.h")
 
 if(DEFINED SENTRY_FOLDER)
 	set_target_properties(sentry PROPERTIES FOLDER ${SENTRY_FOLDER})
-endif()	
+endif()
 
 # check size type
 include(CheckTypeSize)
@@ -457,7 +457,7 @@ if(SENTRY_BACKEND_CRASHPAD)
 			set_target_properties(crashpad_util PROPERTIES FOLDER ${SENTRY_FOLDER})
 			set_target_properties(crashpad_zlib PROPERTIES FOLDER ${SENTRY_FOLDER})
 			set_target_properties(mini_chromium PROPERTIES FOLDER ${SENTRY_FOLDER})
-		endif()	
+		endif()
 
 		target_link_libraries(sentry PRIVATE
 			$<BUILD_INTERFACE:crashpad::client>
@@ -490,8 +490,8 @@ elseif(SENTRY_BACKEND_BREAKPAD)
 
 		if(DEFINED SENTRY_FOLDER)
 			set_target_properties(breakpad_client PROPERTIES FOLDER ${SENTRY_FOLDER})
-		endif()	
-		
+		endif()
+
 		if(NOT SENTRY_BUILD_SHARED_LIBS)
 			sentry_install(TARGETS breakpad_client EXPORT sentry
 				LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -559,6 +559,9 @@ if(SENTRY_BUILD_EXAMPLES)
 	add_executable(sentry_example examples/example.c)
 	target_link_libraries(sentry_example PRIVATE sentry)
 
+	target_compile_definitions(sentry PRIVATE SENTRY_PERFORMANCE_MONITORING)
+	target_compile_definitions(sentry_example PRIVATE SENTRY_PERFORMANCE_MONITORING)
+
 	if(MSVC)
 		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/wd5105>)
 	endif()
@@ -570,7 +573,7 @@ if(SENTRY_BUILD_EXAMPLES)
 
 	if(DEFINED SENTRY_FOLDER)
 		set_target_properties(sentry_example PROPERTIES FOLDER ${SENTRY_FOLDER})
-	endif()	
+	endif()
 
 	add_test(NAME sentry_example COMMAND sentry_example)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,7 +559,6 @@ if(SENTRY_BUILD_EXAMPLES)
 	add_executable(sentry_example examples/example.c)
 	target_link_libraries(sentry_example PRIVATE sentry)
 
-	target_compile_definitions(sentry PRIVATE SENTRY_PERFORMANCE_MONITORING)
 	target_compile_definitions(sentry_example PRIVATE SENTRY_PERFORMANCE_MONITORING)
 
 	if(MSVC)

--- a/examples/example.c
+++ b/examples/example.c
@@ -93,9 +93,11 @@ main(int argc, char **argv)
             options, sentry_transport_new(print_envelope));
     }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
     if (has_arg(argc, argv, "capture-transaction")) {
         sentry_options_set_traces_sample_rate(options, 1.0);
     }
+#endif
 
     sentry_init(options);
 
@@ -212,6 +214,7 @@ main(int argc, char **argv)
         sentry_capture_event(event);
     }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
     if (has_arg(argc, argv, "capture-transaction")) {
         sentry_value_t tx_ctx
             = sentry_value_new_transaction_context("I'm a little teapot",
@@ -224,6 +227,7 @@ main(int argc, char **argv)
         sentry_value_t tx = sentry_transaction_start(tx_ctx);
         sentry_transaction_finish(tx);
     }
+#endif
 
     // make sure everything flushes
     sentry_close();

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1112,16 +1112,13 @@ SENTRY_API void sentry_user_consent_reset(void);
  */
 SENTRY_API sentry_user_consent_t sentry_user_consent_get(void);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
-/**
- * Sends a sentry event. Returns a nil UUID if the event being passed in is a
- * transaction; `sentry_transaction_finish` should be used to send transactions.
- */
-#else
 /**
  * Sends a sentry event.
+ *
+ * If SENTRY_PERFORMANCE_MONITORING is enabled, returns a nil UUID if the event
+ * being passed in is a transaction, and the transaction will not be sent nor
+ * consumed. `sentry_transaction_finish` should be used to send transactions.
  */
-#endif
 SENTRY_API sentry_uuid_t sentry_capture_event(sentry_value_t event);
 
 /**

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -561,6 +561,7 @@ SENTRY_API void sentry_envelope_free(sentry_envelope_t *envelope);
 SENTRY_API sentry_value_t sentry_envelope_get_event(
     const sentry_envelope_t *envelope);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Given an Envelope, returns the embedded Transaction if there is one.
  *
@@ -568,6 +569,7 @@ SENTRY_API sentry_value_t sentry_envelope_get_event(
  */
 SENTRY_EXPERIMENTAL_API sentry_value_t sentry_envelope_get_transaction(
     const sentry_envelope_t *envelope);
+#endif
 
 /**
  * Serializes the envelope.
@@ -1110,10 +1112,16 @@ SENTRY_API void sentry_user_consent_reset(void);
  */
 SENTRY_API sentry_user_consent_t sentry_user_consent_get(void);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Sends a sentry event. Returns a nil UUID if the event being passed in is a
  * transaction; `sentry_transaction_finish` should be used to send transactions.
  */
+#else
+/**
+ * Sends a sentry event.
+ */
+#endif
 SENTRY_API sentry_uuid_t sentry_capture_event(sentry_value_t event);
 
 /**
@@ -1207,6 +1215,7 @@ SENTRY_API void sentry_start_session(void);
  */
 SENTRY_API void sentry_end_session(void);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Sets the maximum number of spans that can be attached to a
  * transaction.
@@ -1311,6 +1320,7 @@ SENTRY_EXPERIMENTAL_API sentry_value_t sentry_transaction_start(
  */
 SENTRY_EXPERIMENTAL_API sentry_uuid_t sentry_transaction_finish(
     sentry_value_t transaction);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,6 @@ sentry_target_sources_cwd(sentry
 	sentry_symbolizer.h
 	sentry_sync.c
 	sentry_sync.h
-	sentry_tracing.c
-	sentry_tracing.h
 	sentry_transport.c
 	sentry_transport.h
 	sentry_utils.c
@@ -156,4 +154,8 @@ endif()
 
 if(SENTRY_BUILD_EXAMPLES)
 	target_compile_definitions(sentry PRIVATE SENTRY_PERFORMANCE_MONITORING)
+	sentry_target_sources_cwd(sentry
+	sentry_tracing.c
+	sentry_tracing.h
+	)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,3 +153,7 @@ if(SENTRY_INTEGRATION_QT)
 		integrations/sentry_integration_qt.h
 	)
 endif()
+
+if(SENTRY_BUILD_EXAMPLES)
+	target_compile_definitions(sentry PRIVATE SENTRY_PERFORMANCE_MONITORING)
+endif()

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -28,11 +28,13 @@
  */
 bool sentry__should_skip_upload(void);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Given a well-formed event, returns whether an event is a transaction or not.
  * Defaults to false, which will also be returned if the event is malformed.
  */
 bool sentry__event_is_transaction(sentry_value_t event);
+#endif
 
 /**
  * Convert the given event into an envelope. This assumes that the event
@@ -57,6 +59,7 @@ sentry_envelope_t *sentry__prepare_event(const sentry_options_t *options,
  */
 sentry_uuid_t sentry__capture_event(sentry_value_t event);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Convert the given transaction into an envelope. This assumes that the
  * event being passed in is a transaction.
@@ -74,6 +77,7 @@ sentry_uuid_t sentry__capture_event(sentry_value_t event);
  */
 sentry_envelope_t *sentry__prepare_transaction(const sentry_options_t *options,
     sentry_value_t transaction, sentry_uuid_t *event_id);
+#endif
 
 /**
  * This function will submit the `envelope` to the given `transport`, first

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -200,15 +200,23 @@ sentry_envelope_get_event(const sentry_envelope_t *envelope)
         return sentry_value_new_null();
     }
     for (size_t i = 0; i < envelope->contents.items.item_count; i++) {
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
         if (!sentry_value_is_null(envelope->contents.items.items[i].event)
             && !sentry__event_is_transaction(
                 envelope->contents.items.items[i].event)) {
             return envelope->contents.items.items[i].event;
         }
+#else
+        if (!sentry_value_is_null(envelope->contents.items.items[i].event)) {
+            return envelope->contents.items.items[i].event;
+        }
+#endif
     }
     return sentry_value_new_null();
 }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_value_t
 sentry_envelope_get_transaction(const sentry_envelope_t *envelope)
 {
@@ -224,6 +232,7 @@ sentry_envelope_get_transaction(const sentry_envelope_t *envelope)
     }
     return sentry_value_new_null();
 }
+#endif
 
 sentry_envelope_item_t *
 sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
@@ -255,6 +264,7 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
     return item;
 }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_envelope_item_t *
 sentry__envelope_add_transaction(
     sentry_envelope_t *envelope, sentry_value_t transaction)
@@ -283,16 +293,17 @@ sentry__envelope_add_transaction(
     sentry_value_incref(event_id);
     sentry__envelope_set_header(envelope, "event_id", event_id);
 
-#ifdef SENTRY_UNITTEST
+#    ifdef SENTRY_UNITTEST
     sentry_value_t now = sentry_value_new_string("2021-12-16T05:53:59.343Z");
-#else
+#    else
     sentry_value_t now = sentry__value_new_string_owned(
         sentry__msec_time_to_iso8601(sentry__msec_time()));
-#endif
+#    endif
     sentry__envelope_set_header(envelope, "sent_at", now);
 
     return item;
 }
+#endif
 
 sentry_envelope_item_t *
 sentry__envelope_add_session(

--- a/src/sentry_envelope.h
+++ b/src/sentry_envelope.h
@@ -36,11 +36,13 @@ sentry_uuid_t sentry__envelope_get_event_id(const sentry_envelope_t *envelope);
 sentry_envelope_item_t *sentry__envelope_add_event(
     sentry_envelope_t *envelope, sentry_value_t event);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Add a transaction to this envelope.
  */
 sentry_envelope_item_t *sentry__envelope_add_transaction(
     sentry_envelope_t *envelope, sentry_value_t transaction);
+#endif
 
 /**
  * Add a session to this envelope.

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -52,8 +52,11 @@ sentry_options_new(void)
     opts->refcount = 1;
     opts->shutdown_timeout = SENTRY_DEFAULT_SHUTDOWN_TIMEOUT;
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
     opts->traces_sample_rate = 0.0;
     opts->max_spans = 0;
+#endif
+
     return opts;
 }
 
@@ -375,6 +378,7 @@ sentry_options_set_database_pathw(sentry_options_t *opts, const wchar_t *path)
 }
 #endif
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Sets the maximum number of spans that can be attached to a
  * transaction.
@@ -421,3 +425,4 @@ sentry_options_get_traces_sample_rate(sentry_options_t *opts)
 {
     return opts->traces_sample_rate;
 }
+#endif

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -55,9 +55,11 @@ typedef struct sentry_options_s {
     sentry_event_function_t before_send_func;
     void *before_send_data;
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
     /* Experimentally exposed */
     double traces_sample_rate;
     size_t max_spans;
+#endif
 
     /* everything from here on down are options which are stored here but
        not exposed through the options API */

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -7,7 +7,7 @@
 #include "sentry_string.h"
 #include "sentry_symbolizer.h"
 #include "sentry_sync.h"
-#include "sentry_tracing.h"
+
 #include <stdlib.h>
 
 #ifdef SENTRY_BACKEND_CRASHPAD
@@ -16,6 +16,10 @@
 #    define SENTRY_BACKEND "breakpad"
 #elif defined(SENTRY_BACKEND_INPROC)
 #    define SENTRY_BACKEND "inproc"
+#endif
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
+#    include "sentry_tracing.h"
 #endif
 
 static bool g_scope_initialized = false;
@@ -74,7 +78,10 @@ get_scope(void)
     g_scope.breadcrumbs = sentry_value_new_list();
     g_scope.level = SENTRY_LEVEL_ERROR;
     g_scope.client_sdk = get_client_sdk();
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
     g_scope.span = sentry_value_new_null();
+#endif
 
     g_scope_initialized = true;
 
@@ -95,7 +102,10 @@ sentry__scope_cleanup(void)
         sentry_value_decref(g_scope.contexts);
         sentry_value_decref(g_scope.breadcrumbs);
         sentry_value_decref(g_scope.client_sdk);
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
         sentry_value_decref(g_scope.span);
+#endif
     }
     sentry__mutex_unlock(&g_lock);
 }
@@ -227,6 +237,7 @@ sentry__symbolize_stacktrace(sentry_value_t stacktrace)
     }
 }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 void
 sentry__scope_set_span(sentry_value_t span)
 {
@@ -234,6 +245,7 @@ sentry__scope_set_span(sentry_value_t span)
     (void)span;
     return;
 }
+#endif
 
 void
 sentry__scope_apply_to_event(const sentry_scope_t *scope,
@@ -282,6 +294,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
     PLACE_CLONED_VALUE("tags", scope->tags);
     PLACE_CLONED_VALUE("extra", scope->extra);
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
     // TODO: better, more thorough deep merging
     sentry_value_t contexts = sentry__value_clone(scope->contexts);
     sentry_value_t trace = sentry__span_get_trace_context(scope->span);
@@ -290,6 +303,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
     }
     PLACE_VALUE("contexts", contexts);
     sentry_value_decref(contexts);
+#endif
 
     if (mode & SENTRY_SCOPE_BREADCRUMBS) {
         PLACE_CLONED_VALUE("breadcrumbs", scope->breadcrumbs);

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -19,12 +19,15 @@ typedef struct sentry_scope_s {
     sentry_value_t breadcrumbs;
     sentry_level_t level;
     sentry_value_t client_sdk;
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
     // Not to be confused with transaction, which is a legacy value. This is
     // also known as a transaction, but to maintain consistency with other SDKs
     // and to avoid a conflict with the existing transaction field this is named
     // span. Whenever possible, `transaction` should pull its value from the
     // `name` property nested in this field.
     sentry_value_t span;
+#endif
 } sentry_scope_t;
 
 /**

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -1,4 +1,5 @@
-#include "sentry_sync.h"
+#ifdef SENTRY_PERFORMANCE_MONITORING
+#    include "sentry_value.h"
 
 sentry_value_t
 sentry__span_get_trace_context(sentry_value_t span)
@@ -11,14 +12,14 @@ sentry__span_get_trace_context(sentry_value_t span)
 
     sentry_value_t trace_context = sentry_value_new_object();
 
-#define PLACE_VALUE(Key, Source)                                               \
-    do {                                                                       \
-        sentry_value_t src = sentry_value_get_by_key(Source, Key);             \
-        if (!sentry_value_is_null(src)) {                                      \
-            sentry_value_incref(src);                                          \
-            sentry_value_set_by_key(trace_context, Key, src);                  \
-        }                                                                      \
-    } while (0)
+#    define PLACE_VALUE(Key, Source)                                           \
+        do {                                                                   \
+            sentry_value_t src = sentry_value_get_by_key(Source, Key);         \
+            if (!sentry_value_is_null(src)) {                                  \
+                sentry_value_incref(src);                                      \
+                sentry_value_set_by_key(trace_context, Key, src);              \
+            }                                                                  \
+        } while (0)
 
     PLACE_VALUE("trace_id", span);
     PLACE_VALUE("span_id", span);
@@ -29,5 +30,6 @@ sentry__span_get_trace_context(sentry_value_t span)
 
     return trace_context;
 
-#undef PLACE_VALUE
+#    undef PLACE_VALUE
 }
+#endif

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -1,5 +1,4 @@
-#ifdef SENTRY_PERFORMANCE_MONITORING
-#    include "sentry_value.h"
+#include "sentry_value.h"
 
 sentry_value_t
 sentry__span_get_trace_context(sentry_value_t span)
@@ -12,14 +11,14 @@ sentry__span_get_trace_context(sentry_value_t span)
 
     sentry_value_t trace_context = sentry_value_new_object();
 
-#    define PLACE_VALUE(Key, Source)                                           \
-        do {                                                                   \
-            sentry_value_t src = sentry_value_get_by_key(Source, Key);         \
-            if (!sentry_value_is_null(src)) {                                  \
-                sentry_value_incref(src);                                      \
-                sentry_value_set_by_key(trace_context, Key, src);              \
-            }                                                                  \
-        } while (0)
+#define PLACE_VALUE(Key, Source)                                               \
+    do {                                                                       \
+        sentry_value_t src = sentry_value_get_by_key(Source, Key);             \
+        if (!sentry_value_is_null(src)) {                                      \
+            sentry_value_incref(src);                                          \
+            sentry_value_set_by_key(trace_context, Key, src);                  \
+        }                                                                      \
+    } while (0)
 
     PLACE_VALUE("trace_id", span);
     PLACE_VALUE("span_id", span);
@@ -30,6 +29,5 @@ sentry__span_get_trace_context(sentry_value_t span)
 
     return trace_context;
 
-#    undef PLACE_VALUE
+#undef PLACE_VALUE
 }
-#endif

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -1,8 +1,9 @@
-#ifndef SENTRY_TRACING_H_INCLUDED
-#define SENTRY_TRACING_H_INCLUDED
+#ifdef SENTRY_PERFORMANCE_MONITORING
+#    ifndef SENTRY_TRACING_H_INCLUDED
+#        define SENTRY_TRACING_H_INCLUDED
 
-#include "sentry_boot.h"
-#include "sentry_value.h"
+#        include "sentry_boot.h"
+#        include "sentry_value.h"
 
 /**
  * Returns an object containing tracing information extracted from a
@@ -10,5 +11,5 @@
  * See https://develop.sentry.dev/sdk/event-payloads/transaction/#examples
  */
 sentry_value_t sentry__span_get_trace_context(sentry_value_t span);
-
+#    endif
 #endif

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -1,9 +1,8 @@
-#ifdef SENTRY_PERFORMANCE_MONITORING
-#    ifndef SENTRY_TRACING_H_INCLUDED
-#        define SENTRY_TRACING_H_INCLUDED
+#ifndef SENTRY_TRACING_H_INCLUDED
+#define SENTRY_TRACING_H_INCLUDED
 
-#        include "sentry_boot.h"
-#        include "sentry_value.h"
+#include "sentry_boot.h"
+#include "sentry_value.h"
 
 /**
  * Returns an object containing tracing information extracted from a
@@ -11,5 +10,4 @@
  * See https://develop.sentry.dev/sdk/event-payloads/transaction/#examples
  */
 sentry_value_t sentry__span_get_trace_context(sentry_value_t span);
-#    endif
 #endif

--- a/src/sentry_uuid.c
+++ b/src/sentry_uuid.c
@@ -102,26 +102,28 @@ sentry_uuid_as_string(const sentry_uuid_t *uuid, char str[37])
 #undef B
 }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 void
 sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[37])
 {
-#define B(X) (unsigned char)uuid->bytes[X]
+#    define B(X) (unsigned char)uuid->bytes[X]
     snprintf(str, 33,
         "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%"
         "02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
         B(0), B(1), B(2), B(3), B(4), B(5), B(6), B(7), B(8), B(9), B(10),
         B(11), B(12), B(13), B(14), B(15));
-#undef B
+#    undef B
 }
 
 void
 sentry__span_uuid_as_string(const sentry_uuid_t *uuid, char str[17])
 {
-#define B(X) (unsigned char)uuid->bytes[X]
+#    define B(X) (unsigned char)uuid->bytes[X]
     snprintf(str, 17, "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx", B(0),
         B(1), B(2), B(3), B(4), B(5), B(6), B(7));
-#undef B
+#    undef B
 }
+#endif
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 sentry_uuid_t

--- a/src/sentry_uuid.h
+++ b/src/sentry_uuid.h
@@ -3,6 +3,7 @@
 
 #include "sentry_boot.h"
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Converts a sentry UUID to a string representation used for internal
  * sentry UUIDs such as event IDs.
@@ -13,6 +14,7 @@ void sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[37]);
  * Converts a sentry UUID to a string representation used for span IDs.
  */
 void sentry__span_uuid_as_string(const sentry_uuid_t *uuid, char str[17]);
+#endif
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 /**

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -974,6 +974,7 @@ sentry__value_new_hexstring(const uint8_t *bytes, size_t len)
     return sentry__value_new_string_owned(buf);
 }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_value_t
 sentry__value_new_span_uuid(const sentry_uuid_t *uuid)
 {
@@ -997,6 +998,7 @@ sentry__value_new_internal_uuid(const sentry_uuid_t *uuid)
     buf[32] = '\0';
     return sentry__value_new_string_owned(buf);
 }
+#endif
 
 sentry_value_t
 sentry__value_new_uuid(const sentry_uuid_t *uuid)
@@ -1124,6 +1126,7 @@ sentry_value_new_stacktrace(void **ips, size_t len)
     return stacktrace;
 }
 
+#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_value_t
 sentry__value_new_span(sentry_value_t parent, const char *operation)
 {
@@ -1193,6 +1196,7 @@ sentry_transaction_context_remove_sampled(sentry_value_t transaction_context)
 {
     sentry_value_remove_by_key(transaction_context, "sampled");
 }
+#endif
 
 static sentry_value_t
 sentry__get_or_insert_values_list(sentry_value_t parent, const char *key)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 target_compile_definitions(sentry PRIVATE SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
 
 target_compile_definitions(sentry_test_unit PRIVATE SENTRY_UNITTEST)
+target_compile_definitions(sentry_test_unit PRIVATE SENTRY_PERFORMANCE_MONITORING)
 
 add_test(NAME sentry_test_unit COMMAND sentry_test_unit)
 

--- a/tests/unit/sentry_testsupport.h
+++ b/tests/unit/sentry_testsupport.h
@@ -7,6 +7,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef SENTRY_PERFORMANCE_MONITORING
+#    define SENTRY_PERFORMANCE_MONITORING
+#endif
+
 #ifndef SENTRY_TEST_DEFINE_MAIN
 #    define TEST_NO_MAIN
 #endif

--- a/tests/unit/sentry_testsupport.h
+++ b/tests/unit/sentry_testsupport.h
@@ -7,10 +7,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifndef SENTRY_PERFORMANCE_MONITORING
-#    define SENTRY_PERFORMANCE_MONITORING
-#endif
-
 #ifndef SENTRY_TEST_DEFINE_MAIN
 #    define TEST_NO_MAIN
 #endif


### PR DESCRIPTION
This moves both the external and the internal parts of the API related to performance monitoring (/tracing) behind a compile flag. This is to make it easier for us to iterate on the API, and to potentially break it or leave it in a compilable but incomplete state. 

If an end user runs into any issues with the feature they must have deliberately opted into the feature and/or attempted to use something that isn't publicly documented and is therefore not yet publicly supported by the SDK yet.

relates to #601 