### PR TITLE
docs: clarify behavior of sentry_flush + sentry_close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@sapphonie](https://github.com/sapphonie)
+
 ## 0.6.5
 
 **Fixes**:

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1275,7 +1275,7 @@ SENTRY_API int sentry_flush(uint64_t timeout);
  *
  * Returns 0 on success.
  *
- * Note that this does not uninstall any crash handler that may have been set.
+ * Note that this does not uninstall any crash handler that may have been set, with the exception of the `inproc` backend.
  */
 SENTRY_API int sentry_close(void);
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1274,6 +1274,8 @@ SENTRY_API int sentry_flush(uint64_t timeout);
  * Shuts down the sentry client and forces transports to flush out.
  *
  * Returns 0 on success.
+ *
+ * Note that this does not uninstall any crash handler that may have been set.
  */
 SENTRY_API int sentry_close(void);
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1267,6 +1267,8 @@ SENTRY_API int sentry_init(sentry_options_t *options);
  * The `timeout` parameter is in milliseconds.
  *
  * Returns 0 on success, or a non-zero return value in case the timeout is hit.
+ *
+ * Note that this function will block on the thread it was called from until the sentry background worker has finished its work or until the timeout is hit, whichever comes first.
  */
 SENTRY_API int sentry_flush(uint64_t timeout);
 
@@ -1276,6 +1278,7 @@ SENTRY_API int sentry_flush(uint64_t timeout);
  * Returns 0 on success.
  *
  * Note that this does not uninstall any crash handler that may have been set, with the exception of the `inproc` backend.
+ * Further note that this function will block on the thread it was called from until the sentry background worker has finished its work or until the timeout is hit, whichever comes first.
  */
 SENTRY_API int sentry_close(void);
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1268,7 +1268,9 @@ SENTRY_API int sentry_init(sentry_options_t *options);
  *
  * Returns 0 on success, or a non-zero return value in case the timeout is hit.
  *
- * Note that this function will block on the thread it was called from until the sentry background worker has finished its work or until the timeout is hit, whichever comes first.
+ * Note that this function will block the thread it was called from until the
+ * sentry background worker has finished its work or it timed out, whichever
+ * comes first.
  */
 SENTRY_API int sentry_flush(uint64_t timeout);
 
@@ -1277,8 +1279,13 @@ SENTRY_API int sentry_flush(uint64_t timeout);
  *
  * Returns 0 on success.
  *
- * Note that this does not uninstall any crash handler that may have been set, with the exception of the `inproc` backend.
- * Further note that this function will block on the thread it was called from until the sentry background worker has finished its work or until the timeout is hit, whichever comes first.
+ * Note that this does not uninstall any crash handler installed by our
+ * backends, which will still process crashes after `sentry_close()`, except
+ * when using `crashpad` on Linux or the `inproc` backend.
+ *
+ * Further note that this function will block the thread it was called from
+ * until the sentry background worker has finished its work or it timed out,
+ * whichever comes first.
  */
 SENTRY_API int sentry_close(void);
 


### PR DESCRIPTION
This PR
- clarifies that sentry_shutdown does not remove any crash handlers

Copying over a conversation from the Sentry discord;

> supervacuus — Today at 4:25 AM
@sappho
 The crashpad client does not provide a mechanism to uninstall its in-process crash-handler nor shutdown the crashpad_handler executable. So the handler is still installed after sentry_close().

> On Linux we brutally restore signal handlers without making crashpad aware of this. Maybe we should do the same on Windows?

> If you want to disable the crash-handler you can call  SetUnhandledExceptionFilter(NULL) which will disable the local handler installed by crashpad. This can happen in your Shutdown() method right after invoking sentry_close(). 


More TODO involving


- [x] ~~documenting if sentry_flush() is async or not~~ done, it is not async, it blocks
- [x] ~~documenting if sentry_close() is async or not~~ done, see above
- [ ] documenting in example.c that crash handling will still be called after sentry_shutdown()

#skip-changelog

