### PR TITLE
fix: stuck crashpad_client on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Prevent stuck crashpad-client on Windows ([#902](https://github.com/getsentry/sentry-native/pull/902), [crashpad#89](https://github.com/getsentry/crashpad/pull/89))
+
 ## 0.6.6
 
 **Fixes**:


### PR DESCRIPTION
This also breaks CI and thus prevents the release of 0.6.7 which should contain https://github.com/getsentry/sentry-native/pull/901
