### PR TITLE
feat: crashpad backend allows inspecting the event-id in the on_crash/before_send hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Features**:
 
-- disable PC adjustment in the backend for libunwindstack ([#839](https://github.com/getsentry/sentry-native/pull/839))
+- Disable PC adjustment in the backend for libunwindstack ([#839](https://github.com/getsentry/sentry-native/pull/839))
+- Crashpad backend allows inspecting the event-id in the on_crash/before_send hooks ([#840](https://github.com/getsentry/sentry-native/pull/840))
 
 **Internal**:
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -147,7 +147,8 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
 
     SENTRY_WITH_OPTIONS (options) {
         auto *data = static_cast<crashpad_state_t *>(options->backend->data);
-        data->event_id = sentry_value_get_key(event, "event_id");
+        data->event_id = sentry_value_get_by_key(event, "event_id");
+        crashpad_backend_flush_scope(options->backend, options);
         if (options->on_crash_func) {
             sentry_ucontext_t uctx;
 #    ifdef SENTRY_PLATFORM_WINDOWS


### PR DESCRIPTION
fixes #779 
