### PR TITLE
fix: retrieve only completed crash-reports from the crashpad database...

### DIFF
--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -409,14 +409,6 @@ sentry__crashpad_backend_last_crash(sentry_backend_t *backend)
     uint64_t crash_time = 0;
 
     std::vector<crashpad::CrashReportDatabase::Report> reports;
-    if (data->db->GetPendingReports(&reports)
-        == crashpad::CrashReportDatabase::kNoError) {
-        for (const crashpad::CrashReportDatabase::Report &report : reports) {
-            report_crash_time(&crash_time, report);
-        }
-    }
-
-    reports.clear();
     if (data->db->GetCompletedReports(&reports)
         == crashpad::CrashReportDatabase::kNoError) {
         for (const crashpad::CrashReportDatabase::Report &report : reports) {


### PR DESCRIPTION
when recovering the timestamp of the last potential crash on initialization.

This is one attempt discussed with @Swatinem to fix https://github.com/getsentry/sentry-native/issues/716. I create it as a draft though, because I still cannot reproduce the issue, but it still could be useful for testing if the customer has a stable repro.