### PR TITLE
fix: allow crashpad to run with Epic's Anti-Cheat client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## Unreleased
 
-- [Documentation] Add missed compile time flag SENTRY_TRANSPORT_COMPRESSION description to the README.md file ([#976](https://github.com/getsentry/sentry-native/pull/976))
+**Fixes**:
+
+- Allow `crashpad` to run under [Epic's Anti-Cheat Client](https://dev.epicgames.com/docs/game-services/anti-cheat/using-anti-cheat#external-crash-dumpers) by deferring the full `crashpad_handler` access rights to the client application until a crash occurred. ([#980](https://github.com/getsentry/sentry-native/pull/980), [crashpad#99](https://github.com/getsentry/crashpad/pull/99))
+
+**Docs**:
+
+- Add compile-time flag `SENTRY_TRANSPORT_COMPRESSION` description to the `README.md` file. ([#976](https://github.com/getsentry/sentry-native/pull/976))
+
+**Thank you**:
+
+- [@AenBleidd](https://github.com/AenBleidd)
+- [@kristjanvalur](https://github.com/kristjanvalur)
 
 ## 0.7.2
 


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-native/issues/975.

Actual change: https://github.com/getsentry/crashpad/pull/99.