### PR TITLE
allow defining `SENTRY_SDK_NAME` externally

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -23,7 +23,9 @@ extern "C" {
 #endif
 
 /* SDK Version */
-#ifndef SENTRY_SDK_NAME
+#ifdef __ANDROID__
+#    define SENTRY_SDK_NAME "sentry.native.android"
+#else
 #    define SENTRY_SDK_NAME "sentry.native"
 #endif
 #define SENTRY_SDK_VERSION "0.4.15"

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -25,6 +25,7 @@ extern "C" {
 /* SDK Version */
 #ifndef SENTRY_SDK_NAME
 #define SENTRY_SDK_NAME "sentry.native"
+#endif
 #define SENTRY_SDK_VERSION "0.4.15"
 #define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -23,6 +23,7 @@ extern "C" {
 #endif
 
 /* SDK Version */
+#ifndef SENTRY_SDK_NAME
 #define SENTRY_SDK_NAME "sentry.native"
 #define SENTRY_SDK_VERSION "0.4.15"
 #define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -24,7 +24,7 @@ extern "C" {
 
 /* SDK Version */
 #ifndef SENTRY_SDK_NAME
-#define SENTRY_SDK_NAME "sentry.native"
+#    define SENTRY_SDK_NAME "sentry.native"
 #endif
 #define SENTRY_SDK_VERSION "0.4.15"
 #define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -59,7 +59,9 @@ def assert_meta(
             {"name": "github:getsentry/sentry-native", "version": "0.4.15"},
         ],
     }
-    if not is_android:
+    if is_android:
+        expected_sdk["name"] = "sentry.native.android"
+    else:
         if sys.platform == "win32":
             assert_matches(
                 event["contexts"]["os"],


### PR DESCRIPTION
Is this a feasible solution to this issue? https://github.com/getsentry/sentry-java/issues/1901

That assumes we can define `SENTRY_SDK_NAME` in the NDK [CMakeLists](https://github.com/getsentry/sentry-java/blob/main/sentry-android-ndk/CMakeLists.txt#L8) or [Gradle](https://github.com/getsentry/sentry-java/blob/33aeeb081e38aac8da02fd4101b6dfeb25d424ce/sentry-android-ndk/build.gradle.kts#L31-L32)