### PR TITLE
fix: Make Windows ModuleFinder more resilient to missing Debug Info

### DIFF
--- a/src/modulefinder/sentry_modulefinder_windows.c
+++ b/src/modulefinder/sentry_modulefinder_windows.c
@@ -38,6 +38,12 @@ extract_pdb_info(uintptr_t module_addr, sentry_value_t module)
         return;
     }
 
+    char id_buf[50];
+    snprintf(id_buf, sizeof(id_buf), "%08x%X",
+        nt_headers->FileHeader.TimeDateStamp,
+        nt_headers->OptionalHeader.SizeOfImage);
+    sentry_value_set_by_key(module, "code_id", sentry_value_new_string(id_buf));
+
     uint32_t relative_addr
         = nt_headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG]
               .VirtualAddress;
@@ -63,18 +69,11 @@ extract_pdb_info(uintptr_t module_addr, sentry_value_t module)
 
     sentry_uuid_t debug_id_base
         = sentry__uuid_from_native(&debug_info->pdb_signature);
-    char id_buf[50];
     sentry_uuid_as_string(&debug_id_base, id_buf);
     id_buf[36] = '-';
     snprintf(id_buf + 37, 10, "%x", debug_info->pdb_age);
     sentry_value_set_by_key(
         module, "debug_id", sentry_value_new_string(id_buf));
-
-    snprintf(id_buf, sizeof(id_buf), "%08x%X",
-        nt_headers->FileHeader.TimeDateStamp,
-        nt_headers->OptionalHeader.SizeOfImage);
-    sentry_value_set_by_key(module, "code_id", sentry_value_new_string(id_buf));
-    sentry_value_set_by_key(module, "type", sentry_value_new_string("pe"));
 }
 
 static void
@@ -97,6 +96,8 @@ load_modules(void)
                         module.modBaseAddr, &vmem_info, sizeof(vmem_info))
                 && vmem_info.State == MEM_COMMIT) {
                 sentry_value_t rv = sentry_value_new_object();
+                sentry_value_set_by_key(
+                    rv, "type", sentry_value_new_string("pe"));
                 sentry_value_set_by_key(rv, "image_addr",
                     sentry__value_new_addr((uint64_t)module.modBaseAddr));
                 sentry_value_set_by_key(rv, "image_size",


### PR DESCRIPTION
Previously the Windows ModuleFinder would early-return in case the
loaded library had no debug directory / codeview record.
In that case, the image type and code-id would be missing which results
in normalization errors in Relay. We now always write the image type,
and the code-id as early as possible.