### PR TITLE
fix: Apply default rate limit

### DIFF
--- a/src/sentry_ratelimiter.c
+++ b/src/sentry_ratelimiter.c
@@ -83,6 +83,14 @@ sentry__rate_limiter_update_from_http_retry_after(
 }
 
 bool
+sentry__rate_limiter_update_from_429(sentry_rate_limiter_t *rl)
+{
+    rl->disabled_until[SENTRY_RL_CATEGORY_ANY]
+        = sentry__monotonic_time() + 60 * 1000;
+    return true;
+}
+
+bool
 sentry__rate_limiter_is_disabled(const sentry_rate_limiter_t *rl, int category)
 {
     uint64_t now = sentry__monotonic_time();

--- a/src/sentry_ratelimiter.h
+++ b/src/sentry_ratelimiter.h
@@ -35,6 +35,12 @@ bool sentry__rate_limiter_update_from_http_retry_after(
     sentry_rate_limiter_t *rl, const char *retry_after);
 
 /**
+ * This will update the rate limiters internal state based on receiving a 429
+ * status code.
+ */
+bool sentry__rate_limiter_update_from_429(sentry_rate_limiter_t *rl);
+
+/**
  * This will return `true` if the specified `category` is currently rate
  * limited.
  */

--- a/tests/test_integration_ratelimits.py
+++ b/tests/test_integration_ratelimits.py
@@ -42,3 +42,14 @@ def test_rate_limits(cmake, httpserver):
     )
     run(tmp_path, "sentry_example", ["log", "capture-multiple"], check=True, env=env)
     assert len(httpserver.log) == 2
+
+def test_only_429(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data(
+        "OK", 429
+    )
+    run(tmp_path, "sentry_example", ["log", "capture-multiple"], check=True, env=env)
+    assert len(httpserver.log) == 1

--- a/tests/test_integration_ratelimits.py
+++ b/tests/test_integration_ratelimits.py
@@ -43,6 +43,7 @@ def test_rate_limits(cmake, httpserver):
     run(tmp_path, "sentry_example", ["log", "capture-multiple"], check=True, env=env)
     assert len(httpserver.log) == 2
 
+
 def test_only_429(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
 


### PR DESCRIPTION
The transport will now fall back to a default 60 second rate limit
when it receives a 429 response without additional headers.