### PR TITLE
ref(tracing): Update name of attached transaction in set_transaction [NATIVE-444]

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1193,11 +1193,6 @@ SENTRY_API void sentry_remove_fingerprint(void);
 SENTRY_API void sentry_set_transaction(const char *transaction);
 
 /**
- * Removes the transaction.
- */
-SENTRY_API void sentry_remove_transaction(void);
-
-/**
  * Sets the event level.
  */
 SENTRY_API void sentry_set_level(sentry_level_t level);

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -722,19 +722,6 @@ sentry_set_transaction(const char *transaction)
 }
 
 void
-sentry_remove_transaction(void)
-{
-    SENTRY_WITH_SCOPE_MUT (scope) {
-        sentry_free(scope->transaction);
-        scope->transaction = NULL;
-
-#ifdef SENTRY_PERFORMANCE_MONITORING
-        scope->span = sentry_value_new_null();
-#endif
-    }
-}
-
-void
 sentry_set_level(sentry_level_t level)
 {
     SENTRY_WITH_SCOPE_MUT (scope) {

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -712,13 +712,26 @@ sentry_set_transaction(const char *transaction)
     SENTRY_WITH_SCOPE_MUT (scope) {
         sentry_free(scope->transaction);
         scope->transaction = sentry__string_clone(transaction);
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
+        if (!sentry_value_is_null(scope->span)) {
+            sentry_transaction_set_name(scope->span, transaction);
+        }
+#endif
     }
 }
 
 void
 sentry_remove_transaction(void)
 {
-    sentry_set_transaction(NULL);
+    SENTRY_WITH_SCOPE_MUT (scope) {
+        sentry_free(scope->transaction);
+        scope->transaction = NULL;
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
+        scope->span = sentry_value_new_null();
+#endif
+    }
 }
 
 void

--- a/tests/unit/test_uninit.c
+++ b/tests/unit/test_uninit.c
@@ -25,7 +25,6 @@ SENTRY_TEST(uninitialized)
     sentry_set_fingerprint("foo", "bar", NULL);
     sentry_remove_fingerprint();
     sentry_set_transaction("foo");
-    sentry_remove_transaction();
     sentry_set_level(SENTRY_LEVEL_DEBUG);
     sentry_start_session();
     sentry_end_session();


### PR DESCRIPTION
This adjusts `sentry_set_transaction` and `sentry_remove_transaction` so that if `SENTRY_PERFORMANCE_MONITORING` is defined, they also change the name of/remove the transaction ("`span`") attached to the scope.
