### PR TITLE
fix(tracing): Set max spans to the default amount when tracing is enabled

### DIFF
--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -415,6 +415,10 @@ sentry_options_set_traces_sample_rate(
         sample_rate = 1.0;
     }
     opts->traces_sample_rate = sample_rate;
+
+    if (sample_rate > 0 && opts->max_spans == 0) {
+        opts->max_spans = SENTRY_SPANS_MAX;
+    }
 }
 
 /**

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -349,7 +349,6 @@ SENTRY_TEST(basic_spans)
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_traces_sample_rate(options, 1.0);
-    sentry_options_set_max_spans(options, 3);
     sentry_init(options);
 
     // Starting a child with no active transaction should fail
@@ -404,7 +403,6 @@ SENTRY_TEST(spans_on_scope)
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_traces_sample_rate(options, 1.0);
-    sentry_options_set_max_spans(options, 3);
     sentry_init(options);
 
     sentry_transaction_context_t *opaque_tx_cxt


### PR DESCRIPTION
This fixes a minor issue that forces the user to explicitly set `max_spans` in sentry options in order to be able to capture any spans. Now, the default amount of max spans (1000) is automatically set if the user enables tracing. 

Custom `max_spans` values will be preserved if a user enables and disables tracing prior to initializing sentry. 
e.g. if the following actions are performed in this order:
- set max spans to 500
- set a sampling rate >0
- set a sampling value <= 0
- set a sampling rate >0
- init sentry
sentry will enforce a limit of a 500 max spans.