### PR TITLE
fix: define a timeout for android sim start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
       - name: Starting Android Simulator
         if: ${{ env['ANDROID_API'] }}
         run: bash scripts/start-android.sh
+        timeout-minutes: 10
 
       - name: Test
         shell: bash


### PR DESCRIPTION
It happens regularly that the android simulator doesn't start (for whatever reason). But by default, that obsolete step runs until the default job timeout of 360 minutes is reached.

When starting successfully, this job step never reaches 6 minutes, so 10 minutes should give it more than enough time (and would still be within the bounds of our typical CI run end-to-end of ~15 mins).