### PR TITLE
ci: add danger workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,9 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+jobs:
+  danger:
+    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
Add a CI workflow to apply common checks to PRs, e.g. check if a changelog entry is missing.