### PR TITLE
chore: update crashpad 2023 09 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Fixes**:
+
+- Use a more up-to-date version of `mini_chromium` as a `crashpad` dependency, which fixes a build error on some systems. ([#891](https://github.com/getsentry/sentry-native/pull/891), [crashpad#88](https://github.com/getsentry/crashpad/pull/88))
+
 **Internal**:
 
 - Updated `libunwindstack` to 2023-09-13. ([#884](https://github.com/getsentry/sentry-native/pull/884), [libunwindstack-ndk#8](https://github.com/getsentry/libunwindstack-ndk/pull/8))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Internal**:
 
 - Updated `libunwindstack` to 2023-09-13. ([#884](https://github.com/getsentry/sentry-native/pull/884), [libunwindstack-ndk#8](https://github.com/getsentry/libunwindstack-ndk/pull/8))
+- Updated `crashpad` to 2023-09-28. ([#891](https://github.com/getsentry/sentry-native/pull/891), [crashpad#88](https://github.com/getsentry/crashpad/pull/88))
 
 **Thank you**:
 

--- a/scripts/install-llvm-mingw.ps1
+++ b/scripts/install-llvm-mingw.ps1
@@ -49,6 +49,7 @@ New-Item -ItemType Directory -Force -Path "${NINJA_INSTALL_PATH}"
 Expand-Archive -LiteralPath "${NINJA_DL_PATH}" -DestinationPath "${NINJA_INSTALL_PATH}"
 # Export the NINJA executable path
 echo "NINJA_INSTALL_PATH=${NINJA_INSTALL_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+echo "PATH=${NINJA_INSTALL_PATH};$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
 # Add CMAKE_DEFINES
 echo "CMAKE_DEFINES=-DCMAKE_C_COMPILER=${env:MINGW_PKG_PREFIX}-gcc -DCMAKE_CXX_COMPILER=${env:MINGW_PKG_PREFIX}-g++ -DCMAKE_RC_COMPILER=${env:MINGW_PKG_PREFIX}-windres -DCMAKE_ASM_MASM_COMPILER=${env:MINGW_ASM_MASM_COMPILER} -GNinja" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -21,7 +21,7 @@ typedef struct {
 #    pragma pack(pop)
 
 sentry_threadid_t
-sentry__thread_get_current_threadid()
+sentry__thread_get_current_threadid(void)
 {
     return GetCurrentThread();
 }


### PR DESCRIPTION
This will also fix: https://github.com/getsentry/sentry-native/issues/882

But I am mostly trying to get a cross-check from the CI because I have some weird behavior when reinstalling the crashpad backend on Windows (this is not ready for review).