### PR TITLE
feat(tracing): Allow setting a scope on a span

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1366,8 +1366,8 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_update_from_header(
  *
  * To ensure that any Events or Message Events are associated with this
  * Transaction while it is active, invoke and pass in the Transaction returned
- * by this function to `sentry_set_span`. Further documentation on this can be
- * found in `sentry_set_span`'s docstring.
+ * by this function to `sentry_set_transaction_object`. Further documentation on this can be
+ * found in `sentry_set_transaction_object`'s docstring.
  *
  * Takes ownership of `transaction_context`. A Transaction Context cannot be
  * modified or re-used after it is used to start a Transaction.
@@ -1394,7 +1394,7 @@ SENTRY_EXPERIMENTAL_API sentry_uuid_t sentry_transaction_finish(
     sentry_transaction_t *tx);
 
 /**
- * Sets the Span (actually Transaction) so any Events sent while the Transaction
+ * Sets the Transaction so any Events sent while the Transaction
  * is active will be associated with the Transaction.
  *
  * If the Transaction being passed in is unsampled, it will still be associated
@@ -1402,12 +1402,23 @@ SENTRY_EXPERIMENTAL_API sentry_uuid_t sentry_transaction_finish(
  * missing traces in sentry, see
  * https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#orphan-traces-and-broken-subtraces
  *
- * This increases the number of references pointing to the transaction. Invoke
- * `sentry_transaction_finish` to remove the Span set by this function as well
+ * This increases the number of references pointing to the Transaction. Invoke
+ * `sentry_transaction_finish` to remove the Transaction set by this function as well
  * as its reference by passing in the same Transaction as the one passed into
  * this function.
  */
-SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_transaction_t *tx);
+SENTRY_EXPERIMENTAL_API void sentry_set_transaction_object(sentry_transaction_t *tx);
+
+/**
+ * Sets the Span so any Events sent while the Span
+ * is active will be associated with the Span.
+ *
+ * This increases the number of references pointing to the Span. Invoke
+ * `sentry_span_finish` to remove the Span set by this function as well
+ * as its reference by passing in the same Span as the one passed into
+ * this function.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_span_t *span);
 
 /**
  * Starts a new Span.
@@ -1428,6 +1439,11 @@ SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_transaction_t *tx);
  * finishing the Span means it will be discarded, and will not be sent to
  * sentry. `sentry_value_null` will be returned if the child Span could not be
  * created.
+ *
+ * To ensure that any Events or Message Events are associated with this
+ * Span while it is active, invoke and pass in the Span returned
+ * by this function to `sentry_set_span`. Further documentation on this can be
+ * found in `sentry_set_span`'s docstring.
  *
  * This increases the number of references pointing to the Transaction.
  *
@@ -1458,6 +1474,11 @@ SENTRY_EXPERIMENTAL_API sentry_span_t *sentry_transaction_start_child(
  * finishing the Span means it will be discarded, and will not be sent to
  * sentry. `sentry_value_null` will be returned if the child Span could not be
  * created.
+ *
+ * To ensure that any Events or Message Events are associated with this
+ * Span while it is active, invoke and pass in the Span returned
+ * by this function to `sentry_set_span`. Further documentation on this can be
+ * found in `sentry_set_span`'s docstring.
  *
  * The returned value is not thread-safe. Users are expected to ensure that
  * appropriate locking mechanisms are implemented over the Span if it needs

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1366,8 +1366,8 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_update_from_header(
  *
  * To ensure that any Events or Message Events are associated with this
  * Transaction while it is active, invoke and pass in the Transaction returned
- * by this function to `sentry_set_transaction_object`. Further documentation on this can be
- * found in `sentry_set_transaction_object`'s docstring.
+ * by this function to `sentry_set_transaction_object`. Further documentation on
+ * this can be found in `sentry_set_transaction_object`'s docstring.
  *
  * Takes ownership of `transaction_context`. A Transaction Context cannot be
  * modified or re-used after it is used to start a Transaction.
@@ -1403,11 +1403,12 @@ SENTRY_EXPERIMENTAL_API sentry_uuid_t sentry_transaction_finish(
  * https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#orphan-traces-and-broken-subtraces
  *
  * This increases the number of references pointing to the Transaction. Invoke
- * `sentry_transaction_finish` to remove the Transaction set by this function as well
- * as its reference by passing in the same Transaction as the one passed into
- * this function.
+ * `sentry_transaction_finish` to remove the Transaction set by this function as
+ * well as its reference by passing in the same Transaction as the one passed
+ * into this function.
  */
-SENTRY_EXPERIMENTAL_API void sentry_set_transaction_object(sentry_transaction_t *tx);
+SENTRY_EXPERIMENTAL_API void sentry_set_transaction_object(
+    sentry_transaction_t *tx);
 
 /**
  * Sets the Span so any Events sent while the Span

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -714,8 +714,8 @@ sentry_set_transaction(const char *transaction)
         scope->transaction = sentry__string_clone(transaction);
 
 #ifdef SENTRY_PERFORMANCE_MONITORING
-        if (scope->span) {
-            sentry_transaction_set_name(scope->span, transaction);
+        if (scope->transaction_object) {
+            sentry_transaction_set_name(scope->transaction_object, transaction);
         }
 #endif
     }
@@ -779,15 +779,15 @@ sentry_transaction_finish(sentry_transaction_t *opaque_tx)
 
     SENTRY_WITH_SCOPE_MUT (scope) {
         if (scope->span) {
-            sentry_value_t scope_tx = scope->span->inner;
+            sentry_value_t scope_tx = scope->transaction_object->inner;
 
             const char *tx_id = sentry_value_as_string(
                 sentry_value_get_by_key(tx, "trace_id"));
             const char *scope_tx_id = sentry_value_as_string(
                 sentry_value_get_by_key(scope_tx, "trace_id"));
             if (sentry__string_eq(tx_id, scope_tx_id)) {
-                sentry__transaction_decref(scope->span);
-                scope->span = NULL;
+                sentry__transaction_decref(scope->transaction_object);
+                scope->transaction_object = NULL;
             }
         }
     }
@@ -819,7 +819,7 @@ sentry_transaction_finish(sentry_transaction_t *opaque_tx)
 
     // TODO: add tracestate
     sentry_value_t trace_context
-        = sentry__transaction_get_trace_context(opaque_tx);
+        = sentry__value_get_trace_context(opaque_tx->inner);
     sentry_value_t contexts = sentry_value_new_object();
     sentry_value_set_by_key(contexts, "trace", trace_context);
     sentry_value_set_by_key(tx, "contexts", contexts);
@@ -843,12 +843,26 @@ fail:
 }
 
 void
-sentry_set_span(sentry_transaction_t *tx)
+sentry_set_transaction_object(sentry_transaction_t *tx)
 {
     SENTRY_WITH_SCOPE_MUT (scope) {
-        sentry__transaction_decref(scope->span);
+        sentry__span_decref(scope->span);
+        scope->span = NULL;
+        sentry__transaction_decref(scope->transaction_object);
         sentry__transaction_incref(tx);
-        scope->span = tx;
+        scope->transaction_object = tx;
+    }
+}
+
+void
+sentry_set_span(sentry_span_t *span)
+{
+    SENTRY_WITH_SCOPE_MUT (scope) {
+        sentry__transaction_decref(scope->transaction_object);
+        scope->transaction_object = NULL;
+        sentry__span_decref(scope->span);
+        sentry__span_incref(span);
+        scope->span = span;
     }
 }
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -778,7 +778,7 @@ sentry_transaction_finish(sentry_transaction_t *opaque_tx)
     sentry_value_t tx = sentry__value_clone(opaque_tx->inner);
 
     SENTRY_WITH_SCOPE_MUT (scope) {
-        if (scope->span) {
+        if (scope->transaction_object) {
             sentry_value_t scope_tx = scope->transaction_object->inner;
 
             const char *tx_id = sentry_value_as_string(

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -324,8 +324,9 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
     sentry_value_t contexts = sentry__value_clone(scope->contexts);
     // prep contexts sourced from scope; data about transaction on scope needs
     // to be extracted and inserted
-    sentry_value_t scope_trace
-        = sentry__value_get_trace_context(scope->transaction_object ? scope->transaction_object->inner : scope->span->inner);
+    sentry_value_t scope_trace = sentry__value_get_trace_context(
+        scope->transaction_object ? scope->transaction_object->inner
+                                  : scope->span->inner);
     if (!sentry_value_is_null(scope_trace)) {
         if (sentry_value_is_null(contexts)) {
             contexts = sentry_value_new_object();

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -21,12 +21,16 @@ typedef struct sentry_scope_s {
     sentry_value_t client_sdk;
 
 #ifdef SENTRY_PERFORMANCE_MONITORING
-    // Not to be confused with transaction, which is a legacy value. This is
-    // also known as a transaction, but to maintain consistency with other SDKs
-    // and to avoid a conflict with the existing transaction field this is named
-    // span. Whenever possible, `transaction` should pull its value from the
-    // `name` property nested in this field.
-    sentry_transaction_t *span;
+    // The span attached to this scope, if any.
+    //
+    // Conceptually, every transaction is a span, so it should be possible to
+    // attach spans or transactions to a scope. But sentry_span_t and sentry_transaction_t
+    // are unrelated types in the native SDK, so we need two distinct pointers. At most one
+    // of them should ever be non-null.
+    // Whenever possible, `transaction` should pull its value from the
+    // `name` property nested in transaction_object or span.
+    sentry_transaction_t *transaction_object;
+    sentry_span_t *span;
 #endif
 } sentry_scope_t;
 
@@ -97,6 +101,6 @@ void sentry__scope_apply_to_event(const sentry_scope_t *scope,
 #ifdef SENTRY_PERFORMANCE_MONITORING
 // this is only used in unit tests
 #ifdef SENTRY_UNITTEST
-sentry_value_t sentry__scope_get_span();
+sentry_value_t sentry__scope_get_span_or_transaction();
 #endif
 #endif

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -24,9 +24,9 @@ typedef struct sentry_scope_s {
     // The span attached to this scope, if any.
     //
     // Conceptually, every transaction is a span, so it should be possible to
-    // attach spans or transactions to a scope. But sentry_span_t and sentry_transaction_t
-    // are unrelated types in the native SDK, so we need two distinct pointers. At most one
-    // of them should ever be non-null.
+    // attach spans or transactions to a scope. But sentry_span_t and
+    // sentry_transaction_t are unrelated types in the native SDK, so we need
+    // two distinct pointers. At most one of them should ever be non-null.
     // Whenever possible, `transaction` should pull its value from the
     // `name` property nested in transaction_object or span.
     sentry_transaction_t *transaction_object;

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -47,7 +47,6 @@ void sentry__span_free(sentry_span_t *span);
  * transaction / span which should be included in an event.
  * See https://develop.sentry.dev/sdk/event-payloads/transaction/#examples
  */
-sentry_value_t sentry__value_get_trace_context(
-    sentry_value_t span);
+sentry_value_t sentry__value_get_trace_context(sentry_value_t span);
 
 #endif

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -33,8 +33,8 @@ sentry_transaction_t *sentry__transaction_new(sentry_value_t inner);
 void sentry__transaction_incref(sentry_transaction_t *tx);
 void sentry__transaction_decref(sentry_transaction_t *tx);
 
-void sentry__span_incref(sentry_span_t *tx);
-void sentry__span_decref(sentry_span_t *tx);
+void sentry__span_incref(sentry_span_t *span);
+void sentry__span_decref(sentry_span_t *span);
 
 sentry_value_t sentry__value_span_new(size_t max_spans, sentry_value_t parent,
     char *operation, char *description);

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -33,6 +33,9 @@ sentry_transaction_t *sentry__transaction_new(sentry_value_t inner);
 void sentry__transaction_incref(sentry_transaction_t *tx);
 void sentry__transaction_decref(sentry_transaction_t *tx);
 
+void sentry__span_incref(sentry_span_t *tx);
+void sentry__span_decref(sentry_span_t *tx);
+
 sentry_value_t sentry__value_span_new(size_t max_spans, sentry_value_t parent,
     char *operation, char *description);
 sentry_span_t *sentry__span_new(
@@ -41,10 +44,10 @@ void sentry__span_free(sentry_span_t *span);
 
 /**
  * Returns an object containing tracing information extracted from a
- * transaction (/span) which should be included in an event.
+ * transaction / span which should be included in an event.
  * See https://develop.sentry.dev/sdk/event-payloads/transaction/#examples
  */
-sentry_value_t sentry__transaction_get_trace_context(
-    sentry_transaction_t *span);
+sentry_value_t sentry__value_get_trace_context(
+    sentry_value_t span);
 
 #endif

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -335,7 +335,7 @@ SENTRY_TEST(multiple_transactions)
     tx_cxt = sentry_transaction_context_new("wowee!", NULL);
     tx = sentry_transaction_start(tx_cxt, sentry_value_new_null());
     sentry_set_transaction_object(tx);
-    scope_tx = sentry__scope_get_span();
+    scope_tx = sentry__scope_get_span_or_transaction();
     CHECK_STRING_PROPERTY(scope_tx, "transaction", "wowee!");
     event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -21,7 +21,7 @@ SENTRY_TEST(basic_tracing_context)
     opaque_tx = sentry__transaction_new(sentry__value_clone(tx));
     sentry_value_set_by_key(tx, "op", sentry_value_new_string("honk.beep"));
     TEST_CHECK(
-        sentry_value_is_null(sentry__transaction_get_trace_context(opaque_tx)));
+        sentry_value_is_null(sentry__value_get_trace_context(opaque_tx->inner)));
 
     sentry_uuid_t trace_id = sentry_uuid_new_v4();
     sentry_value_set_by_key(
@@ -29,7 +29,7 @@ SENTRY_TEST(basic_tracing_context)
     sentry__transaction_decref(opaque_tx);
     opaque_tx = sentry__transaction_new(sentry__value_clone(tx));
     TEST_CHECK(
-        sentry_value_is_null(sentry__transaction_get_trace_context(opaque_tx)));
+        sentry_value_is_null(sentry__value_get_trace_context(opaque_tx->inner)));
 
     sentry_uuid_t span_id = sentry_uuid_new_v4();
     sentry_value_set_by_key(
@@ -38,7 +38,7 @@ SENTRY_TEST(basic_tracing_context)
     opaque_tx = sentry__transaction_new(sentry__value_clone(tx));
 
     sentry_value_t trace_context
-        = sentry__transaction_get_trace_context(opaque_tx);
+        = sentry__value_get_trace_context(opaque_tx->inner);
     TEST_CHECK(!sentry_value_is_null(trace_context));
     TEST_CHECK(!IS_NULL(trace_context, "trace_id"));
     TEST_CHECK(!IS_NULL(trace_context, "span_id"));
@@ -316,13 +316,13 @@ SENTRY_TEST(multiple_transactions)
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *tx
         = sentry_start_transaction(tx_cxt, sentry_value_new_null());
-    sentry_set_span(tx);
+    sentry_set_transaction_object(tx);
 
-    sentry_value_t scope_tx = sentry__scope_get_span();
+    sentry_value_t scope_tx = sentry__scope_get_span_or_transaction();
     CHECK_STRING_PROPERTY(scope_tx, "transaction", "wow!");
 
     sentry_uuid_t event_id = sentry_transaction_finish(tx);
-    scope_tx = sentry__scope_get_span();
+    scope_tx = sentry__scope_get_span_or_transaction();
     TEST_CHECK(sentry_value_is_null(scope_tx));
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
 
@@ -330,12 +330,12 @@ SENTRY_TEST(multiple_transactions)
     // one
     tx_cxt = sentry_transaction_context_new("whoa!", NULL);
     tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
-    sentry_set_span(tx);
+    sentry_set_transaction_object(tx);
     sentry__transaction_decref(tx);
     tx_cxt = sentry_transaction_context_new("wowee!", NULL);
     tx = sentry_start_transaction(tx_cxt, sentry_value_new_null());
-    sentry_set_span(tx);
-    scope_tx = sentry__scope_get_span();
+    sentry_set_transaction_object(tx);
+    scope_tx = sentry__scope_get_span_or_transaction();
     CHECK_STRING_PROPERTY(scope_tx, "transaction", "wowee!");
     event_id = sentry_transaction_finish(tx);
     TEST_CHECK(!sentry_uuid_is_nil(&event_id));
@@ -411,7 +411,7 @@ SENTRY_TEST(spans_on_scope)
         = sentry_transaction_context_new("wow!", NULL);
     sentry_transaction_t *opaque_tx
         = sentry_start_transaction(opaque_tx_cxt, sentry_value_new_null());
-    sentry_set_span(opaque_tx);
+    sentry_set_transaction_object(opaque_tx);
 
     sentry_span_t *opaque_child
         = sentry_transaction_start_child(opaque_tx, "honk", "goose");
@@ -420,7 +420,7 @@ SENTRY_TEST(spans_on_scope)
 
     // Peek into the transaction's span list and make sure everything is
     // good
-    sentry_value_t scope_tx = sentry__scope_get_span();
+    sentry_value_t scope_tx = sentry__scope_get_span_or_transaction();
     const char *trace_id
         = sentry_value_as_string(sentry_value_get_by_key(scope_tx, "trace_id"));
     const char *parent_span_id
@@ -433,7 +433,7 @@ SENTRY_TEST(spans_on_scope)
 
     sentry_span_finish(opaque_child);
 
-    scope_tx = sentry__scope_get_span();
+    scope_tx = sentry__scope_get_span_or_transaction();
     TEST_CHECK(!IS_NULL(scope_tx, "spans"));
     sentry_value_t spans = sentry_value_get_by_key(scope_tx, "spans");
     TEST_CHECK_INT_EQUAL(sentry_value_get_length(spans), 1);

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -20,16 +20,16 @@ SENTRY_TEST(basic_tracing_context)
     sentry_value_t tx = sentry_value_new_object();
     opaque_tx = sentry__transaction_new(sentry__value_clone(tx));
     sentry_value_set_by_key(tx, "op", sentry_value_new_string("honk.beep"));
-    TEST_CHECK(
-        sentry_value_is_null(sentry__value_get_trace_context(opaque_tx->inner)));
+    TEST_CHECK(sentry_value_is_null(
+        sentry__value_get_trace_context(opaque_tx->inner)));
 
     sentry_uuid_t trace_id = sentry_uuid_new_v4();
     sentry_value_set_by_key(
         tx, "trace_id", sentry__value_new_internal_uuid(&trace_id));
     sentry__transaction_decref(opaque_tx);
     opaque_tx = sentry__transaction_new(sentry__value_clone(tx));
-    TEST_CHECK(
-        sentry_value_is_null(sentry__value_get_trace_context(opaque_tx->inner)));
+    TEST_CHECK(sentry_value_is_null(
+        sentry__value_get_trace_context(opaque_tx->inner)));
 
     sentry_uuid_t span_id = sentry_uuid_new_v4();
     sentry_value_set_by_key(


### PR DESCRIPTION
Currently the native SDK only supports attaching a transaction to a scope, but it's supposed to be a transaction or a span. This PR changes the `sentry_set_span` function to take a `sentry_span_t` and adds a `sentry_set_transaction_object` that does the same for `sentry_transaction_t`. Internally, a scope now keeps two pointers, one to a transaction and one to a span, and setting one of them unsets the other.