### PR TITLE
feat: Allow ending a session with a different status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- A session may be ended with a different status code. ([#801](https://github.com/getsentry/sentry-native/pull/801))
+
 ## 0.5.4
 
 **Fixes**:

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1347,16 +1347,6 @@ SENTRY_API void sentry_set_transaction(const char *transaction);
 SENTRY_API void sentry_set_level(sentry_level_t level);
 
 /**
- * Starts a new session.
- */
-SENTRY_API void sentry_start_session(void);
-
-/**
- * Ends a session.
- */
-SENTRY_API void sentry_end_session(void);
-
-/**
  * Sets the maximum number of spans that can be attached to a
  * transaction.
  */
@@ -1383,6 +1373,31 @@ SENTRY_EXPERIMENTAL_API void sentry_options_set_traces_sample_rate(
  */
 SENTRY_EXPERIMENTAL_API double sentry_options_get_traces_sample_rate(
     sentry_options_t *opts);
+
+/* -- Session APIs -- */
+
+typedef enum {
+    SENTRY_SESSION_STATUS_OK,
+    SENTRY_SESSION_STATUS_CRASHED,
+    SENTRY_SESSION_STATUS_ABNORMAL,
+    SENTRY_SESSION_STATUS_EXITED,
+} sentry_session_status_t;
+
+/**
+ * Starts a new session.
+ */
+SENTRY_API void sentry_start_session(void);
+
+/**
+ * Ends a session.
+ */
+SENTRY_API void sentry_end_session(void);
+
+/**
+ * Ends a session with an explicit `status` code.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_end_session_with_status(
+    sentry_session_status_t status);
 
 /* -- Performance Monitoring/Tracing APIs -- */
 

--- a/src/sentry_session.h
+++ b/src/sentry_session.h
@@ -8,13 +8,6 @@
 
 struct sentry_jsonwriter_s;
 
-typedef enum {
-    SENTRY_SESSION_STATUS_OK,
-    SENTRY_SESSION_STATUS_CRASHED,
-    SENTRY_SESSION_STATUS_ABNORMAL,
-    SENTRY_SESSION_STATUS_EXITED,
-} sentry_session_status_t;
-
 /**
  * This represents a session, with the number of errors, a status and other
  * metadata.

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -26,7 +26,7 @@ send_envelope(const sentry_envelope_t *envelope, void *data)
         SENTRY_VALUE_TYPE_STRING);
     TEST_CHECK_STRING_EQUAL(
         sentry_value_as_string(sentry_value_get_by_key(session, "status")),
-        "exited");
+        *called == 2 ? "crashed" : "exited");
     TEST_CHECK_STRING_EQUAL(
         sentry_value_as_string(sentry_value_get_by_key(session, "did")),
         *called == 1 ? "foo@blabla.invalid" : "swatinem");
@@ -83,9 +83,12 @@ SENTRY_TEST(session_basics)
         user, "username", sentry_value_new_string("swatinem"));
     sentry_set_user(user);
 
+    sentry_end_session_with_status(SENTRY_SESSION_STATUS_CRASHED);
+    sentry_start_session();
+
     sentry_close();
 
-    TEST_CHECK_INT_EQUAL(called, 2);
+    TEST_CHECK_INT_EQUAL(called, 3);
 }
 
 typedef struct {


### PR DESCRIPTION
As of right now, the status code of the session cannot be modified through this SDK. This is a problem when errors or crashes are handled manually. Such sessions are then marked as "crash-free". This is especially problematic when the `on_crash` callback is used, which may discard processing the event further. This is a snippet from the `inproc` backend:

https://github.com/getsentry/sentry-native/blob/19df84a7b437a9dbe2dabd2a451ac2cf508e00dd/src/backends/sentry_backend_inproc.c#L531-L556

_This is the only place where the session may be marked with the crashed status code._

Because of these reasons, I propose making the session status a part of the public API and an option to end the session using that custom status code. Another possibility is making the session structure public like in other Sentry SDKs. However, that would be a greater change to support it properly in all places.