### PR TITLE
ci: upgrade ubuntu for old gcc job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         include:
           - name: Linux (old gcc, 32-bit)
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             CC: gcc-7
             CXX: g++-7
             TEST_X86: 1
@@ -126,7 +126,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update
-          sudo apt install cmake gcc-multilib g++-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
+          sudo apt install cmake gcc-7-multilib g++-7-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
 
       - name: Installing CodeChecker
         if: ${{ contains(env['RUN_ANALYZER'], 'code-checker') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Internal**:
 
-- CI: update github actions to upgrade deprecated node runners. ([#767](https://github.com/getsentry/sentry-native/pull/767)) 
+- CI: updated github actions to upgrade deprecated node runners. ([#767](https://github.com/getsentry/sentry-native/pull/767))
+- CI: upgraded Ubuntu to 20.04 for "old gcc" (v7) job due to deprecation. ([#768](https://github.com/getsentry/sentry-native/pull/768))
 
 ## 0.5.2
 


### PR DESCRIPTION
because the ubuntu-18.04 environment is deprecated:

https://github.com/actions/virtual-environments/issues/6002