### PR TITLE
fix: align default value for `environment` payload attribute with...

### DIFF
--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -33,6 +33,9 @@ sentry_options_new(void)
     opts->release = sentry__string_clone(getenv("SENTRY_RELEASE"));
     opts->environment = sentry__string_clone(getenv("SENTRY_ENVIRONMENT"));
 #endif
+    if (!opts->environment) {
+        opts->environment = sentry__string_clone("production");
+    }
     opts->max_breadcrumbs = SENTRY_BREADCRUMBS_MAX;
     opts->user_consent = SENTRY_USER_CONSENT_UNKNOWN;
     opts->auto_session_tracking = true;

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -60,6 +60,12 @@ SENTRY_TEST(session_basics)
     sentry_options_set_transport(
         options, sentry_new_function_transport(send_envelope, &called));
     sentry_options_set_release(options, "my_release");
+
+    // the default environment is always `production` if not overwritten by the
+    // OS environment variable `SENTRY_ENVIRONMENT`
+    // (see https://develop.sentry.dev/sdk/event-payloads/#optional-attributes)
+    TEST_CHECK_STRING_EQUAL(
+        sentry_options_get_environment(options), "production");
     sentry_options_set_environment(options, "my_environment");
     sentry_init(options);
 


### PR DESCRIPTION
...the developer documentation:
https://develop.sentry.dev/sdk/event-payloads/#optional-attribute

Fixes: #737
