### PR TITLE
RISC-V support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 
-## 0.7.1
+## Unreleased
 
 **Features**:
 
 - Add optional Gzip transport compression via build option `SENTRY_TRANSPORT_COMPRESSION`. Requires system `zlib`. ([#954](https://github.com/getsentry/sentry-native/pull/954))
-- Add user feedback capability to the Native SDK ([#966](https://github.com/getsentry/sentry-native/pull/966))
+  
+**Fixes**:
+
+- Fix the Linux build when targeting RISC-V. ([#972](https://github.com/getsentry/sentry-native/pull/972))
+
+**Thank you**:
+
+- [@Strive-Sun](https://github.com/Strive-Sun)
+- [@jwinarske](https://github.com/jwinarske)
+
+## 0.7.1
+
+**Features**:
+
+- Add user feedback capability to the Native SDK. ([#966](https://github.com/getsentry/sentry-native/pull/966))
 
 **Internal**:
 
@@ -14,10 +28,6 @@
 **Docs**:
 
 - Add usage of the breadcrumb `data` property to the example. [#951](https://github.com/getsentry/sentry-native/pull/951)
-
-**Thank you**:
-
-- [@Strive-Sun](https://github.com/Strive-Sun)
 
 ## 0.7.0
 

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -568,12 +568,14 @@ try_append_module(sentry_value_t modules, const sentry_module_t *module)
 }
 
 // copied from:
-// https://github.com/google/breakpad/blob/216cea7bca53fa441a3ee0d0f5fd339a3a894224/src/client/linux/minidump_writer/linux_dumper.h#L61-L70
+// https://github.com/google/breakpad/blob/eb28e7ed9c1c1e1a717fa34ce0178bf471a6311f/src/client/linux/minidump_writer/linux_dumper.h#L61-L69
 #if defined(__i386) || defined(__ARM_EABI__)                                   \
-    || (defined(__mips__) && _MIPS_SIM == _ABIO32)
+    || (defined(__mips__) && _MIPS_SIM == _ABIO32)                             \
+    || (defined(__riscv) && __riscv_xlen == 32)
 typedef Elf32_auxv_t elf_aux_entry;
-#elif defined(__x86_64) || defined(__aarch64__) || defined(__powerpc64__)      \
-    || (defined(__mips__) && _MIPS_SIM != _ABIO32)
+#elif defined(__x86_64) || defined(__aarch64__)                                \
+    || (defined(__mips__) && _MIPS_SIM != _ABIO32)                             \
+    || (defined(__riscv) && __riscv_xlen == 64)
 typedef Elf64_auxv_t elf_aux_entry;
 #endif
 


### PR DESCRIPTION
-resolves https://github.com/getsentry/sentry-native/issues/971

* `make format` ran -> there are files outside of this PR that need modification
* `make test` ran -> `316 passed, 8 skipped, 1 warning in 73.93s (0:01:13)`