### PR TITLE
fix: open the file lock on "UNIX" with O_RDRW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Expose llvm PATH for Mac
         if: ${{ runner.os == 'macOS' }}
-        run: echo $(brew --prefix llvm@14)/bin >> $GITHUB_PATH
+        run: echo $(brew --prefix llvm@15)/bin >> $GITHUB_PATH
 
       - name: Installing Android SDK Dependencies
         if: ${{ env['ANDROID_API'] }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Fixes**:
 
+- Open the database file-lock on "UNIX" with `O_RDRW` ([#791](https://github.com/getsentry/sentry-native/pull/791))
 - Better error messages in `sentry_transport_curl`. ([#777](https://github.com/getsentry/sentry-native/pull/777))
 - Fix sporadic crash on Windows due to race condition when initializing background-worker thread-id. ([#785](https://github.com/getsentry/sentry-native/pull/785))
 - Increased curl headers buffer size to 512 (in `sentry_transport_curl`). ([#784](https://github.com/getsentry/sentry-native/pull/784))

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -54,15 +54,7 @@ sentry__filelock_try_lock(sentry_filelock_t *lock)
 {
     lock->is_locked = false;
 
-    const int oflags =
-#ifdef SENTRY_PLATFORM_AIX
-        // Under AIX, O_TRUNC can only be set if it can be written to, and
-        // flock (well, fcntl) will return EBADF if the fd is not read-write.
-        O_RDWR | O_CREAT | O_TRUNC;
-#else
-        O_RDONLY | O_CREAT | O_TRUNC;
-#endif
-    int fd = open(lock->path->path, oflags,
+    int fd = open(lock->path->path, O_RDWR | O_CREAT | O_TRUNC,
         S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
     if (fd < 0) {
         return false;


### PR DESCRIPTION
For some reason, the file lock on UNIX was always opened using `O_RDONLY`. This doesn't make sense in combination with `O_TRUNC` since it is a write operation. On some systems (the trigger scenario was AWS EFS), this will lead to an `EBADF` if we try to `flock()` that descriptor. The docs consider this combination undefined.

This change also removes the AIX compile-conditional since this should work on all systems now.

I also added a warning to the run-initialization in case we get an error when trying to lock.