### PR TITLE
fix: deadlock pattern in dynamic sdk-name assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Remove deadlock pattern in dynamic sdk-name assignment ([#857](https://github.com/getsentry/sentry-native/pull/857))
+
 ## 0.6.4
 
 **Fixes**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,7 @@ The example currently supports the following commands:
 - `discarding-before-send`: Installs a `before_send()` callback that discards the event.
 - `on-crash`: Installs an `on_crash()` callback that retains the crash event. 
 - `discarding-on-crash`: Installs an `on_crash()` callback that discards the crash event.
+- `override-sdk-name`: Changes the SDK name via the options at runtime.
 
 Only on Windows using crashpad with its WER handler module: 
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -218,6 +218,10 @@ main(int argc, char **argv)
             options, discarding_on_crash_callback, NULL);
     }
 
+    if (has_arg(argc, argv, "override-sdk-name")) {
+        sentry_options_set_sdk_name(options, "sentry.native.android.flutter");
+    }
+
     sentry_init(options);
 
     if (!has_arg(argc, argv, "no-setup")) {

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -166,9 +166,7 @@ sentry_init(sentry_options_t *options)
     // since at least crashpad needs that.
     // the only way to get a reference to the scope is by locking it, the macro
     // does all that at once, including invoking the backends scope flush hook
-    SENTRY_WITH_SCOPE_MUT (scope) {
-        (void)scope;
-    }
+    SENTRY_WITH_SCOPE_MUT_AND_OPTIONS(scope, options) { (void)scope; }
     if (backend && backend->user_consent_changed_func) {
         backend->user_consent_changed_func(backend);
     }

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -25,11 +25,11 @@ static sentry_scope_t g_scope = { 0 };
 static sentry_mutex_t g_lock = SENTRY__MUTEX_INIT;
 
 static sentry_value_t
-get_client_sdk(void)
+get_client_sdk(const sentry_options_t *options)
 {
     sentry_value_t client_sdk = sentry_value_new_object();
 
-    SENTRY_WITH_OPTIONS (options) {
+    if (options) {
         sentry_value_t sdk_name = sentry_value_new_string(options->sdk_name);
         sentry_value_set_by_key(client_sdk, "name", sdk_name);
     }
@@ -66,7 +66,7 @@ get_client_sdk(void)
 }
 
 static sentry_scope_t *
-get_scope(void)
+get_scope(const sentry_options_t *options)
 {
     if (g_scope_initialized) {
         return &g_scope;
@@ -82,7 +82,7 @@ get_scope(void)
     sentry_value_set_by_key(g_scope.contexts, "os", sentry__get_os_context());
     g_scope.breadcrumbs = sentry_value_new_list();
     g_scope.level = SENTRY_LEVEL_ERROR;
-    g_scope.client_sdk = get_client_sdk();
+    g_scope.client_sdk = get_client_sdk(options);
     g_scope.transaction_object = NULL;
     g_scope.span = NULL;
 
@@ -115,7 +115,14 @@ sentry_scope_t *
 sentry__scope_lock(void)
 {
     sentry__mutex_lock(&g_lock);
-    return get_scope();
+    return get_scope(NULL);
+}
+
+sentry_scope_t *
+sentry__scope_lock_with_options(const sentry_options_t *options)
+{
+    sentry__mutex_lock(&g_lock);
+    return get_scope(options);
 }
 
 void

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -58,6 +58,9 @@ sentry_scope_t *sentry__scope_lock(void);
  */
 void sentry__scope_unlock(void);
 
+sentry_scope_t *sentry__scope_lock_with_options(
+    const sentry_options_t *options);
+
 /**
  * This will free all the data attached to the global scope
  */
@@ -93,6 +96,9 @@ void sentry__scope_apply_to_event(const sentry_scope_t *scope,
 #define SENTRY_WITH_SCOPE_MUT_NO_FLUSH(Scope)                                  \
     for (sentry_scope_t *Scope = sentry__scope_lock(); Scope;                  \
          sentry__scope_unlock(), Scope = NULL)
+#define SENTRY_WITH_SCOPE_MUT_AND_OPTIONS(Scope, Options)                      \
+    for (sentry_scope_t *Scope = sentry__scope_lock_with_options(Options);     \
+         Scope; sentry__scope_flush_unlock(), Scope = NULL)
 
 #endif
 

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -14,7 +14,6 @@ from .assertions import (
     assert_event,
     assert_crash,
     assert_minidump,
-    assert_timestamp,
     assert_before_send,
     assert_no_before_send,
     assert_crash_timestamp,
@@ -43,6 +42,26 @@ def test_capture_stdout(cmake):
     assert_attachment(envelope)
     assert_stacktrace(envelope)
 
+    assert_event(envelope)
+
+
+def test_dynamic_sdk_name_override(cmake):
+    tmp_path = cmake(
+        ["sentry_example"],
+        {
+            "SENTRY_BACKEND": "none",
+            "SENTRY_TRANSPORT": "none",
+        },
+    )
+
+    output = check_output(
+        tmp_path,
+        "sentry_example",
+        ["stdout", "override-sdk-name", "capture-event"],
+    )
+    envelope = Envelope.deserialize(output)
+
+    assert_meta(envelope, sdk_override="sentry.native.android.flutter")
     assert_event(envelope)
 
 

--- a/tests/unit/test_concurrency.c
+++ b/tests/unit/test_concurrency.c
@@ -43,7 +43,7 @@ SENTRY_TEST(multiple_inits)
         SENTRY_LEVEL_INFO, "root", "Hello World!"));
 
     sentry_value_t obj = sentry_value_new_object();
-    // something that is not a uuid, as this will be forcibly changed
+    // something that is not a UUID, as this will be forcibly changed
     sentry_value_set_by_key(obj, "event_id", sentry_value_new_int32(1234));
     sentry_capture_event(obj);
 
@@ -64,7 +64,7 @@ thread_worker(void *called)
         SENTRY_LEVEL_INFO, "root", "Hello World!"));
 
     sentry_value_t obj = sentry_value_new_object();
-    // something that is not a uuid, as this will be forcibly changed
+    // something that is not a UUID, as this will be forcibly changed
     sentry_value_set_by_key(obj, "event_id", sentry_value_new_int32(1234));
     sentry_capture_event(obj);
 
@@ -75,7 +75,7 @@ SENTRY_TEST(concurrent_init)
 {
     long called = 0;
 
-#define THREADS_NUM 10
+#define THREADS_NUM 100
     sentry_threadid_t threads[THREADS_NUM];
 
     for (size_t i = 0; i < THREADS_NUM; i++) {

--- a/tests/unit/test_options.c
+++ b/tests/unit/test_options.c
@@ -43,7 +43,7 @@ SENTRY_TEST(options_sdk_name_invalid)
     const char *sdk_name = NULL;
     const int result = sentry_options_set_sdk_name(options, sdk_name);
 
-    // then the value should should be ignored
+    // then the value should be ignored
     TEST_CHECK_INT_EQUAL(result, 1);
     TEST_CHECK_STRING_EQUAL(
         sentry_options_get_sdk_name(options), SENTRY_SDK_NAME);


### PR DESCRIPTION
We recently introduced a deadlock in `sentry_init()` when implementing dynamic SDK names. This was the reason for the uptick in build timeouts in the CI (which was almost exclusively due to `TEST(concurrent_init)` being stuck). Sorry, I missed that during the review.

I also increased the concurrency in the test so that there is a higher chance of triggering such cases. The current level should be high enough for CI. I need to up that considerably on my machines to catch the issue.