### PR TITLE
ref(on_crash): follow-up to make on_crash releasable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Expose llvm PATH for Mac
         if: ${{ runner.os == 'macOS' }}
-        run: echo $(brew --prefix llvm@13)/bin >> $GITHUB_PATH
+        run: echo $(brew --prefix llvm@14)/bin >> $GITHUB_PATH
 
       - name: Installing Android SDK Dependencies
         if: ${{ env['ANDROID_API'] }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 **Features**
 
-- Provide `on_crash()` callback to allow clients to act on detected crashes
+- Provide `on_crash()` callback to allow clients to act on detected crashes.
+  Users often inquired about distinguishing between crashes and "normal" events in the `before_send()` hook.
+  `on_crash()` can be considered a replacement for `before_send()` for crash events, where the goal is to use 
+  `before_send()` only for normal events, while `on_crash()` is only invoked for crashes. This change is backward
+  compatible for current users of `before_send()` and allows gradual migration to `on_crash()`
+  ([see the docs for details](https://docs.sentry.io/platforms/native/configuration/filtering/)). 
   ([#724](https://github.com/getsentry/sentry-native/pull/724), 
    [#734](https://github.com/getsentry/sentry-native/pull/734))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,24 @@
 
 ## Unreleased
 
+**Features**
+
+- Provide `on_crash()` callback to allow clients to act on detected crashes
+  ([#724](https://github.com/getsentry/sentry-native/pull/724))
+
 **Fixes**
 
+- Make Windows ModuleFinder more resilient to missing Debug Info 
+  ([#732](https://github.com/getsentry/sentry-native/pull/732))
 - Aligned pre-send event processing in `sentry_capture_event()` with the 
   [cross-SDK session filter order](https://develop.sentry.dev/sdk/sessions/#filter-order) 
   ([#729](https://github.com/getsentry/sentry-native/pull/729))
+
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@espkk](https://github.com/espkk)
 
 ## 0.4.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 **Features**
 
 - Provide `on_crash()` callback to allow clients to act on detected crashes
-  ([#724](https://github.com/getsentry/sentry-native/pull/724))
+  ([#724](https://github.com/getsentry/sentry-native/pull/724), 
+   [#734](https://github.com/getsentry/sentry-native/pull/734))
 
 **Fixes**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,3 +140,7 @@ The example currently supports the following commends:
 - `sleep`: Introduces a 10 second sleep.
 - `add-stacktrace`: Adds the current thread stacktrace to the captured event.
 - `disable-backend`: Disables the build-configured crash-handler backend.
+- `before-send`: Installs a `before_send()` callback that retains the event.
+- `discarding-before-send`: Installs a `before_send()` callback that retains the event.
+- `on-crash`: Installs an `on_crash()` callback that retains the crash event. 
+- `discarding-on-crash`: Installs an `on_crash()` callback that discards the crash event.

--- a/examples/example.c
+++ b/examples/example.c
@@ -26,6 +26,9 @@
 static sentry_value_t
 before_send_callback(sentry_value_t event, void *hint, void *closure)
 {
+    (void)hint;
+    (void)closure;
+
     // make our mark on the event
     sentry_value_set_by_key(
         event, "adapted_by", sentry_value_new_string("before_send"));
@@ -37,6 +40,9 @@ before_send_callback(sentry_value_t event, void *hint, void *closure)
 static int
 discarding_on_crash_callback(const sentry_ucontext_t *uctx, void *closure)
 {
+    (void)uctx;
+    (void)closure;
+
     // tell the backend to discard the event
     return 0;
 }
@@ -44,6 +50,9 @@ discarding_on_crash_callback(const sentry_ucontext_t *uctx, void *closure)
 static int
 retaining_on_crash_callback(const sentry_ucontext_t *uctx, void *closure)
 {
+    (void)uctx;
+    (void)closure;
+
     // tell the backend to retain the event
     return 1;
 }

--- a/examples/example.c
+++ b/examples/example.c
@@ -162,13 +162,13 @@ main(int argc, char **argv)
             options, discarding_before_send_callback, NULL);
     }
 
+    if (has_arg(argc, argv, "on-crash")) {
+        sentry_options_set_on_crash(options, on_crash_callback, NULL);
+    }
+
     if (has_arg(argc, argv, "discarding-on-crash")) {
         sentry_options_set_on_crash(
             options, discarding_on_crash_callback, NULL);
-    }
-
-    if (has_arg(argc, argv, "on-crash")) {
-        sentry_options_set_on_crash(options, on_crash_callback, NULL);
     }
 
     sentry_init(options);

--- a/examples/example.c
+++ b/examples/example.c
@@ -40,6 +40,9 @@ before_send_callback(sentry_value_t event, void *hint, void *closure)
 static sentry_value_t
 discarding_before_send_callback(sentry_value_t event, void *hint, void *closure)
 {
+    (void)hint;
+    (void)closure;
+
     // discard event and signal backend to stop further processing
     sentry_value_decref(event);
     return sentry_value_new_null();

--- a/examples/example.c
+++ b/examples/example.c
@@ -48,24 +48,27 @@ discarding_before_send_callback(sentry_value_t event, void *hint, void *closure)
     return sentry_value_new_null();
 }
 
-static int
-discarding_on_crash_callback(const sentry_ucontext_t *uctx, void *closure)
+static sentry_value_t
+discarding_on_crash_callback(
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *closure)
 {
     (void)uctx;
     (void)closure;
 
-    // tell the backend to discard the event
-    return 0;
+    // discard event and signal backend to stop further processing
+    sentry_value_decref(event);
+    return sentry_value_new_null();
 }
 
-static int
-on_crash_callback(const sentry_ucontext_t *uctx, void *closure)
+static sentry_value_t
+on_crash_callback(
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *closure)
 {
     (void)uctx;
     (void)closure;
 
     // tell the backend to retain the event
-    return 1;
+    return event;
 }
 
 static void

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -770,9 +770,10 @@ SENTRY_API void sentry_options_set_transport(
  * call `sentry_value_decref` on the provided event, and return a
  * `sentry_value_new_null()` instead.
  *
- * If you have set an `on_crash` callback (even one that only returns 1),
- * `before_send` will no longer be invoked for crash-events. This allows you to
- * better differentiate between crashes and all other events.
+ * If you have set an `on_crash` callback (independent of whether it discards or
+ * retains the event), `before_send` will no longer be invoked for crash-events,
+ * which allows you to better distinguish between crashes and all other events
+ * in client-side pre-processing.
  *
  * This function may be invoked inside of a signal handler and must be safe for
  * that purpose, see https://man7.org/linux/man-pages/man7/signal-safety.7.html.
@@ -801,24 +802,48 @@ SENTRY_API void sentry_options_set_before_send(
 /**
  * Type of the `on_crash` callback.
  *
- * Does not work with crashpad on macOS.
- * The callback passes a pointer to sentry_ucontext_s structure when exception
- * handler is invoked. For breakpad on Linux this pointer is NULL.
+ * The `on_crash` callback replaces the `before_send` callback for crash events.
+ * The interface is analogous to `before_send` in that the callback takes
+ * ownership of the `event`, and should usually return that same event. In case
+ * the event should be discarded, the callback needs to call
+ * `sentry_value_decref` on the provided event, and return a
+ * `sentry_value_new_null()` instead.
  *
- * If the callback returns false outgoing crash report will be discarded.
+ * Only the `inproc` backend currently fills the passed-in event with useful
+ * data and processes any modifications to the return value. Since both
+ * `breakpad` and `crashpad` use minidumps to capture the crash state, the
+ * passed-in event is empty when using these backends, and they ignore any
+ * changes to the return value.
  *
- * If this callback is set in the options, a concurrently enabled `before_send`
- * callback will no longer be called in the crash case. This allows for better
- * differentiation between crashes and other events.
+ * If you set this callback in the options, it prevents a concurrently enabled
+ * `before_send` callback from being invoked in the crash case. This allows for
+ * better differentiation between crashes and other events and gradual migration
+ * from existing `before_send` implementations:
+ *
+ *  - if you have a `before_send` implementation and do not define an `on_crash`
+ *    callback your application will receive both normal and crash events as
+ *    before
+ *  - if you have a `before_send` implementation but only want to handle normal
+ *    events with it, then you can define an `on_crash` callback that returns
+ *    the passed-in event and does nothing else
+ *  - if you are not interested in normal events, but only want to act on
+ *    crashes (within the limits mentioned below), then only define an
+ *    `on_crash` callback with the option to filter (on all backends) or enrich
+ *    (only inproc) the crash event
  *
  * This function may be invoked inside of a signal handler and must be safe for
  * that purpose, see https://man7.org/linux/man-pages/man7/signal-safety.7.html.
  * On Windows, it may be called from inside of a `UnhandledExceptionFilter`, see
  * the documentation on SEH (structured exception handling) for more information
  * https://docs.microsoft.com/en-us/windows/win32/debug/structured-exception-handling
+ *
+ * Platform-specific behavior:
+ *
+ *  - does not work with crashpad on macOS.
+ *  - for breakpad on Linux the `uctx` parameter is always NULL.
  */
-typedef int (*sentry_crash_function_t)(
-    const sentry_ucontext_t *uctx, void *closure);
+typedef sentry_value_t (*sentry_crash_function_t)(
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *closure);
 
 /**
  * Sets the `on_crash` callback.

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -113,8 +113,8 @@ sentry__breakpad_backend_callback(
 
         if (should_handle) {
             sentry_value_t event = sentry_value_new_event();
-            sentry_envelope_t *envelope
-                = sentry__prepare_event(options, event, NULL);
+            sentry_envelope_t *envelope = sentry__prepare_event(
+                options, event, nullptr, !options->on_crash_func);
             // the event we just prepared is empty,
             // so no error is recorded for it
             sentry__record_errors_on_current_session(1);

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -91,6 +91,7 @@ sentry__breakpad_backend_callback(
 #else
     dump_path = sentry__path_new(descriptor.path());
 #endif
+    sentry_value_t event = sentry_value_new_event();
 
     SENTRY_WITH_OPTIONS (options) {
         sentry__write_crash_marker(options);
@@ -107,12 +108,12 @@ sentry__breakpad_backend_callback(
 #endif
 
             SENTRY_TRACE("invoking `on_crash` hook");
-            should_handle
-                = options->on_crash_func(uctx, options->on_crash_data);
+            sentry_value_t result
+                = options->on_crash_func(uctx, event, options->on_crash_data);
+            should_handle = !sentry_value_is_null(result);
         }
 
         if (should_handle) {
-            sentry_value_t event = sentry_value_new_event();
             sentry_envelope_t *envelope = sentry__prepare_event(
                 options, event, nullptr, !options->on_crash_func);
             // the event we just prepared is empty,
@@ -152,6 +153,7 @@ sentry__breakpad_backend_callback(
             sentry__path_free(dump_path);
         } else {
             SENTRY_TRACE("event was discarded by the `on_crash` hook");
+            sentry_value_decref(event);
         }
 
         // after capturing the crash event, try to dump all the in-flight

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -213,7 +213,8 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
     // crashpad
     if (!should_dump) {
 #    ifdef SENTRY_PLATFORM_WINDOWS
-        TerminateProcess(GetCurrentProcess(), kTerminationCodeCrashNoDump);
+        // TerminateProcess(GetCurrentProcess(), kTerminationCodeCrashNoDump);
+        TerminateProcess(GetCurrentProcess(), 1);
 #    else
         _exit(EXIT_FAILURE);
 #    endif

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -43,6 +43,7 @@ extern "C" {
 extern "C" {
 
 #ifdef SENTRY_PLATFORM_LINUX
+#    include <unistd.h>
 #    define SIGNAL_STACK_SIZE 65536
 static stack_t g_signal_stack;
 

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -535,8 +535,8 @@ handle_ucontext(const sentry_ucontext_t *uctx)
         }
 
         if (should_handle) {
-            sentry_envelope_t *envelope
-                = sentry__prepare_event(options, event, NULL);
+            sentry_envelope_t *envelope = sentry__prepare_event(
+                options, event, NULL, !options->on_crash_func);
             // TODO(tracing): Revisit when investigating transaction flushing
             // during hard crashes.
 

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -552,6 +552,7 @@ handle_ucontext(const sentry_ucontext_t *uctx)
             sentry_transport_free(disk_transport);
         } else {
             SENTRY_TRACE("event was discarded by the `on_crash` hook");
+            sentry_value_decref(event);
         }
 
         // after capturing the crash event, dump all the envelopes to disk

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -530,8 +530,8 @@ handle_ucontext(const sentry_ucontext_t *uctx)
 
         if (options->on_crash_func) {
             SENTRY_TRACE("invoking `on_crash` hook");
-            should_handle
-                = options->on_crash_func(uctx, options->on_crash_data);
+            event = options->on_crash_func(uctx, event, options->on_crash_data);
+            should_handle = !sentry_value_is_null(event);
         }
 
         if (should_handle) {

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -411,7 +411,7 @@ sentry__capture_event(sentry_value_t event)
         if (sentry__event_is_transaction(event)) {
             envelope = sentry__prepare_transaction(options, event, &event_id);
         } else {
-            envelope = sentry__prepare_event(options, event, &event_id);
+            envelope = sentry__prepare_event(options, event, &event_id, true);
         }
         if (envelope) {
             if (options->session) {
@@ -460,7 +460,7 @@ sentry__should_send_transaction(sentry_value_t tx_cxt)
 
 sentry_envelope_t *
 sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
-    sentry_uuid_t *event_id)
+    sentry_uuid_t *event_id, bool invoke_before_send)
 {
     sentry_envelope_t *envelope = NULL;
 
@@ -477,7 +477,7 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
         sentry__scope_apply_to_event(scope, options, event, mode);
     }
 
-    if (options->before_send_func) {
+    if (options->before_send_func && invoke_before_send) {
         SENTRY_TRACE("invoking `before_send` hook");
         event
             = options->before_send_func(event, NULL, options->before_send_data);

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -40,9 +40,8 @@ bool sentry__event_is_transaction(sentry_value_t event);
  * being passed in is not a transaction.
  *
  * More specifically, it will do the following things:
- * - sample the event, possibly discarding it,
  * - apply the scope to it,
- * - call the before_send hook on it,
+ * - call the before_send hook on it (if invoke_before_send == true),
  * - add the event to a new envelope,
  * - record errors on the current session,
  * - add any attachments to the envelope as well
@@ -51,7 +50,7 @@ bool sentry__event_is_transaction(sentry_value_t event);
  * `event_id` out-parameter.
  */
 sentry_envelope_t *sentry__prepare_event(const sentry_options_t *options,
-    sentry_value_t event, sentry_uuid_t *event_id);
+    sentry_value_t event, sentry_uuid_t *event_id, bool invoke_before_send);
 
 /**
  * Sends a sentry event, regardless of its type.

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,11 +1,11 @@
 import datetime
 import email
 import gzip
-import sys
 import platform
 import re
-from .conditions import is_android
+import sys
 
+from .conditions import is_android
 
 VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)(?:[-\.]?)(.*)")
 
@@ -192,6 +192,25 @@ def assert_crash(envelope):
     # depending on the unwinder, we currently don’t get any stack frames from
     # a `ucontext`
     assert_stacktrace(envelope, inside_exception=True, check_size=False)
+
+
+def assert_crash_timestamp(has_files, tmp_path):
+    # The crash file should survive a `sentry_init` and should still be there
+    # even after restarts.
+    if has_files:
+        with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
+            crash_timestamp = f.read()
+        assert_timestamp(crash_timestamp)
+
+
+def assert_before_send(envelope):
+    event = envelope.get_event()
+    assert_matches(event, {"adapted_by": "before_send"})
+
+
+def assert_no_before_send(envelope):
+    event = envelope.get_event()
+    assert ("adapted_by", "before_send") not in event.items()
 
 
 def assert_crashpad_upload(req):

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -132,10 +132,6 @@ def test_crashpad_crash(cmake, httpserver):
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
 )
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="not yet validated",
-)
 def test_crashpad_crash_before_send(cmake, httpserver):
     session, multipart = run_crashpad_dumping_crash(cmake, httpserver, ["before-send"])
 
@@ -154,10 +150,6 @@ def test_crashpad_crash_before_send(cmake, httpserver):
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
 )
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="not yet validated",
-)
 def test_crashpad_crash_discarding_before_send(cmake, httpserver):
     session = run_crashpad_non_dumping_crash(
         cmake, httpserver, ["discarding-before-send"]
@@ -172,10 +164,6 @@ def test_crashpad_crash_discarding_before_send(cmake, httpserver):
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
 )
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="not yet validated",
-)
 def test_crashpad_crash_discarding_on_crash(cmake, httpserver):
     session = run_crashpad_non_dumping_crash(cmake, httpserver, ["discarding-on-crash"])
 
@@ -187,10 +175,6 @@ def test_crashpad_crash_discarding_on_crash(cmake, httpserver):
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
-)
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="not yet validated",
 )
 def test_crashpad_crash_discarding_before_send_and_on_crash(cmake, httpserver):
     session, multipart = run_crashpad_dumping_crash(

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -85,6 +85,193 @@ def test_crashpad_crash(cmake, httpserver):
 
 
 @pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+def test_crashpad_crash_before_send(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        child = run(
+            tmp_path,
+            "sentry_example",
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "overflow-breadcrumbs",
+                "crash",
+                "before-send",
+            ],
+            env=env,
+        )
+        assert child.returncode  # well, its a crash after all
+
+    assert waiting.result
+
+    # the session crash heuristic on mac uses timestamps, so make sure we have
+    # a small delay here
+    time.sleep(1)
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    assert len(httpserver.log) == 2
+    outputs = (httpserver.log[0][0], httpserver.log[1][0])
+    session, multipart = (
+        (outputs[0].get_data(), outputs[1])
+        if b'"type":"session"' in outputs[0].get_data()
+        else (outputs[1].get_data(), outputs[0])
+    )
+
+    envelope = Envelope.deserialize(session)
+    assert_session(envelope, {"status": "crashed", "errors": 1})
+
+    # TODO(supervacuus): we would expect to see a change coming from the
+    # before_send() hook, but in contrast to the other backends the crashpad
+    # backend currently only checks for null-value as a signal not to produce
+    # a minidump and after this decrefs the event.
+
+    assert_crashpad_upload(multipart)
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+def test_crashpad_crash_discarding_before_send(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=5, raise_assertions=False) as waiting:
+        child = run(
+            tmp_path,
+            "sentry_example",
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "overflow-breadcrumbs",
+                "crash",
+                "discarding-before-send",
+            ],
+            env=env,
+        )
+        assert child.returncode  # well, its a crash after all
+
+    assert waiting.result is False
+
+    # the session crash heuristic on mac uses timestamps, so make sure we have
+    # a small delay here
+    time.sleep(1)
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    assert len(httpserver.log) == 1
+    output = httpserver.log[0][0]
+    session = output.get_data()
+    envelope = Envelope.deserialize(session)
+    assert_session(envelope, {"status": "abnormal", "errors": 0})
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+def test_crashpad_crash_discarding_on_crash(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=5, raise_assertions=False) as waiting:
+        child = run(
+            tmp_path,
+            "sentry_example",
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "overflow-breadcrumbs",
+                "crash",
+                "discarding-on-crash",
+            ],
+            env=env,
+        )
+        assert child.returncode  # well, its a crash after all
+
+    # crashpad is disabled, and we are only crashing, so we expect the wait to timeout
+    assert waiting.result is False
+
+    # the session crash heuristic on mac uses timestamps, so make sure we have
+    # a small delay here
+    time.sleep(1)
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    assert len(httpserver.log) == 1
+    output = httpserver.log[0][0]
+    session = output.get_data()
+    envelope = Envelope.deserialize(session)
+    assert_session(envelope, {"status": "abnormal", "errors": 0})
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+def test_crashpad_crash_discarding_before_send_and_on_crash(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        child = run(
+            tmp_path,
+            "sentry_example",
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "overflow-breadcrumbs",
+                "crash",
+                "discarding-before-send",
+                "on-crash",
+            ],
+            env=env,
+        )
+        assert child.returncode  # well, its a crash after all
+
+    assert waiting.result
+
+    # the session crash heuristic on mac uses timestamps, so make sure we have
+    # a small delay here
+    time.sleep(1)
+
+    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
+
+    assert len(httpserver.log) == 2
+    outputs = (httpserver.log[0][0], httpserver.log[1][0])
+    session, multipart = (
+        (outputs[0].get_data(), outputs[1])
+        if b'"type":"session"' in outputs[0].get_data()
+        else (outputs[1].get_data(), outputs[0])
+    )
+
+    envelope = Envelope.deserialize(session)
+    assert_session(envelope, {"status": "crashed", "errors": 1})
+
+    assert_crashpad_upload(multipart)
+
+
+@pytest.mark.skipif(
     sys.platform == "linux", reason="linux clears the signal handlers on shutdown"
 )
 def test_crashpad_crash_after_shutdown(cmake, httpserver):

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -46,7 +46,7 @@ def test_crashpad_reinstall(cmake, httpserver):
     assert len(httpserver.log) == 1
 
 
-def test_crashpad_crash(cmake, httpserver):
+def run_crashpad_dumping_crash(cmake, httpserver, custom_args):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
@@ -57,7 +57,8 @@ def test_crashpad_crash(cmake, httpserver):
         child = run(
             tmp_path,
             "sentry_example",
-            ["log", "start-session", "attachment", "overflow-breadcrumbs", "crash"],
+            ["log", "start-session", "attachment", "overflow-breadcrumbs", "crash"]
+            + custom_args,
             env=env,
         )
         assert child.returncode  # well, its a crash after all
@@ -78,24 +79,16 @@ def test_crashpad_crash(cmake, httpserver):
         else (outputs[1].get_data(), outputs[0])
     )
 
-    envelope = Envelope.deserialize(session)
-    assert_session(envelope, {"status": "crashed", "errors": 1})
-
-    assert_crashpad_upload(multipart)
+    return session, multipart
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
-)
-def test_crashpad_crash_before_send(cmake, httpserver):
+def run_crashpad_non_dumping_crash(cmake, httpserver, custom_args):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
-    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
     httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
 
-    with httpserver.wait(timeout=10) as waiting:
+    with httpserver.wait(timeout=5, raise_assertions=False) as waiting:
         child = run(
             tmp_path,
             "sentry_example",
@@ -105,13 +98,13 @@ def test_crashpad_crash_before_send(cmake, httpserver):
                 "attachment",
                 "overflow-breadcrumbs",
                 "crash",
-                "before-send",
-            ],
+            ]
+            + custom_args,
             env=env,
         )
         assert child.returncode  # well, its a crash after all
 
-    assert waiting.result
+    assert waiting.result is False
 
     # the session crash heuristic on mac uses timestamps, so make sure we have
     # a small delay here
@@ -119,155 +112,95 @@ def test_crashpad_crash_before_send(cmake, httpserver):
 
     run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
 
-    assert len(httpserver.log) == 2
-    outputs = (httpserver.log[0][0], httpserver.log[1][0])
-    session, multipart = (
-        (outputs[0].get_data(), outputs[1])
-        if b'"type":"session"' in outputs[0].get_data()
-        else (outputs[1].get_data(), outputs[0])
-    )
+    assert len(httpserver.log) == 1
+    output = httpserver.log[0][0]
+    session = output.get_data()
+
+    return session
+
+
+def test_crashpad_crash(cmake, httpserver):
+    session, multipart = run_crashpad_dumping_crash(cmake, httpserver, [])
 
     envelope = Envelope.deserialize(session)
+
     assert_session(envelope, {"status": "crashed", "errors": 1})
+    assert_crashpad_upload(multipart)
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="not yet validated",
+)
+def test_crashpad_crash_before_send(cmake, httpserver):
+    session, multipart = run_crashpad_dumping_crash(cmake, httpserver, ["before-send"])
+
+    envelope = Envelope.deserialize(session)
+
+    assert_session(envelope, {"status": "crashed", "errors": 1})
+    assert_crashpad_upload(multipart)
 
     # TODO(supervacuus): we would expect to see a change coming from the
     # before_send() hook, but in contrast to the other backends the crashpad
     # backend currently only checks for null-value as a signal not to produce
     # a minidump and after this decrefs the event.
 
-    assert_crashpad_upload(multipart)
-
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="not yet validated",
 )
 def test_crashpad_crash_discarding_before_send(cmake, httpserver):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
-
-    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
-    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
-
-    with httpserver.wait(timeout=5, raise_assertions=False) as waiting:
-        child = run(
-            tmp_path,
-            "sentry_example",
-            [
-                "log",
-                "start-session",
-                "attachment",
-                "overflow-breadcrumbs",
-                "crash",
-                "discarding-before-send",
-            ],
-            env=env,
-        )
-        assert child.returncode  # well, its a crash after all
-
-    assert waiting.result is False
-
-    # the session crash heuristic on mac uses timestamps, so make sure we have
-    # a small delay here
-    time.sleep(1)
-
-    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
-
-    assert len(httpserver.log) == 1
-    output = httpserver.log[0][0]
-    session = output.get_data()
-    envelope = Envelope.deserialize(session)
-    assert_session(envelope, {"status": "abnormal", "errors": 0})
-
-
-@pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
-)
-def test_crashpad_crash_discarding_on_crash(cmake, httpserver):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
-
-    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
-    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
-
-    with httpserver.wait(timeout=5, raise_assertions=False) as waiting:
-        child = run(
-            tmp_path,
-            "sentry_example",
-            [
-                "log",
-                "start-session",
-                "attachment",
-                "overflow-breadcrumbs",
-                "crash",
-                "discarding-on-crash",
-            ],
-            env=env,
-        )
-        assert child.returncode  # well, its a crash after all
-
-    # crashpad is disabled, and we are only crashing, so we expect the wait to timeout
-    assert waiting.result is False
-
-    # the session crash heuristic on mac uses timestamps, so make sure we have
-    # a small delay here
-    time.sleep(1)
-
-    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
-
-    assert len(httpserver.log) == 1
-    output = httpserver.log[0][0]
-    session = output.get_data()
-    envelope = Envelope.deserialize(session)
-    assert_session(envelope, {"status": "abnormal", "errors": 0})
-
-
-@pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
-)
-def test_crashpad_crash_discarding_before_send_and_on_crash(cmake, httpserver):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
-
-    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
-    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
-    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
-
-    with httpserver.wait(timeout=10) as waiting:
-        child = run(
-            tmp_path,
-            "sentry_example",
-            [
-                "log",
-                "start-session",
-                "attachment",
-                "overflow-breadcrumbs",
-                "crash",
-                "discarding-before-send",
-                "on-crash",
-            ],
-            env=env,
-        )
-        assert child.returncode  # well, its a crash after all
-
-    assert waiting.result
-
-    # the session crash heuristic on mac uses timestamps, so make sure we have
-    # a small delay here
-    time.sleep(1)
-
-    run(tmp_path, "sentry_example", ["log", "no-setup"], check=True, env=env)
-
-    assert len(httpserver.log) == 2
-    outputs = (httpserver.log[0][0], httpserver.log[1][0])
-    session, multipart = (
-        (outputs[0].get_data(), outputs[1])
-        if b'"type":"session"' in outputs[0].get_data()
-        else (outputs[1].get_data(), outputs[0])
+    session = run_crashpad_non_dumping_crash(
+        cmake, httpserver, ["discarding-before-send"]
     )
 
     envelope = Envelope.deserialize(session)
-    assert_session(envelope, {"status": "crashed", "errors": 1})
 
+    assert_session(envelope, {"status": "abnormal", "errors": 0})
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="not yet validated",
+)
+def test_crashpad_crash_discarding_on_crash(cmake, httpserver):
+    session = run_crashpad_non_dumping_crash(cmake, httpserver, ["discarding-on-crash"])
+
+    envelope = Envelope.deserialize(session)
+
+    assert_session(envelope, {"status": "abnormal", "errors": 0})
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="not yet validated",
+)
+def test_crashpad_crash_discarding_before_send_and_on_crash(cmake, httpserver):
+    session, multipart = run_crashpad_dumping_crash(
+        cmake, httpserver, ["discarding-before-send", "on-crash"]
+    )
+
+    envelope = Envelope.deserialize(session)
+
+    # on_crash() is defined and overrules the discarding before_send()
+    assert_session(envelope, {"status": "crashed", "errors": 1})
     assert_crashpad_upload(multipart)
 
 

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -1,10 +1,11 @@
-import pytest
+import os
 import subprocess
 import sys
-import os
 import time
+
+import pytest
+
 from . import check_output, run, Envelope
-from .conditions import has_breakpad, has_files
 from .assertions import (
     assert_attachment,
     assert_meta,
@@ -14,8 +15,11 @@ from .assertions import (
     assert_crash,
     assert_minidump,
     assert_timestamp,
-    assert_session,
+    assert_before_send,
+    assert_no_before_send,
+    assert_crash_timestamp,
 )
+from .conditions import has_breakpad, has_files
 
 
 def test_capture_stdout(cmake):
@@ -111,52 +115,118 @@ def test_multi_process(cmake):
     assert len(runs) == 0
 
 
-def test_inproc_crash_stdout(cmake):
+def run_crash_stdout_for(backend, cmake, example_args):
     tmp_path = cmake(
         ["sentry_example"],
-        {"SENTRY_BACKEND": "inproc", "SENTRY_TRANSPORT": "none"},
+        {"SENTRY_BACKEND": backend, "SENTRY_TRANSPORT": "none"},
     )
 
-    child = run(tmp_path, "sentry_example", ["attachment", "crash"])
-    assert child.returncode  # well, its a crash after all
+    child = run(tmp_path, "sentry_example", ["attachment", "crash"] + example_args)
+    assert child.returncode  # well, it's a crash after all
 
-    output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
+    return tmp_path, check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
+
+
+def test_inproc_crash_stdout(cmake):
+    tmp_path, output = run_crash_stdout_for("inproc", cmake, [])
+
     envelope = Envelope.deserialize(output)
 
-    # The crash file should survive a `sentry_init` and should still be there
-    # even after restarts.
-    if has_files:
-        with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
-            crash_timestamp = f.read()
-        assert_timestamp(crash_timestamp)
-
+    assert_crash_timestamp(has_files, tmp_path)
     assert_meta(envelope, integration="inproc")
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
+    assert_crash(envelope)
 
+
+def test_inproc_crash_stdout_before_send(cmake):
+    tmp_path, output = run_crash_stdout_for("inproc", cmake, ["before-send"])
+
+    envelope = Envelope.deserialize(output)
+
+    assert_crash_timestamp(has_files, tmp_path)
+    assert_meta(envelope, integration="inproc")
+    assert_breadcrumb(envelope)
+    assert_attachment(envelope)
+    assert_crash(envelope)
+    assert_before_send(envelope)
+
+
+def test_inproc_crash_stdout_discarding_on_crash(cmake):
+    tmp_path, output = run_crash_stdout_for("inproc", cmake, ["discarding-on-crash"])
+
+    # since the on_crash() handler discards further processing we expect an empty response
+    assert len(output) == 0
+
+    assert_crash_timestamp(has_files, tmp_path)
+
+
+def test_inproc_crash_stdout_before_send_and_on_crash(cmake):
+    tmp_path, output = run_crash_stdout_for(
+        "inproc", cmake, ["before-send", "retaining-on-crash"]
+    )
+
+    # the on_crash() hook retains the event
+    envelope = Envelope.deserialize(output)
+    # but we expect no event modification from before_send() since setting on_crash() disables before_send()
+    assert_no_before_send(envelope)
+
+    assert_crash_timestamp(has_files, tmp_path)
+    assert_meta(envelope, integration="inproc")
+    assert_breadcrumb(envelope)
+    assert_attachment(envelope)
     assert_crash(envelope)
 
 
 @pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout(cmake):
-    tmp_path = cmake(
-        ["sentry_example"],
-        {"SENTRY_BACKEND": "breakpad", "SENTRY_TRANSPORT": "none"},
-    )
+    tmp_path, output = run_crash_stdout_for("breakpad", cmake, [])
 
-    child = run(tmp_path, "sentry_example", ["attachment", "crash"])
-    assert child.returncode  # well, its a crash after all
-
-    if has_files:
-        with open("{}/.sentry-native/last_crash".format(tmp_path)) as f:
-            crash_timestamp = f.read()
-        assert_timestamp(crash_timestamp)
-
-    output = check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
     envelope = Envelope.deserialize(output)
 
+    assert_crash_timestamp(has_files, tmp_path)
     assert_meta(envelope, integration="breakpad")
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
-
     assert_minidump(envelope)
+
+
+@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+def test_breakpad_crash_stdout_before_send(cmake):
+    tmp_path, output = run_crash_stdout_for("breakpad", cmake, ["before-send"])
+
+    envelope = Envelope.deserialize(output)
+
+    assert_crash_timestamp(has_files, tmp_path)
+    assert_meta(envelope, integration="breakpad")
+    assert_breadcrumb(envelope)
+    assert_attachment(envelope)
+    assert_minidump(envelope)
+    assert_before_send(envelope)
+
+
+@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+def test_breakpad_crash_stdout_discarding_on_crash(cmake):
+    tmp_path, output = run_crash_stdout_for("breakpad", cmake, ["discarding-on-crash"])
+
+    # since the on_crash() handler discards further processing we expect an empty response
+    assert len(output) == 0
+
+    assert_crash_timestamp(has_files, tmp_path)
+
+
+@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
+    tmp_path, output = run_crash_stdout_for(
+        "breakpad", cmake, ["before-send", "retaining-on-crash"]
+    )
+
+    # the on_crash() hook retains the event
+    envelope = Envelope.deserialize(output)
+    # but we expect no event modification from before_send() since setting on_crash() disables before_send()
+    assert_no_before_send(envelope)
+
+    assert_crash_timestamp(has_files, tmp_path)
+    assert_meta(envelope, integration="breakpad")
+    assert_breadcrumb(envelope)
+    assert_attachment(envelope)

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -163,7 +163,7 @@ def test_inproc_crash_stdout_discarding_on_crash(cmake):
 
 def test_inproc_crash_stdout_before_send_and_on_crash(cmake):
     tmp_path, output = run_crash_stdout_for(
-        "inproc", cmake, ["before-send", "retaining-on-crash"]
+        "inproc", cmake, ["before-send", "on-crash"]
     )
 
     # the on_crash() hook retains the event
@@ -218,7 +218,7 @@ def test_breakpad_crash_stdout_discarding_on_crash(cmake):
 @pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
     tmp_path, output = run_crash_stdout_for(
-        "breakpad", cmake, ["before-send", "retaining-on-crash"]
+        "breakpad", cmake, ["before-send", "on-crash"]
     )
 
     # the on_crash() hook retains the event


### PR DESCRIPTION
* mentioned in the header docs `before_send` vs `on_crash` behavior
* adapted `sentry__prepare_event` to provide a flag for backends on
  whether `before_send` should be invoked
* adapted backends to prevent running `before_send` even if `on_crash`
  returns true
* added `on_crash` vs `before_send` integration tests for `inproc` and
  `breakpad` (`crashpad` will follow)
* removed `stdbool.h` from `sentry.h` and replaced return value `bool`
  with `int` in `sentry_crash_function_t` (since `bool` seemed to be
  explicitly prevented in the header up to now)
* added remaining CHANGELOG entries for upcoming release
