### PR TITLE
feat: Allow disabling of the crash-handler backend at runtime.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,3 +139,4 @@ The example currently supports the following commends:
 - `capture-multiple`: Captures a number of events.
 - `sleep`: Introduces a 10 second sleep.
 - `add-stacktrace`: Adds the current thread stacktrace to the captured event.
+- `disable-backend`: Disables the build-configured crash-handler backend.

--- a/examples/example.c
+++ b/examples/example.c
@@ -65,6 +65,10 @@ main(int argc, char **argv)
 {
     sentry_options_t *options = sentry_options_new();
 
+    if (has_arg(argc, argv, "disable-backend")) {
+        sentry_options_set_backend(options, NULL);
+    }
+
     // this is an example. for real usage, make sure to set this explicitly to
     // an app specific cache location.
     sentry_options_set_database_path(options, ".sentry-native");

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -709,6 +709,20 @@ SENTRY_API void sentry_transport_free(sentry_transport_t *transport);
 SENTRY_API sentry_transport_t *sentry_new_function_transport(
     void (*func)(const sentry_envelope_t *envelope, void *data), void *data);
 
+/**
+ * This represents an interface for user-defined backends.
+ *
+ * Backends are responsible to handle crashes. They are maintained at runtime
+ * via various life-cycle hooks from the sentry-core.
+ *
+ * At this point none of those interfaces are exposed in the API including
+ * creation and destruction. The main use-case of the backend in the API at this
+ * point is to disable it via `sentry_options_set_backend` at runtime before it
+ * is initialized.
+ */
+struct sentry_backend_s;
+typedef struct sentry_backend_s sentry_backend_t;
+
 /* -- Options APIs -- */
 
 /**
@@ -1049,6 +1063,16 @@ SENTRY_API void sentry_options_set_shutdown_timeout(
  * end on shutdown, before attempting a forced termination.
  */
 SENTRY_API uint64_t sentry_options_get_shutdown_timeout(sentry_options_t *opts);
+
+/**
+ * Sets a user-defined backend.
+ *
+ * Since creation and destruction of backends is not exposed in the API, this
+ * can only be used to set the backend to `NULL`, which disables the backend in
+ * the initialization.
+ */
+SENTRY_API void sentry_options_set_backend(
+    sentry_options_t *opts, sentry_backend_t *backend);
 
 /* -- Global APIs -- */
 

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -425,3 +425,10 @@ sentry_options_get_traces_sample_rate(sentry_options_t *opts)
 {
     return opts->traces_sample_rate;
 }
+
+void
+sentry_options_set_backend(sentry_options_t *opts, sentry_backend_t *backend)
+{
+    sentry__backend_free(opts->backend);
+    opts->backend = backend;
+}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-native/issues/705

* Instead of modifying any existing interfaces, I just added new API functions for `sentry_options_t`
* I am not sure if we need all the functions, but most of the options interface is symmetric (i.e. getters and setters) so I did the same, but still tried to hide the backend behind the API facade
* Added new option to example code to allow it to run in an integration-test