### PR TITLE
docs: provide example for breadcrumb data property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove the `CRASHPAD_WER_ENABLED` build flag. The WER module is now built for all supported Windows targets, and registration is conditional on runtime Windows version checks. ([#950](https://github.com/getsentry/sentry-native/pull/950), [crashpad#96](https://github.com/getsentry/crashpad/pull/96))
 
+**Docs**:
+
+- Add usage of the breadcrumb `data` property to the example. [#951](https://github.com/getsentry/sentry-native/pull/951)
+
 ## 0.7.0
 
 **Breaking changes**:

--- a/examples/example.c
+++ b/examples/example.c
@@ -18,7 +18,7 @@
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <synchapi.h>
-#    define sleep_s(SECONDS) Sleep((SECONDS)*1000)
+#    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
 #else
 
 #    include <signal.h>
@@ -155,7 +155,7 @@ static void *invalid_mem = (void *)0xFFFFFFFFFFFFFF9B; // -100 for memset
 static void *invalid_mem = (void *)1;
 #endif
 
-__attribute__((__noinline__)) static void
+static void
 trigger_crash()
 {
     memset((char *)invalid_mem, 1, 100);

--- a/examples/example.c
+++ b/examples/example.c
@@ -18,7 +18,7 @@
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <synchapi.h>
-#    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
+#    define sleep_s(SECONDS) Sleep((SECONDS)*1000)
 #else
 
 #    include <signal.h>

--- a/examples/example.c
+++ b/examples/example.c
@@ -9,17 +9,21 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #ifdef NDEBUG
 #    undef NDEBUG
 #endif
+
 #include <assert.h>
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <synchapi.h>
 #    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
 #else
+
 #    include <signal.h>
 #    include <unistd.h>
+
 #    define sleep_s(SECONDS) sleep(SECONDS)
 #endif
 

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -142,6 +142,12 @@ def assert_breadcrumb(envelope):
         "message": "debug crumb",
         "category": "example!",
         "level": "debug",
+        "data": {
+            "url": "https://example.com/api/1.0/users",
+            "method": "GET",
+            "status_code": 200,
+            "reason": "OK",
+        },
     }
     assert any(matches(b, expected) for b in event["breadcrumbs"])
 


### PR DESCRIPTION
A [conversation on Discord](https://discord.com/channels/621778831602221064/1206628673080528957) made clear, that we have no example of how to create `data` properties in breadcrumbs using the `value` API in the Native SDK. This PR rectifies this by adding the `data` properties of an `http` [breadcrumb](https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#breadcrumb-types) and asserts on the new data in the integration tests.
