### PR TITLE
Use static STL, hide it from prefab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- (Android) Switch ndk back to `libc++_static`, and hide it from prefab ([#996](https://github.com/getsentry/sentry-native/pull/996))
+
 ## 0.7.4
 
 **Fixes**:

--- a/ndk/lib/build.gradle.kts
+++ b/ndk/lib/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments.add(0, "-DANDROID_STL=c++_shared")
+                arguments.add(0, "-DANDROID_STL=c++_static")
                 arguments.add(0, "-DSENTRY_NATIVE_SRC=$sentryNativeSrc")
             }
         }
@@ -90,4 +90,43 @@ android {
 
 dependencies {
     compileOnly("org.jetbrains:annotations:23.0.0")
+}
+
+/*
+ * Prefab doesn't support c++_static, so we need to change it to none.
+ * This should be fine, as we don't expose any conflicting symbols.
+ * Based on: https://github.com/bugsnag/bugsnag-android/blob/59460018551750dfcce4fd4e9f612eae7826559e/bugsnag-plugin-android-ndk/build.gradle.kts
+ *
+ * Copyright (c) 2012 Bugsnag
+
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+afterEvaluate {
+    tasks.getByName("prefabReleasePackage") {
+        doLast {
+            project.fileTree("build/intermediates/prefab_package/") {
+                include("**/abi.json")
+            }.forEach { file ->
+                file.writeText(file.readText().replace("c++_static", "none"))
+            }
+        }
+    }
 }


### PR DESCRIPTION
With the JNI move we switched from using the static stdlib to `c++_shared`.  This had the side effect of `libc++_shared.so` being integrated into the build artifact. As the version of `libc++_shared.so` is tied to the version of the NDK, this could cause troubles / undefined behavior if customer is using a different NDK version than us.

<img width="487" alt="image" src="https://github.com/getsentry/sentry-native/assets/1411808/26c897eb-e872-4ff3-abe2-ff402928dda2">
