### PR TITLE
fix: correctly support stack overflows across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 **Fixes**:
 
 - Allow `crashpad` to run under [Epic's Anti-Cheat Client](https://dev.epicgames.com/docs/game-services/anti-cheat/using-anti-cheat#external-crash-dumpers) by deferring the full `crashpad_handler` access rights to the client application until a crash occurred. ([#980](https://github.com/getsentry/sentry-native/pull/980), [crashpad#99](https://github.com/getsentry/crashpad/pull/99))
-- Reserve enough stack-space on Windows for our handler to run when stack is exhausted from stack-overflow. ([#982](https://github.com/getsentry/sentry-native/pull/982))
+- Reserve enough stack space on Windows for our handler to run when the stack is exhausted from stack-overflow. ([#982](https://github.com/getsentry/sentry-native/pull/982))
+- Only configure a `sigaltstack` in `inproc` if no previous configuration exists on Linux and Android. ([#982](https://github.com/getsentry/sentry-native/pull/982))
 - Store transaction `data` in the event property `extra` since the `data` property is discarded by `relay`. ([#986](https://github.com/getsentry/sentry-native/issues/986))
 
 **Docs**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Allow `crashpad` to run under [Epic's Anti-Cheat Client](https://dev.epicgames.com/docs/game-services/anti-cheat/using-anti-cheat#external-crash-dumpers) by deferring the full `crashpad_handler` access rights to the client application until a crash occurred. ([#980](https://github.com/getsentry/sentry-native/pull/980), [crashpad#99](https://github.com/getsentry/crashpad/pull/99))
+- Reserve enough stack-space on Windows for our handler to run when stack is exhausted from stack-overflow. ([#982](https://github.com/getsentry/sentry-native/pull/982))
 
 **Docs**:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,8 @@ if(SENTRY_BUILD_EXAMPLES)
 
 		# to test handling SEH by-passing exceptions we need to enable the control flow guard
 		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/guard:cf>)
+	else()
+		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:-fno-optimize-sibling-calls>)
 	endif()
 
 	# set static runtime if enabled

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,7 +566,7 @@ if(SENTRY_BUILD_EXAMPLES)
 	target_link_libraries(sentry_example PRIVATE sentry)
 
 	if(MSVC)
-		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/wd5105>)
+		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/wd5105 /wd4717>)
 
 		# to test handling SEH by-passing exceptions we need to enable the control flow guard
 		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/guard:cf>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,9 @@ if(SENTRY_BUILD_EXAMPLES)
 		# to test handling SEH by-passing exceptions we need to enable the control flow guard
 		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:/guard:cf>)
 	else()
-		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:-fno-optimize-sibling-calls>)
+		# Disable all optimizations for the `sentry_example` in gcc/clang. This allows us to keep crash triggers simple.
+		# The effects besides reproducible code-gen across compiler versions, will be negligible for build- and runtime.
+		target_compile_options(sentry_example PRIVATE $<BUILD_INTERFACE:-O0>)
 	endif()
 
 	# set static runtime if enabled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,7 @@ The example currently supports the following commands:
 - `on-crash`: Installs an `on_crash()` callback that retains the crash event. 
 - `discarding-on-crash`: Installs an `on_crash()` callback that discards the crash event.
 - `override-sdk-name`: Changes the SDK name via the options at runtime.
+- `stack-overflow`: Provokes a stack-overflow.
 
 Only on Windows using crashpad with its WER handler module: 
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 
 #ifdef SENTRY_PLATFORM_WINDOWS
+#    include <malloc.h>
 #    include <synchapi.h>
 #    define sleep_s(SECONDS) Sleep((SECONDS)*1000)
 #else
@@ -159,6 +160,13 @@ static void
 trigger_crash()
 {
     memset((char *)invalid_mem, 1, 100);
+}
+
+static void
+trigger_stack_overflow()
+{
+    alloca(1024);
+    trigger_stack_overflow();
 }
 
 int
@@ -321,6 +329,9 @@ main(int argc, char **argv)
 
     if (has_arg(argc, argv, "crash")) {
         trigger_crash();
+    }
+    if (has_arg(argc, argv, "stack-overflow")) {
+        trigger_stack_overflow();
     }
 #if defined(SENTRY_PLATFORM_WINDOWS) && !defined(__MINGW32__)                  \
     && !defined(__MINGW64__)

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -7,6 +7,9 @@ extern "C" {
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_options.h"
+#ifdef SENTRY_PLATFORM_WINDOWS
+#    include "sentry_os.h"
+#endif
 #include "sentry_path.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
@@ -209,6 +212,7 @@ sentry__breakpad_backend_startup(
     sentry_path_t *current_run_folder = options->run->run_path;
 
 #ifdef SENTRY_PLATFORM_WINDOWS
+    sentry__reserve_thread_stack();
     backend->data = new google_breakpad::ExceptionHandler(
         current_run_folder->path, NULL, sentry__breakpad_backend_callback, NULL,
         google_breakpad::ExceptionHandler::HANDLER_EXCEPTION);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -340,6 +340,10 @@ crashpad_backend_startup(
         }
     }
 
+#ifdef SENTRY_PLATFORM_WINDOWS
+    sentry__reserve_thread_stack();
+#endif
+
     // The crashpad client uses shell lookup rules (absolute path, relative
     // path, or bare executable name that is looked up in $PATH).
     // However, it crashes hard when it cant resolve the handler, so we make

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -6,6 +6,9 @@
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_options.h"
+#if defined(SENTRY_PLATFORM_WINDOWS)
+#    include "sentry_os.h"
+#endif
 #include "sentry_scope.h"
 #include "sentry_sync.h"
 #include "sentry_transport.h"
@@ -184,6 +187,7 @@ static int
 startup_inproc_backend(
     sentry_backend_t *UNUSED(backend), const sentry_options_t *UNUSED(options))
 {
+    sentry__reserve_thread_stack();
     g_previous_handler = SetUnhandledExceptionFilter(&handle_exception);
     SetErrorMode(SEM_FAILCRITICALERRORS);
     return 0;

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -111,8 +111,9 @@ startup_inproc_backend(
 
     // set up an alternate signal stack if noone defined one before
     stack_t old_sig_stack;
-    if (sigaltstack(NULL, &old_sig_stack) == -1) {
-        SENTRY_DEBUGF("Installing signal stack (size: %d)", SIGNAL_STACK_SIZE);
+    if (sigaltstack(NULL, &old_sig_stack) == -1 || old_sig_stack.ss_sp == NULL
+        || old_sig_stack.ss_size == 0) {
+        SENTRY_TRACEF("installing signal stack (size: %d)", SIGNAL_STACK_SIZE);
         g_signal_stack.ss_sp = sentry_malloc(SIGNAL_STACK_SIZE);
         if (!g_signal_stack.ss_sp) {
             return 1;
@@ -121,8 +122,8 @@ startup_inproc_backend(
         g_signal_stack.ss_flags = 0;
         sigaltstack(&g_signal_stack, 0);
     } else {
-        SENTRY_DEBUGF(
-            "Using existing signal stack (size: %d)", old_sig_stack.ss_size);
+        SENTRY_TRACEF(
+            "using existing signal stack (size: %d)", old_sig_stack.ss_size);
     }
 
     // install our own signal handler

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -4,7 +4,7 @@
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 
-#    include <winver.h>
+#    include <windows.h>
 #    define CURRENT_VERSION "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"
 
 void *
@@ -136,6 +136,39 @@ sentry__get_os_context(void)
     sentry_value_decref(os);
     return sentry_value_new_null();
 }
+
+void
+sentry__reserve_thread_stack(void)
+{
+    const unsigned long expected_stack_size = 64 * 1024;
+    unsigned long stack_size = 0;
+    SetThreadStackGuarantee(&stack_size);
+    if (stack_size < expected_stack_size) {
+        stack_size = expected_stack_size;
+        SetThreadStackGuarantee(&stack_size);
+    }
+}
+
+#    if defined(SENTRY_BUILD_SHARED)
+
+BOOL APIENTRY
+DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    (void)hModule;
+    (void)lpReserved;
+
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+        sentry__reserve_thread_stack();
+        break;
+    default:
+        return TRUE;
+    }
+    return TRUE;
+}
+
+#    endif // defined(SENTRY_BUILD_SHARED)
 
 #elif defined(SENTRY_PLATFORM_MACOS)
 

--- a/src/sentry_os.h
+++ b/src/sentry_os.h
@@ -4,6 +4,7 @@
 #include "sentry_boot.h"
 
 #ifdef SENTRY_PLATFORM_WINDOWS
+
 typedef struct {
     uint32_t major;
     uint32_t minor;
@@ -13,6 +14,8 @@ typedef struct {
 
 int sentry__get_kernel_version(windows_version_t *win_ver);
 int sentry__get_windows_version(windows_version_t *win_ver);
+void sentry__reserve_thread_stack(void);
+
 #endif
 
 sentry_value_t sentry__get_os_context(void);

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -51,11 +51,11 @@ def assert_user_feedback(envelope):
 
 
 def assert_meta(
-        envelope,
-        release="test-example-release",
-        integration=None,
-        transaction="test-transaction",
-        sdk_override=None,
+    envelope,
+    release="test-example-release",
+    integration=None,
+    transaction="test-transaction",
+    sdk_override=None,
 ):
     event = envelope.get_event()
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -189,9 +189,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     assert_crashpad_upload(multipart)
 
 
-@pytest.mark.skipif(
-    sys.platform != "win32",
-)
+@pytest.mark.skipif(sys.platform != "win32", reason="stack-overflow windows only")
 def test_crashpad_dumping_stack_overflow(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -189,7 +189,6 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     assert_crashpad_upload(multipart)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="stack-overflow windows only")
 def test_crashpad_dumping_stack_overflow(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -189,6 +189,9 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     assert_crashpad_upload(multipart)
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+)
 def test_crashpad_dumping_stack_overflow(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -273,7 +273,7 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
 
 
 @pytest.mark.skipif(
-    not has_breakpad and sys.platform != "win32", reason="test needs breakpad backend"
+    not has_breakpad or sys.platform != "win32", reason="test needs breakpad backend"
 )
 def test_breakpad_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for(

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -273,7 +273,9 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
 
 @pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
 def test_breakpad_stack_overflow_stdout(cmake):
-    tmp_path, output = run_stdout_for("breakpad", cmake, ["attachment", "stack-overflow"])
+    tmp_path, output = run_stdout_for(
+        "breakpad", cmake, ["attachment", "stack-overflow"]
+    )
 
     envelope = Envelope.deserialize(output)
 

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -135,16 +135,20 @@ def test_multi_process(cmake):
     assert len(runs) == 0
 
 
-def run_crash_stdout_for(backend, cmake, example_args):
+def run_stdout_for(backend, cmake, example_args):
     tmp_path = cmake(
         ["sentry_example"],
         {"SENTRY_BACKEND": backend, "SENTRY_TRANSPORT": "none"},
     )
 
-    child = run(tmp_path, "sentry_example", ["attachment", "crash"] + example_args)
+    child = run(tmp_path, "sentry_example", example_args)
     assert child.returncode  # well, it's a crash after all
 
     return tmp_path, check_output(tmp_path, "sentry_example", ["stdout", "no-setup"])
+
+
+def run_crash_stdout_for(backend, cmake, example_args):
+    return run_stdout_for(backend, cmake, ["attachment", "crash"] + example_args)
 
 
 def test_inproc_crash_stdout(cmake):
@@ -190,6 +194,18 @@ def test_inproc_crash_stdout_before_send_and_on_crash(cmake):
     envelope = Envelope.deserialize(output)
     # but we expect no event modification from before_send() since setting on_crash() disables before_send()
     assert_no_before_send(envelope)
+
+    assert_crash_timestamp(has_files, tmp_path)
+    assert_meta(envelope, integration="inproc")
+    assert_breadcrumb(envelope)
+    assert_attachment(envelope)
+    assert_inproc_crash(envelope)
+
+
+def test_inproc_stack_overflow_stdout(cmake):
+    tmp_path, output = run_stdout_for("inproc", cmake, ["attachment", "stack-overflow"])
+
+    envelope = Envelope.deserialize(output)
 
     assert_crash_timestamp(has_files, tmp_path)
     assert_meta(envelope, integration="inproc")
@@ -252,4 +268,18 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
     assert_meta(envelope, integration="breakpad")
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
+    assert_breakpad_crash(envelope)
+
+
+@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+def test_breakpad_stack_overflow_stdout(cmake):
+    tmp_path, output = run_stdout_for("breakpad", cmake, ["attachment", "stack-overflow"])
+
+    envelope = Envelope.deserialize(output)
+
+    assert_crash_timestamp(has_files, tmp_path)
+    assert_meta(envelope, integration="breakpad")
+    assert_breadcrumb(envelope)
+    assert_attachment(envelope)
+    assert_minidump(envelope)
     assert_breakpad_crash(envelope)

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -202,6 +202,7 @@ def test_inproc_crash_stdout_before_send_and_on_crash(cmake):
     assert_inproc_crash(envelope)
 
 
+@pytest.mark.skipif(sys.platform != "win32")
 def test_inproc_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for("inproc", cmake, ["attachment", "stack-overflow"])
 
@@ -271,7 +272,7 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
     assert_breakpad_crash(envelope)
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad and sys.platform != "win32", reason="test needs breakpad backend")
 def test_breakpad_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for(
         "breakpad", cmake, ["attachment", "stack-overflow"]

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -202,7 +202,7 @@ def test_inproc_crash_stdout_before_send_and_on_crash(cmake):
     assert_inproc_crash(envelope)
 
 
-@pytest.mark.skipif(sys.platform != "win32")
+@pytest.mark.skipif(sys.platform != "win32", reason="stack-overflow windows only")
 def test_inproc_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for("inproc", cmake, ["attachment", "stack-overflow"])
 
@@ -272,7 +272,9 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
     assert_breakpad_crash(envelope)
 
 
-@pytest.mark.skipif(not has_breakpad and sys.platform != "win32", reason="test needs breakpad backend")
+@pytest.mark.skipif(
+    not has_breakpad and sys.platform != "win32", reason="test needs breakpad backend"
+)
 def test_breakpad_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for(
         "breakpad", cmake, ["attachment", "stack-overflow"]

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -202,7 +202,6 @@ def test_inproc_crash_stdout_before_send_and_on_crash(cmake):
     assert_inproc_crash(envelope)
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="stack-overflow windows only")
 def test_inproc_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for("inproc", cmake, ["attachment", "stack-overflow"])
 
@@ -272,9 +271,7 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
     assert_breakpad_crash(envelope)
 
 
-@pytest.mark.skipif(
-    not has_breakpad or sys.platform != "win32", reason="test needs breakpad backend"
-)
+@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
 def test_breakpad_stack_overflow_stdout(cmake):
     tmp_path, output = run_stdout_for(
         "breakpad", cmake, ["attachment", "stack-overflow"]


### PR DESCRIPTION
Currently, stack overflows on Windows die somewhere in the handler because we run out of stack space. This is the first attempt to fix the situation by reserving stack space before it is exhausted. This is an analog to `sigaltstack()` on Linux, but Windows only provides a "reserved amount" interface, and with that, you have fewer options to shoot yourself in the foot.

Fixes #987.
Fixes #977.