### PR TITLE
ref: Optimize JSON formatting

### DIFF
--- a/src/sentry_string.c
+++ b/src/sentry_string.c
@@ -39,8 +39,9 @@ sentry__stringbuilder_reserve(sentry_stringbuilder_t *sb, size_t len)
     return &sb->buf[sb->len];
 }
 
-static int
-append(sentry_stringbuilder_t *sb, const char *s, size_t len)
+int
+sentry__stringbuilder_append_buf(
+    sentry_stringbuilder_t *sb, const char *s, size_t len)
 {
     char *buf = sentry__stringbuilder_reserve(sb, len + 1);
     if (!buf) {
@@ -53,33 +54,6 @@ append(sentry_stringbuilder_t *sb, const char *s, size_t len)
     sb->buf[sb->len] = '\0';
 
     return 0;
-}
-
-int
-sentry__stringbuilder_append(sentry_stringbuilder_t *sb, const char *s)
-{
-    return append(sb, s, strlen(s));
-}
-
-int
-sentry__stringbuilder_append_buf(
-    sentry_stringbuilder_t *sb, const char *s, size_t len)
-{
-    return append(sb, s, len);
-}
-
-int
-sentry__stringbuilder_append_char(sentry_stringbuilder_t *sb, char c)
-{
-    return append(sb, &c, 1);
-}
-
-int
-sentry__stringbuilder_append_char32(sentry_stringbuilder_t *sb, uint32_t c)
-{
-    char buf[4];
-    size_t len = sentry__unichar_to_utf8(c, buf);
-    return sentry__stringbuilder_append_buf(sb, buf, len);
 }
 
 char *

--- a/src/sentry_string.h
+++ b/src/sentry_string.h
@@ -22,25 +22,28 @@ typedef struct sentry_stringbuilder_s {
 void sentry__stringbuilder_init(sentry_stringbuilder_t *sb);
 
 /**
- * Appends a zero terminated string to the builder.
- */
-int sentry__stringbuilder_append(sentry_stringbuilder_t *sb, const char *s);
-
-/**
  * Appends a sized buffer.
  */
 int sentry__stringbuilder_append_buf(
     sentry_stringbuilder_t *sb, const char *s, size_t len);
 
 /**
- * Appends a single character.
+ * Appends a zero terminated string to the builder.
  */
-int sentry__stringbuilder_append_char(sentry_stringbuilder_t *sb, char c);
+static inline int
+sentry__stringbuilder_append(sentry_stringbuilder_t *sb, const char *s)
+{
+    return sentry__stringbuilder_append_buf(sb, s, strlen(s));
+}
 
 /**
- * Appends a utf-32 character.
+ * Appends a single character.
  */
-int sentry__stringbuilder_append_char32(sentry_stringbuilder_t *sb, uint32_t c);
+static inline int
+sentry__stringbuilder_append_char(sentry_stringbuilder_t *sb, char c)
+{
+    return sentry__stringbuilder_append_buf(sb, &c, 1);
+}
 
 /**
  * Appends an int64 value.


### PR DESCRIPTION
- Inline some `stringbuilder` functions (and remove an unused one)