### PR TITLE
fix: use void for all empty parameter-lists in C functions

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1861,7 +1861,7 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_iter_headers(
  *   0 = no crash recognized
  *  -1 = sentry_init() hasn't been called yet
  */
-SENTRY_EXPERIMENTAL_API int sentry_get_crashed_last_run();
+SENTRY_EXPERIMENTAL_API int sentry_get_crashed_last_run(void);
 
 /**
  * Clear the status of the "crashed-last-run". You should explicitly call
@@ -1875,22 +1875,22 @@ SENTRY_EXPERIMENTAL_API int sentry_get_crashed_last_run();
  *
  * Returns 0 on success, 1 on error.
  */
-SENTRY_EXPERIMENTAL_API int sentry_clear_crashed_last_run();
+SENTRY_EXPERIMENTAL_API int sentry_clear_crashed_last_run(void);
 
 /**
  * Sentry SDK version.
  */
-SENTRY_EXPERIMENTAL_API const char *sentry_sdk_version();
+SENTRY_EXPERIMENTAL_API const char *sentry_sdk_version(void);
 
 /**
  * Sentry SDK name.
  */
-SENTRY_EXPERIMENTAL_API const char *sentry_sdk_name();
+SENTRY_EXPERIMENTAL_API const char *sentry_sdk_name(void);
 
 /**
  * Sentry SDK User-Agent.
  */
-SENTRY_EXPERIMENTAL_API const char *sentry_sdk_user_agent();
+SENTRY_EXPERIMENTAL_API const char *sentry_sdk_user_agent(void);
 
 #ifdef __cplusplus
 }

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -1014,13 +1014,13 @@ fail:
 }
 
 int
-sentry_get_crashed_last_run()
+sentry_get_crashed_last_run(void)
 {
     return g_last_crash;
 }
 
 int
-sentry_clear_crashed_last_run()
+sentry_clear_crashed_last_run(void)
 {
     bool success = false;
     sentry_options_t *options = sentry__options_lock();

--- a/src/sentry_info.c
+++ b/src/sentry_info.c
@@ -1,19 +1,19 @@
 #include "sentry_boot.h"
 
 const char *
-sentry_sdk_version()
+sentry_sdk_version(void)
 {
     return SENTRY_SDK_VERSION;
 }
 
 const char *
-sentry_sdk_name()
+sentry_sdk_name(void)
 {
     return SENTRY_SDK_NAME;
 }
 
 const char *
-sentry_sdk_user_agent()
+sentry_sdk_user_agent(void)
 {
     return SENTRY_SDK_USER_AGENT;
 }

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -118,7 +118,7 @@ sentry__scope_unlock(void)
 }
 
 void
-sentry__scope_flush_unlock()
+sentry__scope_flush_unlock(void)
 {
     sentry__scope_unlock();
     SENTRY_WITH_OPTIONS (options) {
@@ -245,7 +245,7 @@ sentry__get_span_or_transaction(const sentry_scope_t *scope)
 
 #ifdef SENTRY_UNITTEST
 sentry_value_t
-sentry__scope_get_span_or_transaction()
+sentry__scope_get_span_or_transaction(void)
 {
     SENTRY_WITH_SCOPE (scope) {
         return sentry__get_span_or_transaction(scope);

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -68,7 +68,7 @@ void sentry__scope_cleanup(void);
  * This function must be called while holding the scope lock, and it will be
  * unlocked internally.
  */
-void sentry__scope_flush_unlock();
+void sentry__scope_flush_unlock(void);
 
 /**
  * This will merge the requested data which is in the given `scope` to the given
@@ -98,5 +98,5 @@ void sentry__scope_apply_to_event(const sentry_scope_t *scope,
 
 // this is only used in unit tests
 #ifdef SENTRY_UNITTEST
-sentry_value_t sentry__scope_get_span_or_transaction();
+sentry_value_t sentry__scope_get_span_or_transaction(void);
 #endif

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -68,7 +68,7 @@ sentry__thread_setname(sentry_threadid_t thread_id, const char *thread_name)
 }
 #else
 sentry_threadid_t
-sentry__thread_get_current_threadid()
+sentry__thread_get_current_threadid(void)
 {
     return pthread_self();
 }

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -480,7 +480,7 @@ sentry__iso8601_to_msec(const char *iso)
 // to ensure the C locale is also used there.
 #if !defined(SENTRY_PLATFORM_ANDROID) && !defined(SENTRY_PLATFORM_IOS)
 static sentry__locale_t
-c_locale()
+c_locale(void)
 {
     static long c_locale_initialized = 0;
     static sentry__locale_t c_locale;


### PR DESCRIPTION
This is one of many aspects where C and C++ standards deviate:

An empty parameter list in C++ is equivalent to a void parameter list. But in C an empty parameter list meant: you can give any number of any types as parameters (ignoring the difference between declaration and definition for brevity).

With C11, this "feature" became obsolete: empty parameter lists are no longer standard-conforming C. Since some of those are in our API surface we should fix this.

#skip-changelog