### PR TITLE
fix: cmake `SENTRY_LIBRARY_TYPE` variable check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ if(SENTRY_LINK_PTHREAD)
 endif()
 
 # apply platform libraries to sentry library
-if(SENTRY_LIBRARY_TYPE STREQUAL "static")
+if(SENTRY_LIBRARY_TYPE STREQUAL "STATIC")
     target_link_libraries(sentry PUBLIC ${_SENTRY_PLATFORM_LIBS})
 else()
     target_link_libraries(sentry PRIVATE ${_SENTRY_PLATFORM_LIBS})


### PR DESCRIPTION
Fixes #661.

We do not need case-insensitive check here because `SENTRY_LIBRARY_TYPE` is not intended to be set by user.