### PR TITLE
chore: add top-level install directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 CMakeSettings.json
 .idea
 
-# CMake builds
+# CMake builds & install
 /*build*
+/*install*
 
 # Run files
 .sentry-native


### PR DESCRIPTION
As suggested on Discord. It makes sense to have this similar to the build clause.

#skip-changelog