### PR TITLE
fix: increase curl headers buffer size to 512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Better error messages in `sentry_transport_curl`. ([#777](https://github.com/getsentry/sentry-native/pull/777))
+- Increased curl headers buffer size to 512 (in `sentry_transport_curl`). ([#784](https://github.com/getsentry/sentry-native/pull/784))
 
 **Internal**:
 
@@ -30,7 +31,7 @@
 **Internal**:
 
 - Updated Breakpad and Crashpad backends to 2022-10-17. ([#765](https://github.com/getsentry/sentry-native/pull/765))
- 
+
 **Thank you**:
 
 Features, fixes and improvements in this release have been contributed by:
@@ -650,6 +651,7 @@ See [#220](https://github.com/getsentry/sentry-native/issues/220) for details.
   This function now takes a pointer to the new `sentry_transport_t` type.
   Migrating from the old API can be done by wrapping with
   `sentry_new_function_transport`, like this:
+
   ```c
   sentry_options_set_transport(
         options, sentry_new_function_transport(send_envelope_func, &closure_data));

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -150,7 +150,7 @@ sentry__curl_send_task(void *_envelope, void *_state)
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "expect:");
     for (size_t i = 0; i < req->headers_len; i++) {
-        char buf[255];
+        char buf[512];
         size_t written = (size_t)snprintf(buf, sizeof(buf), "%s:%s",
             req->headers[i].key, req->headers[i].value);
         if (written >= sizeof(buf)) {


### PR DESCRIPTION
The company that I work for is using an internal proxy with in-house generated public keys, which can be up to 400 characters long. When substituting the Sentry public key with the custom one, the `curl` transport doesn't write the `X-Sentry-Auth` header because the existing buffer 255 is too small.
