### PR TITLE
fix: Setting the default level for crash events in Crashpad to `fatal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Fixes**:
+
+- Events captured by Crashpad are initialized with level `FATAL` ([#852](https://github.com/getsentry/sentry-native/pull/852))
+
 **Features**:
 
 - crashpad_handler: log `body` if minidump endpoint response is not `OK` ([#851](https://github.com/getsentry/sentry-native/pull/851), [crashpad#87](https://github.com/getsentry/crashpad/pull/87))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Fixes**:
 
-- Events captured by Crashpad are initialized with level `FATAL` ([#852](https://github.com/getsentry/sentry-native/pull/852))
+- Crash events are initialized with level `FATAL` ([#852](https://github.com/getsentry/sentry-native/pull/852))
 
 **Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@
 **Fixes**:
 
 - Crash events are initialized with level `FATAL` ([#852](https://github.com/getsentry/sentry-native/pull/852))
+- Fix MSVC compiler error with on non-Unicode systems ([#846](https://github.com/getsentry/sentry-native/pull/846), [crashpad#85](https://github.com/getsentry/crashpad/pull/85))
 
 **Features**:
 
 - crashpad_handler: log `body` if minidump endpoint response is not `OK` ([#851](https://github.com/getsentry/sentry-native/pull/851), [crashpad#87](https://github.com/getsentry/crashpad/pull/87))
+
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@xyz1001](https://github.com/xyz1001)
 
 ## 0.6.3
 
@@ -22,10 +29,6 @@
 
 - Updated Breakpad backend to 2023-05-03. ([#836](https://github.com/getsentry/sentry-native/pull/836), [breakpad#35](https://github.com/getsentry/breakpad/pull/35))
 - Updated Crashpad backend to 2023-05-03. ([#837](https://github.com/getsentry/sentry-native/pull/837), [crashpad#82](https://github.com/getsentry/crashpad/pull/82))
-
-**Fixes**:
-
-- Fix MSVC compiler error with on non-Unicode systems ([#846](https://github.com/getsentry/sentry-native/pull/846), [crashpad#85](https://github.com/getsentry/crashpad/pull/85))
 
 ## 0.6.2
 

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -92,6 +92,8 @@ sentry__breakpad_backend_callback(
     dump_path = sentry__path_new(descriptor.path());
 #endif
     sentry_value_t event = sentry_value_new_event();
+    sentry_value_set_by_key(
+        event, "level", sentry__value_new_level(SENTRY_LEVEL_FATAL));
 
     SENTRY_WITH_OPTIONS (options) {
         sentry__write_crash_marker(options);

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -118,9 +118,6 @@ sentry__breakpad_backend_callback(
         if (should_handle) {
             sentry_envelope_t *envelope = sentry__prepare_event(
                 options, event, nullptr, !options->on_crash_func);
-            // the event we just prepared is empty,
-            // so no error is recorded for it
-            sentry__record_errors_on_current_session(1);
             sentry_session_t *session = sentry__end_current_session_with_status(
                 SENTRY_SESSION_STATUS_CRASHED);
             sentry__envelope_add_session(envelope, session);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -108,6 +108,8 @@ crashpad_backend_flush_scope(
     sentry_value_t event = data->crash_event;
     if (sentry_value_is_null(event)) {
         event = sentry_value_new_object();
+        // FIXME: This should be handled in the FirstChanceHandler but that does
+        // not exist for macOS just yet.
         sentry_value_set_by_key(
             event, "level", sentry__value_new_level(SENTRY_LEVEL_FATAL));
     }

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -105,9 +105,12 @@ crashpad_backend_flush_scope(
     // properties that we do not want here. But in case of a crash we use the
     // crash-event filled in the crash-handler and on_crash/before_send
     // respectively.
-    sentry_value_t event = sentry_value_is_null(data->crash_event)
-        ? sentry_value_new_object()
-        : data->crash_event;
+    sentry_value_t event = data->crash_event;
+    if (sentry_value_is_null(event)) {
+        event = sentry_value_new_object();
+        sentry_value_set_by_key(
+            event, "level", sentry__value_new_level(SENTRY_LEVEL_FATAL));
+    }
 
     SENTRY_WITH_SCOPE (scope) {
         // we want the scope without any modules or breadcrumbs

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -149,6 +149,8 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
         auto *data = static_cast<crashpad_state_t *>(options->backend->data);
         sentry_value_decref(data->crash_event);
         data->crash_event = sentry_value_new_event();
+        sentry_value_set_by_key(data->crash_event, "level",
+            sentry__value_new_level(SENTRY_LEVEL_FATAL));
 
         if (options->on_crash_func) {
             sentry_ucontext_t uctx;


### PR DESCRIPTION
So the story goes like this:
An Unreal crash report lands in relay but the `crash_reason` got ignored and asserts and ensures ended up with the severity `FATAL`. 
Relay [now](https://github.com/getsentry/relay/pull/1677/files) reads the reason from the Unreal context and sets the level appropriately.

Unfortunately, Sentry simply overwrite the level set in Relay with `FATAL` anyway. With [this PR](https://github.com/getsentry/sentry/pull/50717/files), previously set levels get respected.

This PR aims to initialize crash events with `FATAL` but still allow users to overwrite the level.