### PR TITLE
ref: Make API forward-compatible to Sampling Context (NATIVE-457)

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -227,7 +227,8 @@ main(int argc, char **argv)
         if (has_arg(argc, argv, "unsample-tx")) {
             sentry_transaction_context_set_sampled(tx_ctx, 0);
         }
-        sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+        sentry_transaction_t *tx
+            = sentry_start_transaction(tx_ctx, sentry_value_new_null());
 
         if (has_arg(argc, argv, "error-status")) {
             sentry_transaction_set_status(

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1265,7 +1265,7 @@ typedef struct sentry_span_s sentry_span_t;
 
 /**
  * Constructs a new Transaction Context. The returned value needs to be passed
- * into `sentry_transaction_start` in order to be recorded and sent to sentry.
+ * into `sentry_start_transaction` in order to be recorded and sent to sentry.
  *
  * See
  * https://docs.sentry.io/platforms/native/enriching-events/transaction-name/
@@ -1351,6 +1351,11 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_update_from_header(
  * external integration (i.e. a span from a different SDK) or manually
  * constructed by a user.
  *
+ * The second parameter is a custom Sampling Context to be used with a Traces
+ * Sampler to make a more informed sampling decision. The SDK does not currently
+ * support a custom Traces Sampler and this parameter is ignored for the time
+ * being but needs to be provided.
+ *
  * Returns a Transaction, which is expected to be manually managed by the
  * caller. Manual management involves ensuring that `sentry_transaction_finish`
  * is invoked for the Transaction, and that the caller manually starts and
@@ -1373,8 +1378,8 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_update_from_header(
  * mention what kind of expectations they carry if they need to mutate or access
  * the object in a thread-safe way.
  */
-SENTRY_EXPERIMENTAL_API sentry_transaction_t *sentry_transaction_start(
-    sentry_transaction_context_t *tx_cxt);
+SENTRY_EXPERIMENTAL_API sentry_transaction_t *sentry_start_transaction(
+    sentry_transaction_context_t *tx_cxt, sentry_value_t sampling_ctx);
 
 /**
  * Finishes and sends a Transaction to sentry. The event ID of the Transaction

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -731,8 +731,13 @@ sentry_set_level(sentry_level_t level)
 
 #ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_transaction_t *
-sentry_transaction_start(sentry_transaction_context_t *opaque_tx_cxt)
+sentry_start_transaction(
+    sentry_transaction_context_t *opaque_tx_cxt, sentry_value_t sampling_ctx)
 {
+    // Just free this immediately until we implement proper support for
+    // traces_sampler.
+    sentry_value_decref(sampling_ctx);
+
     sentry_value_t tx_cxt = opaque_tx_cxt->inner;
 
     // If the parent span ID is some empty-ish value, just remove it

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -137,12 +137,13 @@ SENTRY_TEST(transaction_name_backfill_on_finish)
 
     sentry_transaction_context_t *tx_cxt
         = sentry_transaction_context_new(NULL, NULL);
-    sentry_transaction_t *tx = sentry_transaction_start(tx_cxt);
+    sentry_transaction_t *tx
+        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
     tx_cxt = sentry_transaction_context_new("", "");
-    tx = sentry_transaction_start(tx_cxt);
+    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
@@ -187,7 +188,8 @@ SENTRY_TEST(basic_function_transport_transaction)
 
     sentry_transaction_context_t *tx_cxt = sentry_transaction_context_new(
         "How could you", "Don't capture this.");
-    sentry_transaction_t *tx = sentry_transaction_start(tx_cxt);
+    sentry_transaction_t *tx
+        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
     // TODO: `sentry_capture_event` acts as if the event was sent if user
     // consent was not given
@@ -195,14 +197,14 @@ SENTRY_TEST(basic_function_transport_transaction)
     sentry_user_consent_give();
 
     tx_cxt = sentry_transaction_context_new("honk", "beep");
-    tx = sentry_transaction_start(tx_cxt);
+    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
     sentry_user_consent_revoke();
     tx_cxt = sentry_transaction_context_new(
         "How could you again", "Don't capture this either.");
-    tx = sentry_transaction_start(tx_cxt);
+    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     event_id = sentry_transaction_finish(tx);
     // TODO: `sentry_capture_event` acts as if the event was sent if user
     // consent was not given
@@ -232,7 +234,8 @@ SENTRY_TEST(transport_sampling_transactions)
     for (int i = 0; i < 100; i++) {
         sentry_transaction_context_t *tx_cxt
             = sentry_transaction_context_new("honk", "beep");
-        sentry_transaction_t *tx = sentry_transaction_start(tx_cxt);
+        sentry_transaction_t *tx
+            = sentry_start_transaction(tx_cxt, sentry_value_new_null());
         sentry_uuid_t event_id = sentry_transaction_finish(tx);
         if (!sentry_uuid_is_nil(&event_id)) {
             sent_transactions += 1;
@@ -275,7 +278,8 @@ SENTRY_TEST(transactions_skip_before_send)
 
     sentry_transaction_context_t *tx_cxt
         = sentry_transaction_context_new("honk", "beep");
-    sentry_transaction_t *tx = sentry_transaction_start(tx_cxt);
+    sentry_transaction_t *tx
+        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
@@ -310,7 +314,8 @@ SENTRY_TEST(multiple_transactions)
 
     sentry_transaction_context_t *tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *tx = sentry_transaction_start(tx_cxt);
+    sentry_transaction_t *tx
+        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     sentry_set_span(tx);
 
     sentry_value_t scope_tx = sentry__scope_get_span();
@@ -324,11 +329,11 @@ SENTRY_TEST(multiple_transactions)
     // Set transaction on scope twice, back-to-back without finishing the first
     // one
     tx_cxt = sentry_transaction_context_new("whoa!", NULL);
-    tx = sentry_transaction_start(tx_cxt);
+    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     sentry_set_span(tx);
     sentry__transaction_decref(tx);
     tx_cxt = sentry_transaction_context_new("wowee!", NULL);
-    tx = sentry_transaction_start(tx_cxt);
+    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
     sentry_set_span(tx);
     scope_tx = sentry__scope_get_span();
     CHECK_STRING_PROPERTY(scope_tx, "transaction", "wowee!");
@@ -354,7 +359,8 @@ SENTRY_TEST(basic_spans)
 
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *opaque_tx = sentry_transaction_start(opaque_tx_cxt);
+    sentry_transaction_t *opaque_tx
+        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -403,7 +409,8 @@ SENTRY_TEST(spans_on_scope)
 
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *opaque_tx = sentry_transaction_start(opaque_tx_cxt);
+    sentry_transaction_t *opaque_tx
+        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
     sentry_set_span(opaque_tx);
 
     sentry_span_t *opaque_child
@@ -454,7 +461,8 @@ SENTRY_TEST(child_spans)
 
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *opaque_tx = sentry_transaction_start(opaque_tx_cxt);
+    sentry_transaction_t *opaque_tx
+        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -509,7 +517,8 @@ SENTRY_TEST(overflow_spans)
 
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *opaque_tx = sentry_transaction_start(opaque_tx_cxt);
+    sentry_transaction_t *opaque_tx
+        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -583,7 +592,8 @@ SENTRY_TEST(drop_unfinished_spans)
 
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *opaque_tx = sentry_transaction_start(opaque_tx_cxt);
+    sentry_transaction_t *opaque_tx
+        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -632,7 +642,8 @@ SENTRY_TEST(distributed_headers)
 
     sentry_transaction_context_t *tx_ctx
         = sentry_transaction_context_new("wow!", NULL);
-    sentry_transaction_t *tx = sentry_transaction_start(tx_ctx);
+    sentry_transaction_t *tx
+        = sentry_start_transaction(tx_ctx, sentry_value_new_null());
 
     const char *trace_id = sentry_value_as_string(
         sentry_value_get_by_key(tx->inner, "trace_id"));
@@ -645,7 +656,8 @@ SENTRY_TEST(distributed_headers)
     // check transaction
     tx_ctx = sentry_transaction_context_new("distributed!", NULL);
     sentry_transaction_iter_headers(tx, forward_headers_to, (void *)tx_ctx);
-    sentry_transaction_t *dist_tx = sentry_transaction_start(tx_ctx);
+    sentry_transaction_t *dist_tx
+        = sentry_start_transaction(tx_ctx, sentry_value_new_null());
 
     const char *dist_trace_id = sentry_value_as_string(
         sentry_value_get_by_key(dist_tx->inner, "trace_id"));
@@ -666,7 +678,7 @@ SENTRY_TEST(distributed_headers)
 
     tx_ctx = sentry_transaction_context_new("distributed!", NULL);
     sentry_span_iter_headers(child, forward_headers_to, (void *)tx_ctx);
-    dist_tx = sentry_transaction_start(tx_ctx);
+    dist_tx = sentry_start_transaction(tx_ctx, sentry_value_new_null());
 
     dist_trace_id = sentry_value_as_string(
         sentry_value_get_by_key(dist_tx->inner, "trace_id"));
@@ -686,11 +698,11 @@ SENTRY_TEST(distributed_headers)
     // check sampled flag
     tx_ctx = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_context_set_sampled(tx_ctx, 0);
-    tx = sentry_transaction_start(tx_ctx);
+    tx = sentry_start_transaction(tx_ctx, sentry_value_new_null());
 
     tx_ctx = sentry_transaction_context_new("distributed!", NULL);
     sentry_transaction_iter_headers(tx, forward_headers_to, (void *)tx_ctx);
-    dist_tx = sentry_transaction_start(tx_ctx);
+    dist_tx = sentry_start_transaction(tx_ctx, sentry_value_new_null());
 
     TEST_CHECK(!sentry_value_is_true(
         sentry_value_get_by_key(dist_tx->inner, "sampled")));


### PR DESCRIPTION
This also renames `sentry_start_transaction` to use the naming that is defined here: https://develop.sentry.dev/sdk/performance/#static-api-changes