### PR TITLE
ref: Update black so it stops breaking our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
             RUN_ANALYZER: asan,llvm-cov
-          - name: Windows (VS2017, 32bit)
-            os: vs2017-win2016
+          - name: Windows (VS2019)
+            os: windows-2019
             TEST_X86: 1
           - name: Windows (latest)
             os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - New API to check whether the application has crashed in the previous run: `sentry_get_crashed_last_run()` and `sentry_clear_crashed_last_run()` ([#685](https://github.com/getsentry/sentry-native/pull/685)).
 - Allow overriding the SDK name at build time - set the `SENTRY_SDK_NAME` CMake cache variable.
 
+**Fixes**:
+- Updated CI as well as list of supported platforms to reflect Windows Server 2016, and therefore MSVC 2017 losing active support.
+
 ## 0.4.15
 
 **Fixes**:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The SDK currently supports and is tested on the following OS/Compiler variations
 - 64bit Linux with clang 9
 - 32bit Linux with GCC 7 (cross compiled from 64bit host)
 - 64bit Windows with MSVC 2019
-- 32bit Windows with MSVC 2017
+- 64bit Windows with MSVC 2022
 - macOS Catalina with most recent Compiler toolchain
 - Android API29 built by NDK21 toolchain
 - Android API16 built by NDK19 toolchain

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The SDK currently supports and is tested on the following OS/Compiler variations
 - 64bit Linux with GCC 9
 - 64bit Linux with clang 9
 - 32bit Linux with GCC 7 (cross compiled from 64bit host)
-- 64bit Windows with MSVC 2019
+- 32bit Windows with MSVC 2019
 - 64bit Windows with MSVC 2022
 - macOS Catalina with most recent Compiler toolchain
 - Android API29 built by NDK21 toolchain

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-black==21.9b0
+black==22.3.0
 pytest==6.2.5
 pytest-httpserver==1.0.1


### PR DESCRIPTION
black is currently causing our CI to fail. A naive bump up to a version that fixes this shouldn't be high risk for us since: a. it's a code formatter and b. we use python for our integration tests.

The tests don't completely pass but I don't believe it's a hard requirement to at least get this change in. Some of the tests are failing for completely unrelated reasons (deprecated windows environments on GitHub) and can/should be fixed in a separate PR just to keep things compartmentalized.