### PR TITLE
feat: More aggressively prune the Crashpad database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed the `SENTRY_PERFORMANCE_MONITORING` compile flag requirement to access performance monitoring in the Sentry SDK. Performance monitoring is now available to everybody who has opted into the experimental API.
 - New API to check whether the application has crashed in the previous run: `sentry_get_crashed_last_run()` and `sentry_clear_crashed_last_run()` ([#685](https://github.com/getsentry/sentry-native/pull/685)).
 - Allow overriding the SDK name at build time - set the `SENTRY_SDK_NAME` CMake cache variable.
+- More aggressively prune the Crashpad database. ([#698](https://github.com/getsentry/sentry-native/pull/698))
 
 ## 0.4.15
 

--- a/src/sentry_backend.h
+++ b/src/sentry_backend.h
@@ -25,6 +25,7 @@ struct sentry_backend_s {
         const sentry_options_t *options);
     void (*user_consent_changed_func)(sentry_backend_t *);
     uint64_t (*get_last_crash_func)(sentry_backend_t *);
+    void (*prune_database_func)(sentry_backend_t *);
     void *data;
     bool can_capture_after_shutdown;
 };

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -182,7 +182,11 @@ sentry_init(sentry_options_t *options)
 
     // after initializing the transport, we will submit all the unsent envelopes
     // and handle remaining sessions.
+    SENTRY_TRACE("processing and pruning old runs");
     sentry__process_old_runs(options, last_crash);
+    if (backend && backend->prune_database_func) {
+        backend->prune_database_func(backend);
+    }
 
     if (options->auto_session_tracking) {
         sentry_start_session();


### PR DESCRIPTION
It seems that the defaults in the crashpad_handler only trigger after a long 10min delay, and let the db grow to up to 128M by default. We generally do not care about older/completed reports at all, so make sure to aggressively prune them.