### PR TITLE
fix: failing clang-asan/llvm-cov tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CC: clang-15
             CXX: clang++-15
             ERROR_ON_WARNINGS: 1
-            RUN_ANALYZER: asan
+            RUN_ANALYZER: llvm-cov
           - name: Linux (clang + kcov)
             os: ubuntu-22.04
             CC: clang-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
             # RUN_ANALYZER: gcc
           - name: Linux (clang + asan + llvm-cov)
             os: ubuntu-22.04
-            CC: clang-15
-            CXX: clang++-15
+            CC: clang-14
+            CXX: clang++-14
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: llvm-cov
           - name: Linux (clang + kcov)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
             # RUN_ANALYZER: gcc
           - name: Linux (clang + asan + llvm-cov)
             os: ubuntu-22.04
-            CC: clang-14
-            CXX: clang++-14
+            CC: clang-15
+            CXX: clang++-15
             ERROR_ON_WARNINGS: 1
-            RUN_ANALYZER: llvm-cov
+            RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang + kcov)
             os: ubuntu-22.04
             CC: clang-15
@@ -136,6 +136,11 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install cmake gcc-7-multilib g++-7-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
+
+        # https://github.com/actions/runner-images/issues/9491
+      - name: Decrease vm.mmap_rnd_bit to prevent ASLR ASAN issues
+        if: ${{ runner.os == 'Linux' && contains(env['RUN_ANALYZER'], 'asan') }}
+        run: sudo sysctl vm.mmap_rnd_bits=28
 
       - name: Installing CodeChecker
         if: ${{ contains(env['RUN_ANALYZER'], 'code-checker') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             CC: clang-15
             CXX: clang++-15
             ERROR_ON_WARNINGS: 1
-            RUN_ANALYZER: asan,llvm-cov
+            RUN_ANALYZER: asan
           - name: Linux (clang + kcov)
             os: ubuntu-22.04
             CC: clang-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
             # RUN_ANALYZER: gcc
           - name: Linux (clang + asan + llvm-cov)
             os: ubuntu-22.04
-            CC: clang-14
-            CXX: clang++-14
+            CC: clang-15
+            CXX: clang++-15
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang + kcov)
             os: ubuntu-22.04
-            CC: clang-14
-            CXX: clang++-14
+            CC: clang-15
+            CXX: clang++-15
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: kcov
           - name: Linux (gcc + code-checker + valgrind)

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -54,7 +54,10 @@ def assert_meta(
         "user": {"id": 42, "username": "some_name"},
         "transaction": transaction,
         "tags": {"expected-tag": "some value"},
-        "extra": {"extra stuff": "some value", "…unicode key…": "őá…–🤮🚀¿ 한글 테스트"},
+        "extra": {
+            "extra stuff": "some value",
+            "…unicode key…": "őá…–🤮🚀¿ 한글 테스트",
+        },
     }
     expected_sdk = {
         "name": "sentry.native",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-black==23.3.0
-pytest==7.4.0
-pytest-httpserver==1.0.8
-msgpack==1.0.5
+black==24.2.0
+pytest==8.0.1
+pytest-httpserver==1.0.10
+msgpack==1.0.8


### PR DESCRIPTION
After fixing the failing mingw build in #964, we have another failing build caused by an update to the runner image. We can't connect to the pytest-httpserver anymore, but seemingly only in the clang-asan/llvm-cov build.

#skip-changelog
