### PR TITLE
chore: update libunwindstack-ndk submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Internal**:
 
+- Updated libunwindstack-ndk submodule to 2022-09-16 ([#759](https://github.com/getsentry/sentry-native/pull/759)) 
 - Updated Breakpad and Crashpad backends to 2022-09-14. ([#735](https://github.com/getsentry/sentry-native/pull/735))
 - Be more defensive around transactions ([#757](https://github.com/getsentry/sentry-native/pull/757))
 


### PR DESCRIPTION
synced with commit
235e2604e2fa3c1f8f7a68c5e285f9622e741e64

of upstream repo:
https://android.googlesource.com/platform/system/unwinding

here:
https://github.com/getsentry/libunwindstack-ndk/pull/6