### PR TITLE
fix: missing const qualifiers in sentry tracing

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1618,7 +1618,8 @@ SENTRY_EXPERIMENTAL_API void sentry_set_span(sentry_span_t *span);
  * in a thread-safe way.
  */
 SENTRY_EXPERIMENTAL_API sentry_span_t *sentry_transaction_start_child(
-    sentry_transaction_t *parent, char *operation, char *description);
+    sentry_transaction_t *parent, const char *operation,
+    const char *description);
 
 /**
  * Starts a new Span.
@@ -1651,7 +1652,7 @@ SENTRY_EXPERIMENTAL_API sentry_span_t *sentry_transaction_start_child(
  * in a thread-safe way.
  */
 SENTRY_EXPERIMENTAL_API sentry_span_t *sentry_span_start_child(
-    sentry_span_t *parent, char *operation, char *description);
+    sentry_span_t *parent, const char *operation, const char *description);
 
 /**
  * Finishes a Span.

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -870,8 +870,8 @@ sentry_set_span(sentry_span_t *span)
 }
 
 sentry_span_t *
-sentry_transaction_start_child(
-    sentry_transaction_t *opaque_parent, char *operation, char *description)
+sentry_transaction_start_child(sentry_transaction_t *opaque_parent,
+    const char *operation, const char *description)
 {
     if (!opaque_parent || sentry_value_is_null(opaque_parent->inner)) {
         SENTRY_DEBUG("no transaction available to create a child under");
@@ -892,8 +892,8 @@ sentry_transaction_start_child(
 }
 
 sentry_span_t *
-sentry_span_start_child(
-    sentry_span_t *opaque_parent, char *operation, char *description)
+sentry_span_start_child(sentry_span_t *opaque_parent, const char *operation,
+    const char *description)
 {
     if (!opaque_parent || sentry_value_is_null(opaque_parent->inner)) {
         SENTRY_DEBUG("no parent span available to create a child span under");

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -251,8 +251,8 @@ sentry__span_new(sentry_transaction_t *tx, sentry_value_t inner)
 }
 
 sentry_value_t
-sentry__value_span_new(
-    size_t max_spans, sentry_value_t parent, char *operation, char *description)
+sentry__value_span_new(size_t max_spans, sentry_value_t parent,
+    const char *operation, const char *description)
 {
     if (!sentry_value_is_null(sentry_value_get_by_key(parent, "timestamp"))) {
         SENTRY_DEBUG("span's parent is already finished, not creating span");

--- a/src/sentry_tracing.h
+++ b/src/sentry_tracing.h
@@ -36,7 +36,7 @@ void sentry__span_incref(sentry_span_t *span);
 void sentry__span_decref(sentry_span_t *span);
 
 sentry_value_t sentry__value_span_new(size_t max_spans, sentry_value_t parent,
-    char *operation, char *description);
+    const char *operation, const char *description);
 sentry_span_t *sentry__span_new(
     sentry_transaction_t *parent_tx, sentry_value_t inner);
 


### PR DESCRIPTION
As explained in #831 this PR fixes missing const qualifiers in sentry tracing.