### PR TITLE
fix: explicit breakpad C++17 dependency

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -119,6 +119,8 @@ set(BREAKPAD_SOURCES_CLIENT_IOS
 )
 
 add_library(breakpad_client STATIC)
+set_property(TARGET breakpad_client PROPERTY CXX_STANDARD 17)
+set_property(TARGET breakpad_client PROPERTY CXX_STANDARD_REQUIRED On)
 target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON})
 
 if(LINUX OR ANDROID)


### PR DESCRIPTION
Breakpad now uses features from C++17: https://chromium-review.googlesource.com/c/breakpad/breakpad/+/3954471

We should make this explicit via the `breakpad_client` target requirements. This change only creates a lower bound because for compilers that support only parts of C++17, the build will not necessarily complain. For instance, `breakpad` uses `static_assert()` without a second message parameter, which was added with https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3928.pdf, which not all compilers will support that accept the C++17 standard (e.g., GCC only supports it starting from version 6).

The issue was initially raised here: https://github.com/getsentry/sentry-native/discussions/798#discussioncomment-4826165

CC: @markushi, @bitsandfoxes

#skip-changelog