### PR TITLE
chore: Update crashpad to 2024-06-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
             os: macOs-14
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
-          - name: macOS 12 (xcode llvm)
-            os: macOs-12
+          - name: macOS 13 (xcode llvm)
+            os: macOs-13
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
           - name: macOS (xcode llvm + universal)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
       - name: Expose llvm PATH for Mac
         if: ${{ runner.os == 'macOS' }}
         run: echo $(brew --prefix llvm@15)/bin >> $GITHUB_PATH
+      
+      - name: Enable experimental library for llvm clang 15.0.1
+        if: ${{ runner.os == 'macOS' && contains(env['RUN_ANALYZER'], 'asan')}}
+        run: echo "CXXFLAGS=-fexperimental-library" >> $GITHUB_ENV
 
       - name: Installing LLVM-MINGW Dependencies
         if: ${{ runner.os == 'Windows' && env['TEST_MINGW'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,20 @@ jobs:
             os: ubuntu-22.04
             RUN_ANALYZER: code-checker,valgrind
           - name: macOS (xcode llvm)
-            os: macOs-11
+            os: macOs-14
+            ERROR_ON_WARNINGS: 1
+            SYSTEM_VERSION_COMPAT: 0
+          - name: macOS 12 (xcode llvm)
+            os: macOs-12
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
           - name: macOS (xcode llvm + universal)
-            os: macOs-11
+            os: macOs-14
             ERROR_ON_WARNINGS: 1
             SYSTEM_VERSION_COMPAT: 0
             CMAKE_DEFINES: -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
           - name: macOS (clang + asan + llvm-cov)
-            os: macOs-11
+            os: macOs-14
             CC: clang
             CXX: clang++
             ERROR_ON_WARNINGS: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             SYSTEM_VERSION_COMPAT: 0
             CMAKE_DEFINES: -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
           - name: macOS (clang + asan + llvm-cov)
-            os: macOs-14
+            os: macOs-12
             CC: clang
             CXX: clang++
             ERROR_ON_WARNINGS: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,10 +153,6 @@ jobs:
       - name: Expose llvm PATH for Mac
         if: ${{ runner.os == 'macOS' }}
         run: echo $(brew --prefix llvm@15)/bin >> $GITHUB_PATH
-      
-      - name: Enable experimental library for llvm clang 15.0.1
-        if: ${{ runner.os == 'macOS' && contains(env['RUN_ANALYZER'], 'asan')}}
-        run: echo "CXXFLAGS=-fexperimental-library" >> $GITHUB_ENV
 
       - name: Installing LLVM-MINGW Dependencies
         if: ${{ runner.os == 'Windows' && env['TEST_MINGW'] }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Internal**:
+
+- Updated `crashpad` to 2024-06-11. ([#1014](https://github.com/getsentry/sentry-native/pull/1014), [crashpad#105](https://github.com/getsentry/crashpad/pull/105))
+
 ## 0.7.6
 
 **Fixes**:

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -179,9 +179,8 @@ sentry__breakpad_backend_callback(
 static bool
 IsDebuggerActive()
 {
-    int junk;
     int mib[4];
-    struct kinfo_proc info;
+    kinfo_proc info;
     size_t size;
 
     // Initialize the flags so that, if sysctl fails for some bizarre
@@ -197,7 +196,8 @@ IsDebuggerActive()
 
     // Call sysctl.
     size = sizeof(info);
-    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    [[maybe_unused]] const int junk
+        = sysctl(mib, std::size(mib), &info, &size, nullptr, 0);
     assert(junk == 0);
 
     // We're being debugged if the P_TRACED flag is set.

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -156,12 +156,16 @@ def cmake(cwd, targets, options=None):
 
         # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for the GHA runner that builds
         # sentry-native with LLVM clang for macOS (to run ASAN on macOS) rather than the version coming with XCode.
+        # TODO: remove this if the GHA runner image for macOS ever updates beyond llvm15.
         if (
             sys.platform == "darwin"
             and os.environ.get("CC", "") == "clang"
             and shutil.which("clang") == "/usr/local/opt/llvm@15/bin/clang"
         ):
-            flags = flags + " -L/usr/local/opt/llvm@15/lib/c++ -fexperimental-library"
+            flags = (
+                flags
+                + " -L/usr/local/opt/llvm@15/lib/c++ -fexperimental-library -Wno-unused-command-line-argument"
+            )
 
         configcmd.append("-DCMAKE_CXX_FLAGS='{}'".format(flags))
     if "CMAKE_DEFINES" in os.environ:

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -153,6 +153,16 @@ def cmake(cwd, targets, options=None):
     if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
         flags = "-fprofile-instr-generate -fcoverage-mapping"
         configcmd.append("-DCMAKE_C_FLAGS='{}'".format(flags))
+        
+        # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for GHA runner that builds
+        # sentry-native with LLVM clang for macOS (to run ASAN on macOS) rather than the version coming with XCode.
+        if (
+            sys.platform == "darwin"
+            and os.environ.get("CC", "") == "clang"
+            and shutil.which("clang") == "/usr/local/opt/llvm@15/bin/clang"
+        ):
+            flags = flags + " -fexperimental-library"
+        
         configcmd.append("-DCMAKE_CXX_FLAGS='{}'".format(flags))
     if "CMAKE_DEFINES" in os.environ:
         configcmd.extend(os.environ.get("CMAKE_DEFINES").split())

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -153,16 +153,16 @@ def cmake(cwd, targets, options=None):
     if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
         flags = "-fprofile-instr-generate -fcoverage-mapping"
         configcmd.append("-DCMAKE_C_FLAGS='{}'".format(flags))
-        
-        # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for GHA runner that builds
+
+        # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for the GHA runner that builds
         # sentry-native with LLVM clang for macOS (to run ASAN on macOS) rather than the version coming with XCode.
         if (
             sys.platform == "darwin"
             and os.environ.get("CC", "") == "clang"
             and shutil.which("clang") == "/usr/local/opt/llvm@15/bin/clang"
         ):
-            flags = flags + " -fexperimental-library"
-        
+            flags = flags + " -L/usr/local/opt/llvm@15/lib/c++ -fexperimental-library"
+
         configcmd.append("-DCMAKE_CXX_FLAGS='{}'".format(flags))
     if "CMAKE_DEFINES" in os.environ:
         configcmd.extend(os.environ.get("CMAKE_DEFINES").split())

--- a/tests/leaks.txt
+++ b/tests/leaks.txt
@@ -3,5 +3,7 @@
 # Adding a manual `[paths release]` "fixes" the `crashpad_handler` leak, but leads to a use-after-free in sentry.
 # https://github.com/getsentry/crashpad/blob/9cd1a4dadb51b31665f5e50c5ffc25bb9d10571a/client/crash_report_database_mac.mm#L705
 leak:contentsOfDirectoryAtPath
-leak:SCDynamicStoreCopyProxiesWithOptions
+
+# This is a known issue in ASAN packaged with llvm15/16 (and below): https://github.com/google/sanitizers/issues/1501
+# I cannot reproduce it with the current brew llvm package (18.1.7). TODO: remove when GHA macOS runner image updates the llvm package.
 leak:realizeClassWithoutSwift

--- a/tests/leaks.txt
+++ b/tests/leaks.txt
@@ -4,6 +4,10 @@
 # https://github.com/getsentry/crashpad/blob/9cd1a4dadb51b31665f5e50c5ffc25bb9d10571a/client/crash_report_database_mac.mm#L705
 leak:contentsOfDirectoryAtPath
 
+# This is a known issue introduced with libcurl 7.77.0 on macOS: https://github.com/getsentry/sentry-native/pull/827#issuecomment-1521956265
+# While it should have been fixed with 7.78.0, tests with SDK-packaged version 7.85.0 still detect the same leak. 
+leak:SCDynamicStoreCopyProxiesWithOptions
+
 # This is a known issue in ASAN packaged with llvm15/16 (and below): https://github.com/google/sanitizers/issues/1501
 # I cannot reproduce it with the current brew llvm package (18.1.7). TODO: remove when GHA macOS runner image updates the llvm package.
 leak:realizeClassWithoutSwift

--- a/tests/leaks.txt
+++ b/tests/leaks.txt
@@ -4,3 +4,4 @@
 # https://github.com/getsentry/crashpad/blob/9cd1a4dadb51b31665f5e50c5ffc25bb9d10571a/client/crash_report_database_mac.mm#L705
 leak:contentsOfDirectoryAtPath
 leak:SCDynamicStoreCopyProxiesWithOptions
+leak:realizeClassWithoutSwift


### PR DESCRIPTION
The sentry-native companion to https://github.com/getsentry/crashpad/pull/105