### PR TITLE
fix: better error messages in `sentry_transport_curl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Better error messages in `sentry_transport_curl` ([#777](https://github.com/getsentry/sentry-native/pull/777))
+
 ## 0.5.3
 
-**Fixes**
+**Fixes**:
 
 - Linux module-finder now also searches for code-id in ".note" ELF sections ([#775](https://github.com/getsentry/sentry-native/pull/775))
 

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -176,6 +176,9 @@ sentry__curl_send_task(void *_envelope, void *_state)
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)req->body_len);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, SENTRY_SDK_USER_AGENT);
 
+    char error_buf[CURL_ERROR_SIZE];
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buf);
+
     struct header_info info;
     info.retry_after = NULL;
     info.x_sentry_rate_limits = NULL;
@@ -205,8 +208,17 @@ sentry__curl_send_task(void *_envelope, void *_state)
             sentry__rate_limiter_update_from_429(state->ratelimiter);
         }
     } else {
-        SENTRY_WARNF(
-            "sending via `curl_easy_perform` failed with code `%d`", (int)rv);
+        size_t len = strlen(error_buf);
+        if (len) {
+            if (error_buf[len - 1] == '\n') {
+                error_buf[len - 1] = 0;
+            }
+            SENTRY_WARNF("`curl_easy_perform` failed with code `%d`: %s",
+                (int)rv, error_buf);
+        } else {
+            SENTRY_WARNF("`curl_easy_perform` failed with code `%d`: %s",
+                (int)rv, curl_easy_strerror(rv));
+        }
     }
 
     curl_slist_free_all(headers);

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -177,6 +177,7 @@ sentry__curl_send_task(void *_envelope, void *_state)
     curl_easy_setopt(curl, CURLOPT_USERAGENT, SENTRY_SDK_USER_AGENT);
 
     char error_buf[CURL_ERROR_SIZE];
+    error_buf[0] = 0;
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buf);
 
     struct header_info info;


### PR DESCRIPTION
Up to now, we have only printed the numeric error code returned by `curl_easy_perform()`, which isn't sensationally helpful to our users.

We now also print the contents of a `CURLOPT_ERRORBUFFER` and fall back to `curl_easy_strerror()` in case the error buffer is empty.

Fixes https://github.com/getsentry/sentry-native/issues/774
