### PR TITLE
feat: Include performance monitoring by default in experimental API, remove compile flag for feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Removed the `SENTRY_PERFORMANCE_MONITORING` compile flag requirement to access performance monitoring in the Sentry SDK. Performance monitoring is now available to everybody who has opted into the experimental API.
+
 ## 0.4.15
 
 **Fixes**:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,8 +559,6 @@ if(SENTRY_BUILD_EXAMPLES)
 	add_executable(sentry_example examples/example.c)
 	target_link_libraries(sentry_example PRIVATE sentry)
 
-	target_compile_definitions(sentry_example PRIVATE SENTRY_PERFORMANCE_MONITORING)
-
 	if(MSVC)
 		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/wd5105>)
 	endif()

--- a/examples/example.c
+++ b/examples/example.c
@@ -93,7 +93,6 @@ main(int argc, char **argv)
             options, sentry_transport_new(print_envelope));
     }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
     if (has_arg(argc, argv, "capture-transaction")) {
         sentry_options_set_traces_sample_rate(options, 1.0);
     }
@@ -101,7 +100,6 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "child-spans")) {
         sentry_options_set_max_spans(options, 5);
     }
-#endif
 
     sentry_init(options);
 
@@ -218,7 +216,6 @@ main(int argc, char **argv)
         sentry_capture_event(event);
     }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
     if (has_arg(argc, argv, "capture-transaction")) {
         sentry_transaction_context_t *tx_ctx
             = sentry_transaction_context_new("little.teapot",
@@ -253,7 +250,6 @@ main(int argc, char **argv)
 
         sentry_transaction_finish(tx);
     }
-#endif
 
     // make sure everything flushes
     sentry_close();

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -568,7 +568,6 @@ SENTRY_API sentry_value_t sentry_envelope_get_event(
  */
 SENTRY_EXPERIMENTAL_API sentry_value_t sentry_envelope_get_transaction(
     const sentry_envelope_t *envelope);
-#endif
 
 /**
  * Serializes the envelope.
@@ -1708,4 +1707,5 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_iter_headers(
 
 #ifdef __cplusplus
 }
+#endif
 #endif

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -561,7 +561,6 @@ SENTRY_API void sentry_envelope_free(sentry_envelope_t *envelope);
 SENTRY_API sentry_value_t sentry_envelope_get_event(
     const sentry_envelope_t *envelope);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Given an Envelope, returns the embedded Transaction if there is one.
  *
@@ -1137,9 +1136,9 @@ SENTRY_API sentry_user_consent_t sentry_user_consent_get(void);
 /**
  * Sends a sentry event.
  *
- * If SENTRY_PERFORMANCE_MONITORING is enabled, returns a nil UUID if the event
- * being passed in is a transaction, and the transaction will not be sent nor
- * consumed. `sentry_transaction_finish` should be used to send transactions.
+ * If returns a nil UUID if the event being passed in is a transaction, and the
+ * transaction will not be sent nor consumed. `sentry_transaction_finish` should
+ * be used to send transactions.
  */
 SENTRY_API sentry_uuid_t sentry_capture_event(sentry_value_t event);
 
@@ -1229,7 +1228,6 @@ SENTRY_API void sentry_start_session(void);
  */
 SENTRY_API void sentry_end_session(void);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Sets the maximum number of spans that can be attached to a
  * transaction.
@@ -1708,9 +1706,6 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_iter_headers(
     sentry_transaction_t *tx, sentry_iter_headers_function_t callback,
     void *userdata);
 
-#endif
-
 #ifdef __cplusplus
 }
-#endif
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,6 @@ if(SENTRY_INTEGRATION_QT)
 endif()
 
 if(SENTRY_BUILD_EXAMPLES)
-	target_compile_definitions(sentry PRIVATE SENTRY_PERFORMANCE_MONITORING)
 	sentry_target_sources_cwd(sentry
 	sentry_tracing.c
 	sentry_tracing.h

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -16,15 +16,12 @@
 #include "sentry_session.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
+#include "sentry_tracing.h"
 #include "sentry_transport.h"
 #include "sentry_value.h"
 
 #ifdef SENTRY_INTEGRATION_QT
 #    include "integrations/sentry_integration_qt.h"
-#endif
-
-#ifdef SENTRY_PERFORMANCE_MONITORING
-#    include "sentry_tracing.h"
 #endif
 
 static sentry_options_t *g_options = NULL;
@@ -367,27 +364,21 @@ event_is_considered_error(sentry_value_t event)
     return false;
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 bool
 sentry__event_is_transaction(sentry_value_t event)
 {
     sentry_value_t event_type = sentry_value_get_by_key(event, "type");
     return sentry__string_eq("transaction", sentry_value_as_string(event_type));
 }
-#endif
 
 sentry_uuid_t
 sentry_capture_event(sentry_value_t event)
 {
-#ifdef SENTRY_PERFORMANCE_MONITORING
     if (sentry__event_is_transaction(event)) {
         return sentry_uuid_nil();
     } else {
         return sentry__capture_event(event);
     }
-#else
-    return sentry__capture_event(event);
-#endif
 }
 
 sentry_uuid_t
@@ -401,15 +392,11 @@ sentry__capture_event(sentry_value_t event)
     SENTRY_WITH_OPTIONS (options) {
         was_captured = true;
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
         if (sentry__event_is_transaction(event)) {
             envelope = sentry__prepare_transaction(options, event, &event_id);
         } else {
             envelope = sentry__prepare_event(options, event, &event_id);
         }
-#else
-        envelope = sentry__prepare_event(options, event, &event_id);
-#endif
         if (envelope) {
             if (options->session) {
                 sentry_options_t *mut_options = sentry__options_lock();
@@ -439,7 +426,6 @@ sentry__roll_dice(double probability)
         || ((double)rnd / (double)UINT64_MAX) <= probability;
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 bool
 sentry__should_send_transaction(sentry_value_t tx_cxt)
 {
@@ -456,7 +442,6 @@ sentry__should_send_transaction(sentry_value_t tx_cxt)
     }
     return send;
 }
-#endif
 
 sentry_envelope_t *
 sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
@@ -524,7 +509,6 @@ fail:
     return NULL;
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_envelope_t *
 sentry__prepare_transaction(const sentry_options_t *options,
     sentry_value_t transaction, sentry_uuid_t *event_id)
@@ -555,7 +539,6 @@ fail:
     sentry_value_decref(transaction);
     return NULL;
 }
-#endif
 
 void
 sentry_handle_exception(const sentry_ucontext_t *uctx)
@@ -723,11 +706,9 @@ sentry_set_transaction(const char *transaction)
         sentry_free(scope->transaction);
         scope->transaction = sentry__string_clone(transaction);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
         if (scope->transaction_object) {
             sentry_transaction_set_name(scope->transaction_object, transaction);
         }
-#endif
     }
 }
 
@@ -739,7 +720,6 @@ sentry_set_level(sentry_level_t level)
     }
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_transaction_t *
 sentry_transaction_start(
     sentry_transaction_context_t *opaque_tx_cxt, sentry_value_t sampling_ctx)
@@ -1019,4 +999,3 @@ fail:
     sentry__span_free(opaque_span);
     return;
 }
-#endif

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -29,13 +29,11 @@
  */
 bool sentry__should_skip_upload(void);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Given a well-formed event, returns whether an event is a transaction or not.
  * Defaults to false, which will also be returned if the event is malformed.
  */
 bool sentry__event_is_transaction(sentry_value_t event);
-#endif
 
 /**
  * Convert the given event into an envelope. This assumes that the event
@@ -60,7 +58,6 @@ sentry_envelope_t *sentry__prepare_event(const sentry_options_t *options,
  */
 sentry_uuid_t sentry__capture_event(sentry_value_t event);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Convert the given transaction into an envelope. This assumes that the
  * event being passed in is a transaction.
@@ -78,7 +75,6 @@ sentry_uuid_t sentry__capture_event(sentry_value_t event);
  */
 sentry_envelope_t *sentry__prepare_transaction(const sentry_options_t *options,
     sentry_value_t transaction, sentry_uuid_t *event_id);
-#endif
 
 /**
  * This function will submit the `envelope` to the given `transport`, first
@@ -122,9 +118,7 @@ void sentry__options_unlock(void);
 // these for now are only needed outside of core for tests
 #ifdef SENTRY_UNITTEST
 bool sentry__roll_dice(double probability);
-#    ifdef SENTRY_PERFORMANCE_MONITORING
 bool sentry__should_send_transaction(sentry_value_t tx_cxt);
-#    endif
 #endif
 
 #endif

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -201,22 +201,15 @@ sentry_envelope_get_event(const sentry_envelope_t *envelope)
     }
     for (size_t i = 0; i < envelope->contents.items.item_count; i++) {
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
         if (!sentry_value_is_null(envelope->contents.items.items[i].event)
             && !sentry__event_is_transaction(
                 envelope->contents.items.items[i].event)) {
             return envelope->contents.items.items[i].event;
         }
-#else
-        if (!sentry_value_is_null(envelope->contents.items.items[i].event)) {
-            return envelope->contents.items.items[i].event;
-        }
-#endif
     }
     return sentry_value_new_null();
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_value_t
 sentry_envelope_get_transaction(const sentry_envelope_t *envelope)
 {
@@ -232,7 +225,6 @@ sentry_envelope_get_transaction(const sentry_envelope_t *envelope)
     }
     return sentry_value_new_null();
 }
-#endif
 
 sentry_envelope_item_t *
 sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
@@ -264,7 +256,6 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
     return item;
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_envelope_item_t *
 sentry__envelope_add_transaction(
     sentry_envelope_t *envelope, sentry_value_t transaction)
@@ -293,17 +284,16 @@ sentry__envelope_add_transaction(
     sentry_value_incref(event_id);
     sentry__envelope_set_header(envelope, "event_id", event_id);
 
-#    ifdef SENTRY_UNITTEST
+#ifdef SENTRY_UNITTEST
     sentry_value_t now = sentry_value_new_string("2021-12-16T05:53:59.343Z");
-#    else
+#else
     sentry_value_t now = sentry__value_new_string_owned(
         sentry__msec_time_to_iso8601(sentry__msec_time()));
-#    endif
+#endif
     sentry__envelope_set_header(envelope, "sent_at", now);
 
     return item;
 }
-#endif
 
 sentry_envelope_item_t *
 sentry__envelope_add_session(

--- a/src/sentry_envelope.h
+++ b/src/sentry_envelope.h
@@ -36,13 +36,11 @@ sentry_uuid_t sentry__envelope_get_event_id(const sentry_envelope_t *envelope);
 sentry_envelope_item_t *sentry__envelope_add_event(
     sentry_envelope_t *envelope, sentry_value_t event);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Add a transaction to this envelope.
  */
 sentry_envelope_item_t *sentry__envelope_add_transaction(
     sentry_envelope_t *envelope, sentry_value_t transaction);
-#endif
 
 /**
  * Add a session to this envelope.

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -51,11 +51,8 @@ sentry_options_new(void)
     opts->sample_rate = 1.0;
     opts->refcount = 1;
     opts->shutdown_timeout = SENTRY_DEFAULT_SHUTDOWN_TIMEOUT;
-
-#ifdef SENTRY_PERFORMANCE_MONITORING
     opts->traces_sample_rate = 0.0;
     opts->max_spans = 0;
-#endif
 
     return opts;
 }
@@ -378,7 +375,6 @@ sentry_options_set_database_pathw(sentry_options_t *opts, const wchar_t *path)
 }
 #endif
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Sets the maximum number of spans that can be attached to a
  * transaction.
@@ -429,4 +425,3 @@ sentry_options_get_traces_sample_rate(sentry_options_t *opts)
 {
     return opts->traces_sample_rate;
 }
-#endif

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -55,11 +55,9 @@ typedef struct sentry_options_s {
     sentry_event_function_t before_send_func;
     void *before_send_data;
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
     /* Experimentally exposed */
     double traces_sample_rate;
     size_t max_spans;
-#endif
 
     /* everything from here on down are options which are stored here but
        not exposed through the options API */

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -20,7 +20,6 @@ typedef struct sentry_scope_s {
     sentry_level_t level;
     sentry_value_t client_sdk;
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
     // The span attached to this scope, if any.
     //
     // Conceptually, every transaction is a span, so it should be possible to
@@ -31,7 +30,6 @@ typedef struct sentry_scope_s {
     // `name` property nested in transaction_object or span.
     sentry_transaction_t *transaction_object;
     sentry_span_t *span;
-#endif
 } sentry_scope_t;
 
 /**
@@ -98,9 +96,7 @@ void sentry__scope_apply_to_event(const sentry_scope_t *scope,
 
 #endif
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 // this is only used in unit tests
 #ifdef SENTRY_UNITTEST
 sentry_value_t sentry__scope_get_span_or_transaction();
-#endif
 #endif

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -1,9 +1,7 @@
-#include "sentry_boot.h"
-
+#include "sentry_tracing.h"
 #include "sentry_alloc.h"
 #include "sentry_logger.h"
 #include "sentry_string.h"
-#include "sentry_tracing.h"
 #include "sentry_utils.h"
 #include "sentry_value.h"
 #include <string.h>

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -1,7 +1,6 @@
 #ifndef SENTRY_TRACING_H_INCLUDED
 #define SENTRY_TRACING_H_INCLUDED
 
-#include "sentry_boot.h"
 #include "sentry_value.h"
 
 /**

--- a/src/sentry_uuid.c
+++ b/src/sentry_uuid.c
@@ -102,28 +102,26 @@ sentry_uuid_as_string(const sentry_uuid_t *uuid, char str[37])
 #undef B
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 void
 sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[37])
 {
-#    define B(X) (unsigned char)uuid->bytes[X]
+#define B(X) (unsigned char)uuid->bytes[X]
     snprintf(str, 33,
         "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%"
         "02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
         B(0), B(1), B(2), B(3), B(4), B(5), B(6), B(7), B(8), B(9), B(10),
         B(11), B(12), B(13), B(14), B(15));
-#    undef B
+#undef B
 }
 
 void
 sentry__span_uuid_as_string(const sentry_uuid_t *uuid, char str[17])
 {
-#    define B(X) (unsigned char)uuid->bytes[X]
+#define B(X) (unsigned char)uuid->bytes[X]
     snprintf(str, 17, "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx", B(0),
         B(1), B(2), B(3), B(4), B(5), B(6), B(7));
-#    undef B
+#undef B
 }
-#endif
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 sentry_uuid_t

--- a/src/sentry_uuid.h
+++ b/src/sentry_uuid.h
@@ -3,7 +3,6 @@
 
 #include "sentry_boot.h"
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 /**
  * Converts a sentry UUID to a string representation used for internal
  * sentry UUIDs such as event IDs.
@@ -21,6 +20,4 @@ void sentry__span_uuid_as_string(const sentry_uuid_t *uuid, char str[17]);
  * Create a new UUID from the windows-native GUID type.
  */
 sentry_uuid_t sentry__uuid_from_native(const GUID *guid);
-#endif
-
 #endif

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -1009,7 +1009,6 @@ sentry__value_new_hexstring(const uint8_t *bytes, size_t len)
     return sentry__value_new_string_owned(buf);
 }
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_value_t
 sentry__value_new_span_uuid(const sentry_uuid_t *uuid)
 {
@@ -1033,7 +1032,6 @@ sentry__value_new_internal_uuid(const sentry_uuid_t *uuid)
     buf[32] = '\0';
     return sentry__value_new_string_owned(buf);
 }
-#endif
 
 sentry_value_t
 sentry__value_new_uuid(const sentry_uuid_t *uuid)

--- a/src/sentry_value.h
+++ b/src/sentry_value.h
@@ -118,9 +118,7 @@ typedef struct sentry_jsonwriter_s sentry_jsonwriter_t;
 void sentry__jsonwriter_write_value(
     sentry_jsonwriter_t *jw, sentry_value_t value);
 
-#ifdef SENTRY_PERFORMANCE_MONITORING
 sentry_value_t sentry__value_new_span_uuid(const sentry_uuid_t *uuid);
 
 sentry_value_t sentry__value_new_internal_uuid(const sentry_uuid_t *uuid);
-#endif
 #endif

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -83,7 +83,6 @@ endif()
 target_compile_definitions(sentry PRIVATE SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
 
 target_compile_definitions(sentry_test_unit PRIVATE SENTRY_UNITTEST)
-target_compile_definitions(sentry_test_unit PRIVATE SENTRY_PERFORMANCE_MONITORING)
 
 add_test(NAME sentry_test_unit COMMAND sentry_test_unit)
 

--- a/tests/unit/fuzz.c
+++ b/tests/unit/fuzz.c
@@ -24,8 +24,6 @@ afl-fuzz -i fuzzing-examples -o fuzzing-results -- fuzzing/sentry_fuzz_json @@
 #    define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "sentry.h"
-
 #include <assert.h>
 #include <string.h>
 

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -2,7 +2,6 @@
 #include "sentry_path.h"
 #include "sentry_string.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 typedef struct {
     uint64_t called;

--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -1,6 +1,5 @@
 #include "sentry_core.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 static void
 send_envelope_test_basic(const sentry_envelope_t *envelope, void *data)

--- a/tests/unit/test_concurrency.c
+++ b/tests/unit/test_concurrency.c
@@ -1,6 +1,6 @@
 #include "sentry_core.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
+
 #include <sentry_sync.h>
 
 static void

--- a/tests/unit/test_consent.c
+++ b/tests/unit/test_consent.c
@@ -1,6 +1,5 @@
 #include "sentry_path.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 static void
 init_consenting_sentry(void)

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -3,7 +3,6 @@
 #include "sentry_transport.h"
 #include "sentry_utils.h"
 #include "sentry_value.h"
-#include <sentry.h>
 
 SENTRY_TEST(basic_http_request_preparation_for_event)
 {

--- a/tests/unit/test_failures.c
+++ b/tests/unit/test_failures.c
@@ -1,6 +1,5 @@
 #include "sentry_core.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 static int
 transport_startup_fail(

--- a/tests/unit/test_fuzzfailures.c
+++ b/tests/unit/test_fuzzfailures.c
@@ -2,7 +2,7 @@
 #include "sentry_path.h"
 #include "sentry_testsupport.h"
 #include "sentry_value.h"
-#include <sentry.h>
+
 #include <string.h>
 
 static void

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -1,7 +1,6 @@
 #include "sentry_core.h"
 #include "sentry_logger.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 typedef struct {
     uint64_t called;

--- a/tests/unit/test_modulefinder.c
+++ b/tests/unit/test_modulefinder.c
@@ -1,6 +1,5 @@
 #include "sentry_path.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 #ifdef SENTRY_PLATFORM_LINUX
 #    include "modulefinder/sentry_modulefinder_linux.h"

--- a/tests/unit/test_mpack.c
+++ b/tests/unit/test_mpack.c
@@ -1,7 +1,6 @@
 #include "sentry_path.h"
 #include "sentry_scope.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 SENTRY_TEST(mpack_removed_tags)
 {

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -1,7 +1,6 @@
 #include "sentry_path.h"
 #include "sentry_string.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 SENTRY_TEST(recursive_paths)
 {

--- a/tests/unit/test_ratelimiter.c
+++ b/tests/unit/test_ratelimiter.c
@@ -1,7 +1,6 @@
 #include "sentry_ratelimiter.h"
 #include "sentry_testsupport.h"
 #include "sentry_utils.h"
-#include <sentry.h>
 
 SENTRY_TEST(rate_limit_parsing)
 {

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -2,7 +2,6 @@
 #include "sentry_session.h"
 #include "sentry_testsupport.h"
 #include "sentry_value.h"
-#include <sentry.h>
 
 static void
 send_envelope(const sentry_envelope_t *envelope, void *data)

--- a/tests/unit/test_slice.c
+++ b/tests/unit/test_slice.c
@@ -1,6 +1,5 @@
 #include "sentry_slice.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 SENTRY_TEST(slice)
 {

--- a/tests/unit/test_symbolizer.c
+++ b/tests/unit/test_symbolizer.c
@@ -1,6 +1,5 @@
 #include "sentry_symbolizer.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 TEST_VISIBLE void
 test_function(void)

--- a/tests/unit/test_uninit.c
+++ b/tests/unit/test_uninit.c
@@ -1,5 +1,4 @@
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 SENTRY_TEST(uninitialized)
 {

--- a/tests/unit/test_unwinder.c
+++ b/tests/unit/test_unwinder.c
@@ -1,6 +1,5 @@
 #include "sentry_symbolizer.h"
 #include "sentry_testsupport.h"
-#include <sentry.h>
 
 #define MAX_FRAMES 128
 

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -2,7 +2,6 @@
 #include "sentry_testsupport.h"
 #include "sentry_utils.h"
 #include "sentry_value.h"
-#include <sentry.h>
 
 #ifdef SENTRY_PLATFORM_UNIX
 #    include "sentry_unix_pageallocator.h"

--- a/tests/unit/test_uuid.c
+++ b/tests/unit/test_uuid.c
@@ -1,5 +1,5 @@
 #include "sentry_testsupport.h"
-#include <sentry.h>
+
 #include <sentry_uuid.h>
 
 SENTRY_TEST(uuid_api)

--- a/tests/unit/test_uuid.c
+++ b/tests/unit/test_uuid.c
@@ -1,6 +1,6 @@
 #include "sentry_testsupport.h"
 
-#include <sentry_uuid.h>
+#include "sentry_uuid.h"
 
 SENTRY_TEST(uuid_api)
 {

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -3,7 +3,6 @@
 #include "sentry_value.h"
 #include <locale.h>
 #include <math.h>
-#include <sentry.h>
 
 SENTRY_TEST(value_null)
 {


### PR DESCRIPTION
Does what it says in the title. Removes all instances of `SENTRY_PERFORMANCE_MONITORING` so you don't need to include an additional compile time flag to get access to performance monitoring on the SDK if you've already opted into experimental features.

This touches several test files because they import `sentry.h` and `sentry_testsupport.h`, which is causing a double import of perfmon enums. I believe @Swatinem mentioned in a previous PR that the fix for something like this was to remove the `sentry.h` import, hence the diffs on those files. `sentry.h` has been removed as an import from other headers as well (eg `sentry_scope.h` if `sentry_tracing.h` is already imported due to the same issue.
