### PR TITLE
Remove options memory leak during consent setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Updated `crashpad` to 2023-11-24. ([#912](https://github.com/getsentry/sentry-native/pull/912), [crashpad#91](https://github.com/getsentry/crashpad/pull/91))
 - Fixing `crashpad` build for Windows on ARM64. ([#919](https://github.com/getsentry/sentry-native/pull/919), [crashpad#90](https://github.com/getsentry/crashpad/pull/90), [crashpad#92](https://github.com/getsentry/crashpad/pull/92), [crashpad#93](https://github.com/getsentry/crashpad/pull/93), [crashpad#94](https://github.com/getsentry/crashpad/pull/94))
+- Remove options memory leak during consent setting. ([#922](https://github.com/getsentry/sentry-native/pull/922))
   
 **Thank you**:
 

--- a/tests/unit/test_consent.c
+++ b/tests/unit/test_consent.c
@@ -28,6 +28,10 @@ SENTRY_TEST(basic_consent_tracking)
 
     init_consenting_sentry();
     sentry_user_consent_give();
+    // testing correct options ref/decref during double
+    // `sentry_user_consent_give` call see
+    // https://github.com/getsentry/sentry-native/pull/922
+    sentry_user_consent_give();
     TEST_CHECK_INT_EQUAL(sentry_user_consent_get(), SENTRY_USER_CONSENT_GIVEN);
     sentry_close();
     init_consenting_sentry();


### PR DESCRIPTION
Do not do early exit loop early, that leads to a incorrect reference counting of options during consent setting.
