### PR TITLE
ref(tracing): Revert name change of sentry_transaction_start

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -228,7 +228,7 @@ main(int argc, char **argv)
             sentry_transaction_context_set_sampled(tx_ctx, 0);
         }
         sentry_transaction_t *tx
-            = sentry_start_transaction(tx_ctx, sentry_value_new_null());
+            = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
         if (has_arg(argc, argv, "error-status")) {
             sentry_transaction_set_status(

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1265,7 +1265,7 @@ typedef struct sentry_span_s sentry_span_t;
 
 /**
  * Constructs a new Transaction Context. The returned value needs to be passed
- * into `sentry_start_transaction` in order to be recorded and sent to sentry.
+ * into `sentry_transaction_start` in order to be recorded and sent to sentry.
  *
  * See
  * https://docs.sentry.io/platforms/native/enriching-events/transaction-name/
@@ -1378,7 +1378,7 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_update_from_header(
  * mention what kind of expectations they carry if they need to mutate or access
  * the object in a thread-safe way.
  */
-SENTRY_EXPERIMENTAL_API sentry_transaction_t *sentry_start_transaction(
+SENTRY_EXPERIMENTAL_API sentry_transaction_t *sentry_transaction_start(
     sentry_transaction_context_t *tx_cxt, sentry_value_t sampling_ctx);
 
 /**
@@ -1412,7 +1412,7 @@ SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_transaction_t *tx);
 /**
  * Starts a new Span.
  *
- * The return value of `sentry_start_transaction` should be passed in as
+ * The return value of `sentry_transaction_start` should be passed in as
  * `parent`.
  *
  * Both `operation` and `description` can be null, but it is recommended to

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -731,7 +731,7 @@ sentry_set_level(sentry_level_t level)
 
 #ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_transaction_t *
-sentry_start_transaction(
+sentry_transaction_start(
     sentry_transaction_context_t *opaque_tx_cxt, sentry_value_t sampling_ctx)
 {
     // Just free this immediately until we implement proper support for

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -138,12 +138,12 @@ SENTRY_TEST(transaction_name_backfill_on_finish)
     sentry_transaction_context_t *tx_cxt
         = sentry_transaction_context_new(NULL, NULL);
     sentry_transaction_t *tx
-        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
     tx_cxt = sentry_transaction_context_new("", "");
-    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+    tx = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
@@ -189,7 +189,7 @@ SENTRY_TEST(basic_function_transport_transaction)
     sentry_transaction_context_t *tx_cxt = sentry_transaction_context_new(
         "How could you", "Don't capture this.");
     sentry_transaction_t *tx
-        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
     // TODO: `sentry_capture_event` acts as if the event was sent if user
     // consent was not given
@@ -197,14 +197,14 @@ SENTRY_TEST(basic_function_transport_transaction)
     sentry_user_consent_give();
 
     tx_cxt = sentry_transaction_context_new("honk", "beep");
-    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+    tx = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
     sentry_user_consent_revoke();
     tx_cxt = sentry_transaction_context_new(
         "How could you again", "Don't capture this either.");
-    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+    tx = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     event_id = sentry_transaction_finish(tx);
     // TODO: `sentry_capture_event` acts as if the event was sent if user
     // consent was not given
@@ -235,7 +235,7 @@ SENTRY_TEST(transport_sampling_transactions)
         sentry_transaction_context_t *tx_cxt
             = sentry_transaction_context_new("honk", "beep");
         sentry_transaction_t *tx
-            = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+            = sentry_transaction_start(tx_cxt, sentry_value_new_null());
         sentry_uuid_t event_id = sentry_transaction_finish(tx);
         if (!sentry_uuid_is_nil(&event_id)) {
             sent_transactions += 1;
@@ -279,7 +279,7 @@ SENTRY_TEST(transactions_skip_before_send)
     sentry_transaction_context_t *tx_cxt
         = sentry_transaction_context_new("honk", "beep");
     sentry_transaction_t *tx
-        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
@@ -315,7 +315,7 @@ SENTRY_TEST(multiple_transactions)
     sentry_transaction_context_t *tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *tx
-        = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_set_span(tx);
 
     sentry_value_t scope_tx = sentry__scope_get_span();
@@ -329,11 +329,11 @@ SENTRY_TEST(multiple_transactions)
     // Set transaction on scope twice, back-to-back without finishing the first
     // one
     tx_cxt = sentry_transaction_context_new("whoa!", NULL);
-    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+    tx = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_set_span(tx);
     sentry__transaction_decref(tx);
     tx_cxt = sentry_transaction_context_new("wowee!", NULL);
-    tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
+    tx = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_set_span(tx);
     scope_tx = sentry__scope_get_span();
     CHECK_STRING_PROPERTY(scope_tx, "transaction", "wowee!");
@@ -360,7 +360,7 @@ SENTRY_TEST(basic_spans)
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *opaque_tx
-        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -410,7 +410,7 @@ SENTRY_TEST(spans_on_scope)
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *opaque_tx
-        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(opaque_tx_cxt, sentry_value_new_null());
     sentry_set_span(opaque_tx);
 
     sentry_span_t *opaque_child
@@ -462,7 +462,7 @@ SENTRY_TEST(child_spans)
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *opaque_tx
-        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -518,7 +518,7 @@ SENTRY_TEST(overflow_spans)
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *opaque_tx
-        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -593,7 +593,7 @@ SENTRY_TEST(drop_unfinished_spans)
     sentry_transaction_context_t *opaque_tx_cxt
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *opaque_tx
-        = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
+        = sentry_transaction_start(opaque_tx_cxt, sentry_value_new_null());
     sentry_value_t tx = opaque_tx->inner;
 
     sentry_span_t *opaque_child
@@ -658,7 +658,7 @@ SENTRY_TEST(distributed_headers)
         tx_ctx, "sentry-trace-but-a-lot-longer", not_expected_header);
 
     sentry_transaction_t *tx
-        = sentry_start_transaction(tx_ctx, sentry_value_new_null());
+        = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
     const char *trace_id = sentry_value_as_string(
         sentry_value_get_by_key(tx->inner, "trace_id"));
@@ -672,7 +672,7 @@ SENTRY_TEST(distributed_headers)
     tx_ctx = sentry_transaction_context_new("distributed!", NULL);
     sentry_transaction_iter_headers(tx, forward_headers_to, (void *)tx_ctx);
     sentry_transaction_t *dist_tx
-        = sentry_start_transaction(tx_ctx, sentry_value_new_null());
+        = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
     const char *dist_trace_id = sentry_value_as_string(
         sentry_value_get_by_key(dist_tx->inner, "trace_id"));
@@ -693,7 +693,7 @@ SENTRY_TEST(distributed_headers)
 
     tx_ctx = sentry_transaction_context_new("distributed!", NULL);
     sentry_span_iter_headers(child, forward_headers_to, (void *)tx_ctx);
-    dist_tx = sentry_start_transaction(tx_ctx, sentry_value_new_null());
+    dist_tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
     dist_trace_id = sentry_value_as_string(
         sentry_value_get_by_key(dist_tx->inner, "trace_id"));
@@ -713,11 +713,11 @@ SENTRY_TEST(distributed_headers)
     // check sampled flag
     tx_ctx = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_context_set_sampled(tx_ctx, 0);
-    tx = sentry_start_transaction(tx_ctx, sentry_value_new_null());
+    tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
     tx_ctx = sentry_transaction_context_new("distributed!", NULL);
     sentry_transaction_iter_headers(tx, forward_headers_to, (void *)tx_ctx);
-    dist_tx = sentry_start_transaction(tx_ctx, sentry_value_new_null());
+    dist_tx = sentry_transaction_start(tx_ctx, sentry_value_new_null());
 
     TEST_CHECK(!sentry_value_is_true(
         sentry_value_get_by_key(dist_tx->inner, "sampled")));


### PR DESCRIPTION
This reverts the name change of `sentry_transaction_start` to `sentry_start_transaction` for reasons detailed in https://github.com/getsentry/sentry-native/pull/663#issuecomment-1018067869.