### PR TITLE
fix: exclude custom_logger from transport test-suite

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1068,6 +1068,11 @@ typedef void (*sentry_logger_function_t)(
  * Sets the sentry-native logger function.
  *
  * Used for logging debug events when the `debug` option is set to true.
+ *
+ * Note: Multiple threads may invoke your `func`. If you plan to mutate any data
+ * inside the `userdata` argument after initialization, you must ensure proper
+ * synchronization inside the logger function.
+ *
  */
 SENTRY_API void sentry_options_set_logger(
     sentry_options_t *opts, sentry_logger_function_t func, void *userdata);

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,6 +14,9 @@ def test_unit(cmake, unittest):
 
 @pytest.mark.skipif(not has_http, reason="tests need http transport")
 def test_unit_transport(cmake, unittest):
+    if unittest in ["custom_logger"]:
+        pytest.skip("excluded from transport test-suite")
+
     cwd = cmake(["sentry_test_unit"], {"SENTRY_BACKEND": "none"})
     env = dict(os.environ)
     run(cwd, "sentry_test_unit", ["--no-summary", unittest], check=True, env=env)


### PR DESCRIPTION
A race in one of our unit tests was uncovered, probably due to recent fixes and updates in our `ASAN` runner config (https://github.com/getsentry/sentry-native/pull/965), which may have influenced the timing. 

The `custom_logger` test was written for a single-threaded configuration, but since it was automatically added to the transport test suite, the logger in this test would also be called from multiple threads, now leading to unexpected sequences in its assertions:

* https://github.com/getsentry/sentry-native/actions/runs/8388482978/job/22972769285#step:12:5003
* https://github.com/getsentry/sentry-native/actions/runs/8379423984/job/22947434351#step:12:4997
* https://github.com/getsentry/sentry-native/actions/runs/8379423984/job/22946299495#step:12:5038

The fix for this is a trivial exclusion from the transport test suite, but the fact that the race existed for several years in the tests is an excellent reason to add a note to the docs stating that synchronization is required in custom loggers 😅.

#skip-changelog