### PR TITLE
chore: update crashpad 2023-11-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 - Maintain crashpad client instance during Native SDK lifecycle. ([#910](https://github.com/getsentry/sentry-native/pull/910))
 
+**Internal**:
+
+- Updated `crashpad` to 2023-11-24. ([#912](https://github.com/getsentry/sentry-native/pull/912), [crashpad#91](https://github.com/getsentry/crashpad/pull/91))
+  
+**Thank you**:
+
+Features, fixes and improvements in this release have been contributed by:
+
+- [@compnerd](https://github.com/compnerd)
+
 ## 0.6.7
 
 **Fixes**:


### PR DESCRIPTION
This fixes https://github.com/getsentry/sentry-native/issues/907 + includes the [ARM64 build fix](https://github.com/getsentry/crashpad/pull/90) from @compnerd.

I also updated and tested this in the context of https://github.com/getsentry/sentry-native/issues/900 to verify that the observed behavior wasn't a temporary regression.
