### PR TITLE
fix: Remove OpenSSL dependency for the crashpad backend on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Remove OpenSSL as direct dependency for the crashpad backend on Linux. ([#812](https://github.com/getsentry/sentry-native/pull/812), [crashpad#81](https://github.com/getsentry/crashpad/pull/81))
+
 ## 0.6.0
 
 **Breaking changes**:


### PR DESCRIPTION
https://github.com/getsentry/crashpad/pull/81