### PR TITLE
test: Add integration test for envelope with transaction

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -207,7 +207,7 @@ class PayloadRef(object):
             print(textwrap.indent(payload, " " * indent))
         except UnicodeEncodeError:
             # Windows CI appears fickle, and we put emojis in the json
-            payload = payload.encode('ascii', errors='replace')
+            payload = payload.encode("ascii", errors="replace").decode()
             print(textwrap.indent(payload, " " * indent))
 
     def __repr__(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -203,7 +203,12 @@ class PayloadRef(object):
             payload = self.bytes.encode("utf-8", errors="replace")
         if self.json:
             payload = pprint.pformat(self.json)
-        print(textwrap.indent(payload, " " * indent))
+        try:
+            print(textwrap.indent(payload, " " * indent))
+        except UnicodeEncodeError:
+            # Windows CI appears fickle, and we put emojis in the json
+            payload = payload.encode('ascii', errors='replace')
+            print(textwrap.indent(payload, " " * indent))
 
     def __repr__(self):
         # type: (...) -> str

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,8 @@ import json
 import sys
 import urllib
 import pytest
+import pprint
+import textwrap
 
 sourcedir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
@@ -165,6 +167,19 @@ class Envelope(object):
         # type: (...) -> Envelope
         return cls.deserialize_from(io.BytesIO(bytes))
 
+    def print_verbose(self, indent=0):
+        """Pretty prints the envelope."""
+        print(" " * indent + "Envelope:")
+        indent += 2
+        print(" " * indent + "Headers:")
+        indent += 2
+        print(textwrap.indent(pprint.pformat(self.headers), " " * indent))
+        indent -= 2
+        print(" " * indent + "Items:")
+        indent += 2
+        for item in self.items:
+            item.print_verbose(indent)
+
     def __repr__(self):
         # type: (...) -> str
         return "<Envelope headers=%r items=%r>" % (self.headers, self.items)
@@ -179,6 +194,16 @@ class PayloadRef(object):
         # type: (...) -> None
         self.json = json
         self.bytes = bytes
+
+    def print_verbose(self, indent=0):
+        """Pretty prints the item."""
+        print(" " * indent + "Payload:")
+        indent += 2
+        if self.bytes:
+            payload = self.bytes.encode("utf-8", errors="replace")
+        if self.json:
+            payload = pprint.pformat(self.json)
+        print(textwrap.indent(payload, " " * indent))
 
     def __repr__(self):
         # type: (...) -> str
@@ -205,7 +230,11 @@ class Item(object):
 
     def get_event(self):
         # type: (...) -> Optional[Event]
-        if self.headers.get("type") == "event" and self.payload.json is not None:
+        # Transactions are events with a few extra fields, so return them as well.
+        if (
+            self.headers.get("type") in ["event", "transaction"]
+            and self.payload.json is not None
+        ):
             return self.payload.json
         return None
 
@@ -220,7 +249,7 @@ class Item(object):
         headers = json.loads(line)
         length = headers["length"]
         payload = f.read(length)
-        if headers.get("type") == "event" or headers.get("type") == "session":
+        if headers.get("type") in ["event", "session", "transaction"]:
             rv = cls(headers=headers, payload=PayloadRef(json=json.loads(payload)))
         else:
             rv = cls(headers=headers, payload=payload)
@@ -233,6 +262,18 @@ class Item(object):
     ):
         # type: (...) -> Optional[Item]
         return cls.deserialize_from(io.BytesIO(bytes))
+
+    def print_verbose(self, indent=0):
+        """Pretty prints the item."""
+        item_type = self.headers.get("type", "?").capitalize()
+        print(" " * indent + f"{item_type}:")
+        indent += 2
+        print(" " * indent + "Headers:")
+        indent += 2
+        headers = pprint.pformat(self.headers)
+        print(textwrap.indent(headers, " " * indent))
+        indent -= 2
+        self.payload.print_verbose(indent)
 
     def __repr__(self):
         # type: (...) -> str

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -13,6 +13,7 @@ VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)(?:[-\.]?)(.*)")
 def matches(actual, expected):
     return {k: v for (k, v) in actual.items() if k in expected.keys()} == expected
 
+
 def assert_matches(actual, expected):
     """Assert two objects for equality, ignoring extra keys in ``actual``."""
     assert {k: v for (k, v) in actual.items() if k in expected.keys()} == expected

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -65,7 +65,7 @@ def assert_meta(
                 event["contexts"]["os"],
                 {"name": "Windows", "version": platform.version()},
             )
-            assert_event["contexts"]["os"]["build"] is not None
+            assert event["contexts"]["os"]["build"] is not None
         elif sys.platform == "linux":
             version = platform.release()
             match = VERSION_RE.match(version)

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -10,6 +10,9 @@ from .conditions import is_android
 VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)(?:[-\.]?)(.*)")
 
 
+def matches(actual, expected):
+    return {k: v for (k, v) in actual.items() if k in expected.keys()} == expected
+
 def assert_matches(actual, expected):
     """Assert two objects for equality, ignoring extra keys in ``actual``."""
     assert {k: v for (k, v) in actual.items() if k in expected.keys()} == expected
@@ -28,7 +31,7 @@ def assert_session(envelope, extra_assertion=None):
         "environment": "development",
     }
     if extra_assertion:
-        assert matches(session, extra_assertion)
+        assert_matches(session, extra_assertion)
 
 
 def assert_meta(

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -1,9 +1,11 @@
+import time
 import pytest
 import subprocess
 import sys
 import os
 import time
 import itertools
+import uuid
 import json
 from . import make_dsn, check_output, run, Envelope
 from .conditions import has_http, has_breakpad, has_files
@@ -413,3 +415,60 @@ def test_shutdown_timeout(cmake, httpserver):
     run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
 
     assert len(httpserver.log) == 10
+
+
+def test_transaction_only(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+
+    httpserver.expect_oneshot_request(
+        "/api/123456/envelope/",
+        headers={"x-sentry-auth": auth_header},
+    ).respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver), SENTRY_RELEASE="🤮🚀")
+
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "capture-transaction"],
+        check=True,
+        env=env,
+    )
+
+    assert len(httpserver.log) == 1
+    output = httpserver.log[0][0].get_data()
+    envelope = Envelope.deserialize(output)
+
+    # Show what the envelope looks like if the test fails.
+    envelope.print_verbose()
+
+    # The transaction is overwritten.
+    assert_meta(envelope, transaction="little.teapot")
+
+    # Extract the one-and-only-item
+    (event,) = envelope.items
+
+    assert event.headers["type"] == "transaction"
+    json = event.payload.json
+
+    # See https://develop.sentry.dev/sdk/performance/trace-context/#trace-context
+    trace_context = json["contexts"]["trace"]
+
+    assert (
+        trace_context["op"] == "Short and stout here is my handle and here is my spout"
+    )
+
+    assert trace_context["trace_id"]
+    trace_id = uuid.UUID(hex=trace_context["trace_id"])
+    assert trace_id
+
+    # TODO: currently missing
+    # assert trace_context['public_key']
+
+    assert trace_context["span_id"]
+    assert trace_context["status"] == "ok"
+
+    RFC3339_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+    start_timestamp = time.strptime(json["start_timestamp"], RFC3339_FORMAT)
+    assert start_timestamp
+    timestamp = time.strptime(json["timestamp"], RFC3339_FORMAT)
+    assert timestamp >= start_timestamp


### PR DESCRIPTION
This adds an integration test which inspects the envelope of a
transaction sent by the native SDK.

-------

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->