### PR TITLE
feat: SDK name override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 **Features**:
 
 - Removed the `SENTRY_PERFORMANCE_MONITORING` compile flag requirement to access performance monitoring in the Sentry SDK. Performance monitoring is now available to everybody who has opted into the experimental API.
+- Allow overriding the SDK name at build time - set the `SENTRY_SDK_NAME` CMake cache variable.
+- Remove `SENTRY_SDK_NAME` and `SENTRY_SDK_USER_AGENT` macros from `sentry.h`
 
 ## 0.4.15
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,17 @@ if(SENTRY_BACKEND_CRASHPAD AND ANDROID)
 	message(FATAL_ERROR "The Crashpad backend is not currently supported on Android")
 endif()
 
+if(ANDROID)
+	set(SENTRY_DEFAULT_SDK_NAME "sentry.native.android")
+else()
+	set(SENTRY_DEFAULT_SDK_NAME "sentry.native")
+endif()
+set(SENTRY_SDK_NAME "${SENTRY_DEFAULT_SDK_NAME}" CACHE STRING "The SDK name to report when sending events.")
+
 message(STATUS "SENTRY_TRANSPORT=${SENTRY_TRANSPORT}")
 message(STATUS "SENTRY_BACKEND=${SENTRY_BACKEND}")
 message(STATUS "SENTRY_LIBRARY_TYPE=${SENTRY_LIBRARY_TYPE}")
+message(STATUS "SENTRY_SDK_NAME=${SENTRY_SDK_NAME}")
 
 if(ANDROID)
 	set(SENTRY_WITH_LIBUNWINDSTACK TRUE)
@@ -220,6 +228,8 @@ add_library(sentry ${SENTRY_LIBRARY_TYPE} "${PROJECT_SOURCE_DIR}/vendor/mpack.c"
 target_sources(sentry PRIVATE "${PROJECT_SOURCE_DIR}/include/sentry.h")
 add_library(sentry::sentry ALIAS sentry)
 add_subdirectory(src)
+
+target_compile_definitions(sentry PRIVATE SENTRY_SDK_NAME="${SENTRY_SDK_NAME}")
 
 # we do not need this on android, only linux
 if(LINUX)

--- a/README.md
+++ b/README.md
@@ -264,12 +264,15 @@ Legend:
 
 - `SENTRY_FOLDER` (Default: not defined):
   Sets the sentry-native projects folder name for generators which support project hierarchy (like Microsoft Visual Studio).
-  To use this feature you need to enable hierarchy via [`USE_FOLDERS` property](https://cmake.org/cmake/help/latest/prop_gbl/USE_FOLDERS.html) 
+  To use this feature you need to enable hierarchy via [`USE_FOLDERS` property](https://cmake.org/cmake/help/latest/prop_gbl/USE_FOLDERS.html)
 
 - `CRASHPAD_ENABLE_STACKTRACE` (Default: OFF):
   This enables client-side stackwalking when using the crashpad backend. Stack unwinding will happen on the client's machine
   and the result will be submitted to Sentry attached to the generated minidump.
   Note that this feature is still experimental.
+
+- `SENTRY_SDK_NAME` (Default: sentry.native or sentry.native.android):
+  Sets the SDK name that should be included in the reported events.
 
 ### Build Targets
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -23,13 +23,7 @@ extern "C" {
 #endif
 
 /* SDK Version */
-#ifdef __ANDROID__
-#    define SENTRY_SDK_NAME "sentry.native.android"
-#else
-#    define SENTRY_SDK_NAME "sentry.native"
-#endif
 #define SENTRY_SDK_VERSION "0.4.15"
-#define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION
 
 /* common platform detection */
 #ifdef _WIN32

--- a/src/sentry_boot.h
+++ b/src/sentry_boot.h
@@ -40,4 +40,6 @@
 #include <sentry.h>
 #include <stdbool.h>
 
+#define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION
+
 #endif

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -40,6 +40,7 @@ def assert_meta(
     release="test-example-release",
     integration=None,
     transaction="test-transaction",
+    sdk_override=None,
 ):
     event = envelope.get_event()
 
@@ -93,6 +94,9 @@ def assert_meta(
                 },
             )
             assert event["contexts"]["os"]["build"] is not None
+
+    if sdk_override != None:
+        expected_sdk["name"] = sdk_override
 
     assert_matches(event, expected)
     assert_matches(event["sdk"], expected_sdk)

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -42,6 +42,28 @@ def test_capture_stdout(cmake):
     assert_event(envelope)
 
 
+def test_sdk_name_override(cmake):
+    sdk_name = "cUsToM.SDK"
+    tmp_path = cmake(
+        ["sentry_example"],
+        {
+            "SENTRY_BACKEND": "none",
+            "SENTRY_TRANSPORT": "none",
+            "SENTRY_SDK_NAME": sdk_name,
+        },
+    )
+
+    output = check_output(
+        tmp_path,
+        "sentry_example",
+        ["stdout", "capture-event"],
+    )
+    envelope = Envelope.deserialize(output)
+
+    assert_meta(envelope, sdk_override=sdk_name)
+    assert_event(envelope)
+
+
 @pytest.mark.skipif(not has_files, reason="test needs a local filesystem")
 def test_multi_process(cmake):
     # NOTE: It would have been nice to do *everything* in a unicode-named


### PR DESCRIPTION
To support https://github.com/getsentry/sentry-unity/issues/616