### PR TITLE
ci: Bump compiler and OS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
       RUN_ANALYZER: ${{ matrix.RUN_ANALYZER }}
       ANDROID_API: ${{ matrix.ANDROID_API }}
       ANDROID_NDK: ${{ matrix.ANDROID_NDK }}
+      ANDROID_ARCH: ${{ matrix.ANDROID_ARCH }}
       CMAKE_DEFINES: ${{ matrix.CMAKE_DEFINES }}
       SYSTEM_VERSION_COMPAT: ${{ matrix.SYSTEM_VERSION_COMPAT }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         if: ${{ env['ANDROID_API'] }}
         run: |
           export ANDROID_IMAGE="system-images;android-$ANDROID_API;google_apis;$ANDROID_ARCH"
-          echo "Downloading ndk;$ANDROID_NDK and $ANDROID_IMAGE ($ANDROID_ARCH)"
+          echo "Downloading ndk;$ANDROID_NDK and $ANDROID_IMAGE"
           echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install \
             "ndk;$ANDROID_NDK" "$ANDROID_IMAGE" | \
             grep -v "\[=" || true # suppress the progress bar, so we get meaningful logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,12 @@ jobs:
             os: macOs-latest
             ANDROID_API: 16
             ANDROID_NDK: 20.1.5948944
+            ANDROID_ARCH: x86
           - name: Android (new API/NDK)
             os: macOs-latest
             ANDROID_API: 32
             ANDROID_NDK: 25.0.8775105
+            ANDROID_ARCH: x86_64
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -133,8 +135,8 @@ jobs:
       - name: Installing Android SDK Dependencies
         if: ${{ env['ANDROID_API'] }}
         run: |
-          export ANDROID_IMAGE="system-images;android-$ANDROID_API;google_apis;x86"
-          echo "Downloading ndk;$ANDROID_NDK and $ANDROID_IMAGE"
+          export ANDROID_IMAGE="system-images;android-$ANDROID_API;google_apis;$ANDROID_ARCH"
+          echo "Downloading ndk;$ANDROID_NDK and $ANDROID_IMAGE ($ANDROID_ARCH)"
           echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install \
             "ndk;$ANDROID_NDK" "$ANDROID_IMAGE" | \
             grep -v "\[=" || true # suppress the progress bar, so we get meaningful logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,33 +31,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux (gcc 7, 32-bit)
+          - name: Linux (old gcc, 32-bit)
             os: ubuntu-18.04
             CC: gcc-7
             CXX: g++-7
             TEST_X86: 1
-          - name: Linux (gcc 10)
-            os: ubuntu-20.04
-            CC: gcc-10
-            CXX: g++-10
+          - name: Linux (new gcc)
+            os: ubuntu-22.04
+            CC: gcc-12
+            CXX: g++-12
             # ERROR_ON_WARNINGS: 1
             # The GCC analyzer 10.0.1 (as on CI) has an internal compiler error
             # currently, and is not stable enough to activate.
             # RUN_ANALYZER: gcc
-          - name: Linux (clang 11 + asan + llvm-cov)
-            os: ubuntu-20.04
-            CC: clang-11
-            CXX: clang++-11
+          - name: Linux (clang + asan + llvm-cov)
+            os: ubuntu-22.04
+            CC: clang-14
+            CXX: clang++-14
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
-          - name: Linux (clang 11 + kcov)
-            os: ubuntu-20.04
-            CC: clang-11
-            CXX: clang++-11
+          - name: Linux (clang + kcov)
+            os: ubuntu-22.04
+            CC: clang-14
+            CXX: clang++-14
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: kcov
-          - name: Linux (code-checker + valgrind)
-            os: ubuntu-20.04
+          - name: Linux (gcc + code-checker + valgrind)
+            os: ubuntu-22.04
             RUN_ANALYZER: code-checker,valgrind
           - name: macOS (xcode llvm)
             os: macOs-latest
@@ -68,28 +68,28 @@ jobs:
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
             CMAKE_DEFINES: -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
-          - name: macOS (clang 13 + asan + llvm-cov)
+          - name: macOS (clang + asan + llvm-cov)
             os: macOs-latest
             CC: clang
             CXX: clang++
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
             RUN_ANALYZER: asan,llvm-cov
-          - name: Windows (VS2019)
+          - name: Windows (old VS, 32-bit)
             os: windows-2019
             TEST_X86: 1
           - name: Windows (latest)
             os: windows-latest
           # The Android emulator is currently only available on macos, see:
           # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/android?view=azure-devops#test-on-the-android-emulator
-          - name: Android (API 16, NDK 20)
+          - name: Android (old API/NDK)
             os: macOs-latest
             ANDROID_API: 16
             ANDROID_NDK: 20.1.5948944
-          - name: Android (API 30, NDK 22)
+          - name: Android (new API/NDK)
             os: macOs-latest
-            ANDROID_API: 30
-            ANDROID_NDK: 22.1.7171670
+            ANDROID_API: 32
+            ANDROID_NDK: 25.0.8775105
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -114,9 +114,9 @@ jobs:
         # workaround: https://github.com/actions/virtual-environments/issues/1536#issuecomment-698537248
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' -y
+          sudo add-apt-repository 'http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main' -y
           sudo apt update
-          sudo apt install cmake clang-11 clang-tools llvm kcov g++-10 valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang-14 clang-tools llvm kcov g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
 
       - name: Installing Linux 32-bit Dependencies
         if: ${{ runner.os == 'Linux' && env['TEST_X86'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,7 @@ jobs:
 
       - name: Installing CodeChecker
         if: ${{ contains(env['RUN_ANALYZER'], 'code-checker') }}
-        run: |
-          sudo apt install clang-tidy curl doxygen gcc-multilib libxml2-dev libxslt1-dev python3-dev python3-virtualenv
-          git clone https://github.com/Ericsson/CodeChecker.git --depth 1 --branch v6.15.0
-          cd CodeChecker
-          BUILD_LOGGER_64_BIT_ONLY=YES BUILD_UI_DIST=NO make standalone_package
-          echo "$PWD/build/CodeChecker/bin" >> $GITHUB_PATH
+        run: sudo snap install codechecker --classic
 
       - name: Expose llvm PATH for Mac
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,7 @@ jobs:
 
       - name: Installing Linux Dependencies
         if: ${{ runner.os == 'Linux' && !env['TEST_X86'] }}
-        # workaround: https://github.com/actions/virtual-environments/issues/1536#issuecomment-698537248
         run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main' -y
           sudo apt update
           sudo apt install cmake clang-14 clang-tools llvm kcov g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Align the default value initialization for the `environment` payload attribute with the
   [developer documentation](https://develop.sentry.dev/sdk/event-payloads/#optional-attribute)
   ([#739](https://github.com/getsentry/sentry-native/pull/739))
+- Iterate all debug directory entries when parsing PE modules for a valid CodeView record
+  ([#740](https://github.com/getsentry/sentry-native/pull/740))
 
 **Thank you**:
 

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -175,7 +175,7 @@ def cmake(cwd, targets, options=None):
     buildcmd.append("--parallel")
     if "code-checker" in os.environ.get("RUN_ANALYZER", ""):
         buildcmd = [
-            "CodeChecker",
+            "codechecker",
             "log",
             "--output",
             "compilation.json",
@@ -206,7 +206,7 @@ def cmake(cwd, targets, options=None):
         ]
         disables = ["--disable={}".format(d) for d in disable]
         checkcmd = [
-            "CodeChecker",
+            "codechecker",
             "check",
             "--jobs",
             str(os.cpu_count()),


### PR DESCRIPTION
- bumps Linux CI host to Ubuntu 22.04
- bumps new gcc to 12, clang to 14
- bumps Android API/NDK to latest versions
- renames CI jobs so their names are version independent (for easier updating)