### PR TITLE
fix: Correctly apply contexts from the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Fix contexts from the scope not being attached to events correctly.
+- Improve performance of event serialization.
+
 ## 0.4.14
 
-**Features**
+**Features**:
 
 - The Sentry SDK now has experimental support for performance monitoring.
   The performance monitoring API allows manually creating transactions and instrumenting spans, and offers APIs for distributed tracing.
@@ -10,7 +17,7 @@
   For more information, take a look at the more detailed [documentation of performance monitoring](https://docs.sentry.io/platforms/native/performance/).
 - Sentry now has an explicit `sentry_flush` method that blocks the calling thread for the given time, waiting for the transport queue to be flushed. Custom transports need to implement a new `flush_hook` for this to work.
 
-**Fixes**
+**Fixes**:
 
 - Fix Sentry API deadlocking when the SDK was not initialized (or `sentry_init` failed).
 - The rate limit handling of the default transports was updated to match the expected behavior.
@@ -26,13 +33,13 @@ Features, fixes and improvements in this release have been contributed by:
 
 ## 0.4.13
 
-**Features**
+**Features**:
 
 - Add client-side stackwalking on Linux, Windows, and macOS (disabled by default).
 - CMake: add ability to set solution folder name.
 - Add AIX support.
 
-**Fixes**
+**Fixes**:
 
 - CMake: check whether libcurl was already found.
 - Increment CXX standard version to 14 to allow crashpad to build.

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -326,8 +326,9 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
         sentry__value_merge_objects(event_extra, scope->extra);
     }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
     sentry_value_t contexts = sentry__value_clone(scope->contexts);
+
+#ifdef SENTRY_PERFORMANCE_MONITORING
     // prep contexts sourced from scope; data about transaction on scope needs
     // to be extracted and inserted
     sentry_value_t scope_trace = sentry__value_get_trace_context(
@@ -338,6 +339,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
         }
         sentry_value_set_by_key(contexts, "trace", scope_trace);
     }
+#endif
 
     // merge contexts sourced from scope into the event
     sentry_value_t event_contexts = sentry_value_get_by_key(event, "contexts");
@@ -347,7 +349,6 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
         sentry__value_merge_objects(event_contexts, contexts);
     }
     sentry_value_decref(contexts);
-#endif
 
     if (mode & SENTRY_SCOPE_BREADCRUMBS) {
         PLACE_CLONED_VALUE("breadcrumbs", scope->breadcrumbs);


### PR DESCRIPTION
Fixes #675 