### PR TITLE
fix: avoid race condition when starting bgw thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Better error messages in `sentry_transport_curl`. ([#777](https://github.com/getsentry/sentry-native/pull/777))
+- Fix sporadic crash on Windows due to race condition when initializing bgw thread id. ([#785](https://github.com/getsentry/sentry-native/pull/785))
 
 **Internal**:
 

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -20,6 +20,12 @@ typedef struct {
 } THREADNAME_INFO;
 #    pragma pack(pop)
 
+sentry_threadid_t
+sentry__thread_get_current_threadid()
+{
+    return GetCurrentThread();
+}
+
 int
 sentry__thread_setname(sentry_threadid_t thread_id, const char *thread_name)
 {
@@ -61,6 +67,12 @@ sentry__thread_setname(sentry_threadid_t thread_id, const char *thread_name)
     return 0;
 }
 #else
+sentry_threadid_t
+sentry__thread_get_current_threadid()
+{
+    return pthread_self();
+}
+
 int
 sentry__thread_setname(sentry_threadid_t thread_id, const char *thread_name)
 {
@@ -218,7 +230,12 @@ worker_thread(void *data)
 
     // should be called inside thread itself because of MSVC issues and mac
     // https://randomascii.wordpress.com/2015/10/26/thread-naming-in-windows-time-for-something-better/
-    if (sentry__thread_setname(bgw->thread_id, bgw->thread_name)) {
+    // Additionally, `bgw->thread_id` cannot be used reliably because it is
+    // subject to initialization race condition: current thread might be running
+    // before `bgw->thread_id` is initialized in the thread that started the
+    // background worker.
+    if (sentry__thread_setname(
+            sentry__thread_get_current_threadid(), bgw->thread_name)) {
         SENTRY_WARN("failed to set background worker thread name");
     }
 


### PR DESCRIPTION
Specifically on Windows, the `sentry_thread_spawn` macro is defined as follows:

```
#    define sentry__thread_spawn(ThreadId, Func, Data)                         \
        (*ThreadId = CreateThread(NULL, 0, Func, Data, 0, NULL),               \
            *ThreadId == INVALID_HANDLE_VALUE ? 1 : 0)
```

We can see that `ThreadId` is initialized with the value returned by `CreateThread`, but the new thread might be running before `CreateThread` returns. If the new thread tries to access `bgw->thread_id`, the value might not be initialized yet, leading to undefined behaviour / crash.

In this change a new function `sentry__thread_get_current_threadid` is added, which returns the current thread id in a reliable way.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
