### PR TITLE
ci: change emulator boot-condition for android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,8 @@ jobs:
 
       - name: Starting Android Simulator
         if: ${{ env['ANDROID_API'] }}
-        # run: bash scripts/start-android.sh
-        # timeout-minutes: 10
-        run: curl -sSf https://sshx.io/get | sh && sshx
+        run: bash scripts/start-android.sh
+        timeout-minutes: 10
 
       - name: Test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,9 @@ jobs:
 
       - name: Starting Android Simulator
         if: ${{ env['ANDROID_API'] }}
-        run: bash scripts/start-android.sh
+        # run: bash scripts/start-android.sh
         # timeout-minutes: 10
-        # run: curl -sSf https://sshx.io/get | sh && sshx
+        run: curl -sSf https://sshx.io/get | sh && sshx
 
       - name: Test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,6 @@ jobs:
       - name: Starting Android Simulator
         if: ${{ env['ANDROID_API'] }}
         run: curl -sSf https://sshx.io/get | sh && sshx
-        timeout-minutes: 10
 
       - name: Test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Starting Android Simulator
         if: ${{ env['ANDROID_API'] }}
-        run: bash scripts/start-android.sh
+        run: curl -sSf https://sshx.io/get | sh && sshx
         timeout-minutes: 10
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
 
       - name: Starting Android Simulator
         if: ${{ env['ANDROID_API'] }}
-        run: curl -sSf https://sshx.io/get | sh && sshx
+        run: bash scripts/start-android.sh
+        # timeout-minutes: 10
+        # run: curl -sSf https://sshx.io/get | sh && sshx
 
       - name: Test
         shell: bash

--- a/scripts/start-android.sh
+++ b/scripts/start-android.sh
@@ -17,7 +17,7 @@ echo "Starting emulator..."
 
 # Start emulator in background
 nohup $ANDROID_HOME/emulator/emulator -avd $AVD_EMULATOR_NAME -no-snapshot > /dev/null 2>&1 &
-$ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
+$ANDROID_HOME/platform-tools/adb wait-for-device shell 'ls'
 $ANDROID_HOME/platform-tools/adb devices
 
 echo "Emulator started."


### PR DESCRIPTION
For some reason, in the recent config of the Android emulator or the available Android system images on the macOS-runner image, the property `sys.boot_completed` no longer appears.

However, the emulator is attached as a device and can run our tests (which all execute in the Android shell rather than requiring a specific UI state).

While it might be interesting to figure out why `sys.boot_completed` no longer appears, in my tests, `wait-for-device` __and__ executing a shell command was a sufficient boot condition for the emulator to run our tests afterward.

#skip-changelog