### PR TITLE
wip: feat(tracing): add in actual types very wip probably 30% done

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1244,6 +1244,46 @@ SENTRY_EXPERIMENTAL_API double sentry_options_get_traces_sample_rate(
 /* -- Performance Monitoring/Tracing APIs -- */
 
 /**
+ *  The status of a Span or Transaction.
+ */
+enum sentry_span_status_s;
+typedef enum sentry_span_status_s sentry_span_status_t;
+
+/**
+ * A sentry Transaction Context.
+ *
+ * See Transaction Interface under
+ * https://develop.sentry.dev/sdk/performance/#new-span-and-transaction-classes
+ */
+struct sentry_transaction_context_s;
+typedef struct sentry_transaction_context_s sentry_transaction_context_t;
+
+/**
+ * A sentry Span Context.
+ *
+ * See Span Interface under
+ * https://develop.sentry.dev/sdk/performance/#new-span-and-transaction-classes
+ */
+struct sentry_span_context_s;
+typedef struct sentry_span_context_s sentry_span_context_t;
+
+/**
+ * A sentry Transaction.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/transaction/
+ */
+struct sentry_transaction_s;
+typedef struct sentry_transaction_s sentry_transaction_t;
+
+/**
+ * A sentry Span.
+ *
+ * See https://develop.sentry.dev/sdk/event-payloads/span/
+ */
+struct sentry_span_s;
+typedef struct sentry_span_s sentry_span_t;
+
+/**
  * Constructs a new Transaction Context. The returned value needs to be passed
  * into `sentry_transaction_start` in order to be recorded and sent to sentry.
  *
@@ -1257,15 +1297,15 @@ SENTRY_EXPERIMENTAL_API double sentry_options_get_traces_sample_rate(
  * for an explanation of `operation`, in addition to other properties and
  * actions that can be performed on a Transaction.
  */
-SENTRY_EXPERIMENTAL_API sentry_value_t sentry_value_new_transaction_context(
-    const char *name, const char *operation);
+SENTRY_EXPERIMENTAL_API sentry_transaction_context_t *
+sentry_value_new_transaction_context(const char *name, const char *operation);
 
 /**
  * Sets the `name` on a Transaction Context, which will be used in the
  * Transaction constructed off of the context.
  */
 SENTRY_EXPERIMENTAL_API void sentry_transaction_context_set_name(
-    sentry_value_t transaction, const char *name);
+    sentry_transaction_context_t *tx_cxt, const char *name);
 
 /**
  * Sets the `operation` on a Transaction Context, which will be used in the
@@ -1275,7 +1315,7 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_set_name(
  * conventions on `operation`s.
  */
 SENTRY_EXPERIMENTAL_API void sentry_transaction_context_set_operation(
-    sentry_value_t transaction, const char *operation);
+    sentry_transaction_context_t *tx_cxt, const char *operation);
 
 /**
  * Sets the `sampled` field on a Transaction Context, which will be used in the
@@ -1286,7 +1326,7 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_set_operation(
  * child spans will never be sent to sentry.
  */
 SENTRY_EXPERIMENTAL_API void sentry_transaction_context_set_sampled(
-    sentry_value_t transaction, int sampled);
+    sentry_transaction_context_t *tx_cxt, int sampled);
 
 /**
  * Removes the sampled field on a Transaction Context, which will be used in the
@@ -1295,7 +1335,7 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_set_sampled(
  * The Transaction will use the sampling rate as defined in `sentry_options`.
  */
 SENTRY_EXPERIMENTAL_API void sentry_transaction_context_remove_sampled(
-    sentry_value_t transaction);
+    sentry_transaction_context_t *tx_cxt);
 
 /**
  * Starts a new Transaction based on the provided context, restored from an
@@ -1316,8 +1356,8 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_remove_sampled(
  *
  * Takes ownership of `transaction_context`.
  */
-SENTRY_EXPERIMENTAL_API sentry_value_t sentry_transaction_start(
-    sentry_value_t transaction_context);
+SENTRY_EXPERIMENTAL_API sentry_transaction_t *sentry_transaction_start(
+    sentry_transaction_context_t *tx_cxt);
 
 /**
  * Finishes and sends a Transaction to sentry. The event ID of the Transaction
@@ -1329,7 +1369,7 @@ SENTRY_EXPERIMENTAL_API sentry_value_t sentry_transaction_start(
  * this will remove the
  */
 SENTRY_EXPERIMENTAL_API sentry_uuid_t sentry_transaction_finish(
-    sentry_value_t transaction);
+    sentry_transaction_t *tx);
 
 /**
  * Sets the Span (actually Transaction) so any Events sent while the Transaction
@@ -1345,7 +1385,7 @@ SENTRY_EXPERIMENTAL_API sentry_uuid_t sentry_transaction_finish(
  * well as its reference by passing in the same Transaction as the one passed
  * into this function.
  */
-SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_value_t transaction);
+SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_transaction_t *tx);
 
 /**
  * Starts a new Span.
@@ -1367,8 +1407,8 @@ SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_value_t transaction);
  * sentry. `sentry_value_null` will be returned if the child Span could not be
  * created.
  */
-SENTRY_EXPERIMENTAL_API sentry_value_t sentry_span_start_child(
-    sentry_value_t parent, char *operation, char *description);
+SENTRY_EXPERIMENTAL_API sentry_span_t *sentry_span_start_child(
+    sentry_transaction_t *parent, char *operation, char *description);
 
 /**
  * Finishes a Span.
@@ -1386,7 +1426,7 @@ SENTRY_EXPERIMENTAL_API sentry_value_t sentry_span_start_child(
  * complete than the parent span they belong to.
  */
 SENTRY_EXPERIMENTAL_API void sentry_span_finish(
-    sentry_value_t root_transaction, sentry_value_t span);
+    sentry_transaction_t *parent, sentry_span_t *span);
 #endif
 
 #ifdef __cplusplus

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -730,6 +730,59 @@ sentry_set_level(sentry_level_t level)
 }
 
 #ifdef SENTRY_PERFORMANCE_MONITORING
+SENTRY_EXPERIMENTAL_API sentry_transaction_context_t *
+sentry_value_new_transaction_context(const char *name, const char *operation)
+{
+    sentry_span_context_t *span_ctx = sentry__new_span_context(NULL, operation);
+    span_ctx->start_timestamp = sentry__msec_time();
+
+    sentry_transaction_context_t *tx_cxt
+        = SENTRY_MAKE(sentry_transaction_context_t);
+    if (!tx_cxt) {
+        return NULL;
+    }
+    memset(tx_cxt, 0, sizeof(sentry_transaction_context_t));
+
+    tx_cxt->span_context = span_ctx;
+
+    sentry_transaction_context_set_name(tx_cxt, name);
+
+    return tx_cxt;
+}
+
+SENTRY_EXPERIMENTAL_API void
+sentry_transaction_context_set_name(
+    sentry_transaction_context_t *tx_cxt, const char *name)
+{
+    if (tx_cxt->name) {
+        sentry_free(tx_cxt->name);
+    }
+    tx_cxt->name = sentry__string_clone(name);
+}
+
+SENTRY_EXPERIMENTAL_API void
+sentry_transaction_context_set_operation(
+    sentry_transaction_context_t *tx_cxt, const char *operation)
+{
+    if (tx_cxt->operation) {
+        sentry_free(tx_cxt->operation);
+    }
+    tx_cxt->operation = sentry__string_clone(operation);
+}
+
+SENTRY_EXPERIMENTAL_API void
+sentry_transaction_context_set_sampled(
+    sentry_transaction_context_t *tx_cxt, int sampled)
+{
+    tx_cxt->span_context->sampled = !!sampled;
+}
+
+SENTRY_EXPERIMENTAL_API void
+sentry_transaction_context_remove_sampled(sentry_transaction_context_t *tx_cxt)
+{
+    tx_cxt->span_context->sampled = NULL;
+}
+
 sentry_value_t
 sentry_transaction_start(sentry_value_t tx_cxt)
 {

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -1,34 +1,133 @@
-#include "sentry_value.h"
+#include "sentry_tracing.h"
+#include "sentry_alloc.h"
+#include "sentry_string.h"
+#include "sentry_sync.h"
+#include <stdlib.h>
 
-sentry_value_t
-sentry__span_get_trace_context(sentry_value_t span)
+sentry_transaction_t *
+sentry__transaction_incref(sentry_transaction_t *tx)
 {
-    if (sentry_value_is_null(span)
-        || sentry_value_is_null(sentry_value_get_by_key(span, "trace_id"))
-        || sentry_value_is_null(sentry_value_get_by_key(span, "span_id"))) {
-        return sentry_value_new_null();
+    // if (options) {
+    //     sentry__atomic_fetch_and_add(&options->refcount, 1);
+    // }
+    // return options;
+}
+
+void
+sentry__transaction_decref(sentry_transaction_t *tx)
+{
+    // if (!dsn) {
+    //     return;
+    // }
+    // if (sentry__atomic_fetch_and_add(&dsn->refcount, -1) == 1) {
+    //     sentry_free(dsn->raw);
+    //     sentry_free(dsn->host);
+    //     sentry_free(dsn->path);
+    //     sentry_free(dsn->public_key);
+    //     sentry_free(dsn->secret_key);
+    //     sentry_free(dsn);
+    // }
+}
+
+sentry_span_t *
+sentry__span_incref(sentry_span_t *tx)
+{
+    // if (options) {
+    //     sentry__atomic_fetch_and_add(&options->refcount, 1);
+    // }
+    // return options;
+}
+
+void
+sentry__span_decref(sentry_span_t *tx)
+{
+    // if (!dsn) {
+    //     return;
+    // }
+    // if (sentry__atomic_fetch_and_add(&dsn->refcount, -1) == 1) {
+    //     sentry_free(dsn->raw);
+    //     sentry_free(dsn->host);
+    //     sentry_free(dsn->path);
+    //     sentry_free(dsn->public_key);
+    //     sentry_free(dsn->secret_key);
+    //     sentry_free(dsn);
+    // }
+}
+
+sentry_span_context_t *
+sentry__new_span_context(sentry_span_context_t *parent, const char *operation)
+{
+    sentry_span_context_t *span_ctx = SENTRY_MAKE(sentry_span_context_t);
+    if (!span_ctx) {
+        return NULL;
+    }
+    memset(span_ctx, 0, sizeof(sentry_span_context_t));
+
+    span_ctx->op = sentry__string_clone(operation);
+    span_ctx->span_id = sentry_uuid_new_v4();
+    span_ctx->status = SENTRY_SPAN_STATUS_OK;
+    span_ctx->trace_id = sentry_uuid_nil();
+    span_ctx->span_id = sentry_uuid_nil();
+    span_ctx->parent_span_id = sentry_uuid_nil(); // nullable
+    span_ctx->tags = sentry_value_new_null();
+    span_ctx->data = sentry_value_new_null();
+    // Don't set timestamps. Make it the responsibility of the caller since this
+    // isn't "starting" anything.
+
+    // Span creation is currently aggressively pruned prior to this function so
+    // once we're in here we definitely know that the span and its parent
+    // transaction are sampled.
+    // Sampling decisions inherited from traces created in other SDKs should be
+    // taken care of `continue_from_headers`, spans don't need to worry about
+    // (inheriting) forced sampling decisions, and transactions cannot be
+    // children of other transactions, so no inheriting of the sampling field is
+    // needed.
+    if (parent) {
+        // jank way of cloning uuids
+        char trace_id_bytes[16];
+        sentry_uuid_as_bytes(&parent->trace_id, trace_id_bytes);
+        span_ctx->trace_id = sentry_uuid_from_bytes(trace_id_bytes);
+
+        char span_id_bytes[16];
+        sentry_uuid_as_bytes(&parent->span_id, span_id_bytes);
+        span_ctx->span_id = sentry_uuid_from_bytes(span_id_bytes);
+    } else {
+        span_ctx->trace_id = sentry_uuid_new_v4();
     }
 
-    sentry_value_t trace_context = sentry_value_new_object();
+    return span_ctx;
+}
 
-#define PLACE_VALUE(Key, Source)                                               \
-    do {                                                                       \
-        sentry_value_t src = sentry_value_get_by_key(Source, Key);             \
-        if (!sentry_value_is_null(src)) {                                      \
-            sentry_value_incref(src);                                          \
-            sentry_value_set_by_key(trace_context, Key, src);                  \
-        }                                                                      \
-    } while (0)
+sentry_value_t
+sentry__span_get_trace_context(sentry_span_t *span)
+{
+    //     if (sentry_value_is_null(span)
+    //         || sentry_value_is_null(sentry_value_get_by_key(span,
+    //         "trace_id"))
+    //         || sentry_value_is_null(sentry_value_get_by_key(span,
+    //         "span_id"))) { return sentry_value_new_null();
+    //     }
 
-    PLACE_VALUE("trace_id", span);
-    PLACE_VALUE("span_id", span);
-    PLACE_VALUE("parent_span_id", span);
-    PLACE_VALUE("op", span);
-    PLACE_VALUE("description", span);
-    PLACE_VALUE("status", span);
+    //     sentry_value_t trace_context = sentry_value_new_object();
 
-    // TODO: freeze this
-    return trace_context;
+    // #define PLACE_VALUE(Key, Source)                                               \
+//     do {                                                                       \
+//         sentry_value_t src = sentry_value_get_by_key(Source, Key);             \
+//         if (!sentry_value_is_null(src)) {                                      \
+//             sentry_value_incref(src);                                          \
+//             sentry_value_set_by_key(trace_context, Key, src);                  \
+//         }                                                                      \
+//     } while (0)
 
-#undef PLACE_VALUE
+    //     PLACE_VALUE("trace_id", span);
+    //     PLACE_VALUE("span_id", span);
+    //     PLACE_VALUE("parent_span_id", span);
+    //     PLACE_VALUE("op", span);
+    //     PLACE_VALUE("description", span);
+    //     PLACE_VALUE("status", span);
+
+    //     // TODO: freeze this
+    //     return trace_context;
+
+    // #undef PLACE_VALUE
 }

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -1,15 +1,135 @@
 #ifndef SENTRY_TRACING_H_INCLUDED
 #define SENTRY_TRACING_H_INCLUDED
 
-#include "sentry_boot.h"
+// #include "sentry_boot.h"
+// #include "sentry_path.h"
+#include "sentry_utils.h"
 #include "sentry_value.h"
+
+/**
+ *  The status of a Span or Transaction.
+ */
+typedef enum sentry_span_status_s {
+    // Catch-all indeterminate status.
+    SENTRY_SPAN_STATUS_UNDEFINED = 0,
+    // The operation completed successfully.
+    // HTTP status 100..299 + successful redirects from the 3xx range.
+    SENTRY_SPAN_STATUS_OK = 0,
+    // The operation was cancelled (typically by the user).
+    SENTRY_SPAN_STATUS_CANCELLED,
+    // Unknown. Any non-standard HTTP status code.
+    // "We do not know whether the transaction failed or succeeded"
+    SENTRY_SPAN_STATUS_UNKNOWN,
+    // Client specified an invalid argument. 4xx.
+    // Note that this differs from FailedPrecondition. InvalidArgument
+    // indicates arguments that are problematic regardless of the
+    // state of the system.
+    SENTRY_SPAN_STATUS_INVALID_ARGUMENT,
+    // Deadline expired before operation could complete.
+    // For operations that change the state of the system, this error may be
+    // returned even if the operation has been completed successfully.
+    // HTTP redirect loops and 504 Gateway Timeout
+    SENTRY_SPAN_STATUS_DEADLINE_EXCEEDED,
+    // 404 Not Found. Some requested entity (file or directory) was not found.
+    SENTRY_SPAN_STATUS_NOT_FOUND,
+    // Already exists (409)
+    // Some entity that we attempted to create already exists.
+    SENTRY_SPAN_STATUS_ALREADY_EXISTS,
+    // 403 Forbidden
+    // The caller does not have permission to execute the specified operation.
+    SENTRY_SPAN_STATUS_PERMISSION_DENIED,
+    // 429 Too Many Requests
+    // Some resource has been exhausted, perhaps a per-user quota or perhaps
+    // the entire file system is out of space.
+    SENTRY_SPAN_STATUS_RESOURCE_EXHAUSTED,
+    // Operation was rejected because the system is not in a state required for
+    // the operation's execution
+    SENTRY_SPAN_STATUS_FAILED_PRECONDITION,
+    // The operation was aborted, typically due to a concurrency issue.
+    SENTRY_SPAN_STATUS_ABORTED,
+    // Operation was attempted past the valid range.
+    SENTRY_SPAN_STATUS_OUT_OF_RANGE,
+    // 501 Not Implemented
+    // Operation is not implemented or not enabled.
+    SENTRY_SPAN_STATUS_UNIMPLEMENTED,
+    // Other/generic 5xx.
+    SENTRY_SPAN_STATUS_INTERNAL_ERROR,
+    // 503 Service Unavailable
+    SENTRY_SPAN_STATUS_UNAVAILABLE,
+    // Unrecoverable data loss or corruption
+    SENTRY_SPAN_STATUS_DATA_LOSS,
+    // 401 Unauthorized (actually does mean unauthenticated according to RFC
+    // 7235)
+    // Prefer PermissionDenied if a user is logged in.
+    SENTRY_SPAN_STATUS_UNAUTHENTICATED,
+} sentry_span_status_t;
+
+/**
+ * This represents a span, which measures the duration of an event.
+ */
+typedef struct sentry_span_context_s {
+    sentry_uuid_t trace_id;
+    sentry_uuid_t span_id;
+    sentry_uuid_t parent_span_id; // nullable
+    sentry_span_status_t status;
+    char *op;
+    char *description;
+    bool sampled;
+    // A map or list of tags for this event. Each tag must be less than 200
+    // characters.
+    sentry_value_t tags;
+    sentry_value_t data;
+    uint64_t start_timestamp;
+    uint64_t end_timestamp;
+} sentry_span_context_t;
+
+/**
+ * A span.
+ */
+typedef struct sentry_span_s {
+    sentry_span_context_t *context;
+
+    bool parent_sampled;
+    sentry_uuid_t event_id;
+} sentry_span_t;
+
+/**
+ * A transaction context. Is a span context + a name, and is used to
+ * pre-populate new child spans and transactions.
+ */
+typedef struct sentry_transaction_context_s {
+    // TODO: just duplicate all of the properties?
+    sentry_span_context_t *span_context;
+    char *name;
+} sentry_transaction_context_t;
+
+/**
+ * A transaction.
+ */
+typedef struct sentry_transaction_s {
+    sentry_transaction_context_t *context;
+
+    bool parent_sampled;
+    sentry_uuid_t event_id;
+    // Flat list of all child spans, nesting should be reconstructed via
+    // `parent_span_id`s
+    sentry_value_t spans;
+} sentry_transaction_t;
+
+sentry_transaction_t *sentry__transaction_incref(sentry_transaction_t *tx);
+
+void sentry__transaction_decref(sentry_transaction_t *tx);
+
+sentry_span_t *sentry__span_incref(sentry_span_t *span);
+
+void sentry__span_decref(sentry_span_t *span);
 
 /**
  * Returns an object containing tracing information extracted from a
  * transaction (/span) which should be included in an event.
  * See https://develop.sentry.dev/sdk/event-payloads/transaction/#examples
  */
-sentry_value_t sentry__span_get_trace_context(sentry_value_t span);
+sentry_value_t sentry__span_get_trace_context(sentry_span_t *span);
 
-sentry_value_t sentry__span_get_span_context(sentry_value_t span);
+sentry_span_context_t *sentry__span_get_span_context(sentry_span_t *span);
 #endif

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -1127,81 +1127,84 @@ sentry_value_new_stacktrace(void **ips, size_t len)
 }
 
 #ifdef SENTRY_PERFORMANCE_MONITORING
-sentry_value_t
-sentry__value_new_span(sentry_value_t parent, const char *operation)
-{
-    sentry_value_t span = sentry_value_new_object();
+// sentry_value_t
+// sentry__value_new_span(sentry_value_t parent, const char *operation)
+// {
+//     sentry_value_t span = sentry_value_new_object();
 
-    sentry_transaction_context_set_operation(span, operation);
+//     sentry_transaction_context_set_operation(span, operation);
 
-    sentry_uuid_t span_id = sentry_uuid_new_v4();
-    sentry_value_set_by_key(
-        span, "span_id", sentry__value_new_span_uuid(&span_id));
+//     sentry_uuid_t span_id = sentry_uuid_new_v4();
+//     sentry_value_set_by_key(
+//         span, "span_id", sentry__value_new_span_uuid(&span_id));
 
-    sentry_value_set_by_key(span, "status", sentry_value_new_string("ok"));
+//     sentry_value_set_by_key(span, "status", sentry_value_new_string("ok"));
 
-    // Span creation is currently aggressively pruned prior to this function so
-    // once we're in here we definitely know that the span and its parent
-    // transaction are sampled.
-    // Sampling decisions inherited from traces created in other SDKs should be
-    // taken care of `continue_from_headers`, spans don't need to worry about
-    // (inheriting) forced sampling decisions, and transactions cannot be
-    // children of other transactions, so no inheriting of the sampling field is
-    // needed.
-    if (!sentry_value_is_null(parent)) {
-        sentry_value_set_by_key(span, "trace_id",
-            sentry_value_get_by_key_owned(parent, "trace_id"));
-        sentry_value_set_by_key(span, "parent_span_id",
-            sentry_value_get_by_key_owned(parent, "span_id"));
-    }
+//     // Span creation is currently aggressively pruned prior to this function
+//     so
+//     // once we're in here we definitely know that the span and its parent
+//     // transaction are sampled.
+//     // Sampling decisions inherited from traces created in other SDKs should
+//     be
+//     // taken care of `continue_from_headers`, spans don't need to worry about
+//     // (inheriting) forced sampling decisions, and transactions cannot be
+//     // children of other transactions, so no inheriting of the sampling field
+//     is
+//     // needed.
+//     if (!sentry_value_is_null(parent)) {
+//         sentry_value_set_by_key(span, "trace_id",
+//             sentry_value_get_by_key_owned(parent, "trace_id"));
+//         sentry_value_set_by_key(span, "parent_span_id",
+//             sentry_value_get_by_key_owned(parent, "span_id"));
+//     }
 
-    return span;
-}
+//     return span;
+// }
 
-sentry_value_t
-sentry_value_new_transaction_context(const char *name, const char *operation)
-{
-    sentry_value_t transaction_context
-        = sentry__value_new_span(sentry_value_new_null(), operation);
+// sentry_value_t
+// sentry_value_new_transaction_context(const char *name, const char *operation)
+// {
+//     sentry_value_t transaction_context
+//         = sentry__value_new_span(sentry_value_new_null(), operation);
 
-    sentry_uuid_t trace_id = sentry_uuid_new_v4();
-    sentry_value_set_by_key(transaction_context, "trace_id",
-        sentry__value_new_internal_uuid(&trace_id));
+//     sentry_uuid_t trace_id = sentry_uuid_new_v4();
+//     sentry_value_set_by_key(transaction_context, "trace_id",
+//         sentry__value_new_internal_uuid(&trace_id));
 
-    sentry_transaction_context_set_name(transaction_context, name);
+//     sentry_transaction_context_set_name(transaction_context, name);
 
-    return transaction_context;
-}
+//     return transaction_context;
+// }
 
-void
-sentry_transaction_context_set_name(
-    sentry_value_t transaction_context, const char *name)
-{
-    sentry_value_set_by_key(
-        transaction_context, "transaction", sentry_value_new_string(name));
-}
+// void
+// sentry_transaction_context_set_name(
+//     sentry_value_t transaction_context, const char *name)
+// {
+//     sentry_value_set_by_key(
+//         transaction_context, "transaction", sentry_value_new_string(name));
+// }
 
-void
-sentry_transaction_context_set_operation(
-    sentry_value_t transaction_context, const char *operation)
-{
-    sentry_value_set_by_key(
-        transaction_context, "op", sentry_value_new_string(operation));
-}
+// void
+// sentry_transaction_context_set_operation(
+//     sentry_value_t transaction_context, const char *operation)
+// {
+//     sentry_value_set_by_key(
+//         transaction_context, "op", sentry_value_new_string(operation));
+// }
 
-void
-sentry_transaction_context_set_sampled(
-    sentry_value_t transaction_context, int sampled)
-{
-    sentry_value_set_by_key(
-        transaction_context, "sampled", sentry_value_new_bool(sampled));
-}
+// void
+// sentry_transaction_context_set_sampled(
+//     sentry_value_t transaction_context, int sampled)
+// {
+//     sentry_value_set_by_key(
+//         transaction_context, "sampled", sentry_value_new_bool(sampled));
+// }
 
-void
-sentry_transaction_context_remove_sampled(sentry_value_t transaction_context)
-{
-    sentry_value_remove_by_key(transaction_context, "sampled");
-}
+// void
+// sentry_transaction_context_remove_sampled(sentry_value_t transaction_context)
+// {
+//     sentry_value_remove_by_key(transaction_context, "sampled");
+// }
 #endif
 
 static sentry_value_t


### PR DESCRIPTION
# !!!!! WIP !!!!!!!
```
wip             wip  wip  wipwipwip 
wip             wip  wip  wip    wip
wip             wip  wip  wip    wip
wip     wip     wip  wip  wipwipwip 
   wip  wip  wip     wip  wip       
   wipwipwipwip      wip  wip         
```

by the way did i mention that this was a **WORK IN PROGRESS** PR, that means that msot of this work is probably not remotely done, and the list below is a summary of what is done

about 30% of this is done.
- [x] copy over types introduced ages ago for spans, transactions, their contexts
  - [ ] stuff ref to transaction into span 
- [x] update signatures to use new types
- [ ] implement reference counting for types
- [ ] transaction context: port constructor and setters
- [ ] transactions: port start and finish
- [ ] spans: port start child and finish 
- [ ] odds and ends
- [ ] update tests

super bonus changes
- [ ] converter function from status enum to their respective string
- [ ] change finish child's signature 
- [ ] build an idea of how concurrency is even going to work here