### PR TITLE
Fix path to ndk module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,5 +229,5 @@ jobs:
           name: ${{ github.sha }}
           if-no-files-found: error
           path: |
-            ./*/build/distributions/*.zip
+            ndk/lib/build/distributions/*.zip
             sentry-native.zip


### PR DESCRIPTION
The last release https://github.com/getsentry/sentry-native/releases/tag/0.7.3 should have had a maven artifact (`./ndk/lib/build/distributions/sentry-native-ndk-0.7.2.zip`) file attached to it, but the regex was simply wrong 🙈 

#skip-changelog