### PR TITLE
fix: crashpad scope flushing synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Further clean up of the exported dependency configuration. ([#1013](https://github.com/getsentry/sentry-native/pull/1013), [crashpad#106](https://github.com/getsentry/crashpad/pull/106))
+- Clean-up scope flushing synchronization in crashpad-backend. ([#1019](https://github.com/getsentry/sentry-native/pull/1019), [crashpad#109](https://github.com/getsentry/crashpad/pull/109))
 
 **Internal**:
 
@@ -14,6 +15,7 @@
 
 - [@JonLiu1993](https://github.com/JonLiu1993)
 - [@dg0yt](https://github.com/dg0yt)
+- [@stima](https://github.com/stima)
 
 ## 0.7.6
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -225,6 +225,7 @@ crashpad_backend_flush_scope(
 #endif
 }
 
+#if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_WINDOWS)
 static void
 flush_scope_from_handler(
     const sentry_options_t *options, sentry_value_t crash_event)
@@ -246,7 +247,6 @@ flush_scope_from_handler(
         state->event_path, options, crash_event);
 }
 
-#if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_WINDOWS)
 #    ifdef SENTRY_PLATFORM_WINDOWS
 static bool
 sentry__crashpad_handler(EXCEPTION_POINTERS *ExceptionInfo)

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -85,16 +85,16 @@ constexpr int g_CrashSignals[] = {
 };
 #endif
 
-struct crashpad_state_t {
-    crashpad::CrashReportDatabase *db {};
-    crashpad::CrashpadClient *client {};
-    sentry_path_t *event_path {};
-    sentry_path_t *breadcrumb1_path {};
-    sentry_path_t *breadcrumb2_path {};
-    size_t num_breadcrumbs {};
-    std::atomic_flag crashed = ATOMIC_FLAG_INIT;
-    std::atomic_flag scope_flush_in_progress = ATOMIC_FLAG_INIT;
-};
+typedef struct {
+    crashpad::CrashReportDatabase *db;
+    crashpad::CrashpadClient *client;
+    sentry_path_t *event_path;
+    sentry_path_t *breadcrumb1_path;
+    sentry_path_t *breadcrumb2_path;
+    size_t num_breadcrumbs;
+    std::atomic<bool> crashed;
+    std::atomic<bool> scope_flush;
+} crashpad_state_t;
 
 /**
  * Correctly destruct C++ members of the crashpad state.
@@ -201,12 +201,11 @@ crashpad_backend_flush_scope(
     (void)options;
 #else
     auto *data = static_cast<crashpad_state_t *>(backend->data);
+    bool expected = false;
 
-    if (!data->event_path
-        || data->crashed.test_and_set(std::memory_order_relaxed)
-        || data->scope_flush_in_progress.test_and_set(
-            std::memory_order_acquire)) {
-        SENTRY_DEBUG("flush scope via callback blocked");
+    //
+    if (!data->event_path || data->crashed.load()
+        || !data->scope_flush.compare_exchange_strong(expected, true)) {
         return;
     }
 
@@ -217,7 +216,7 @@ crashpad_backend_flush_scope(
         event, "level", sentry__value_new_level(SENTRY_LEVEL_FATAL));
 
     crashpad_backend_flush_scope_to_event(data->event_path, options, event);
-    data->scope_flush_in_progress.clear(std::memory_order_release);
+    data->scope_flush.store(false);
 #endif
 }
 
@@ -228,15 +227,12 @@ flush_scope_from_handler(
     auto state = static_cast<crashpad_state_t *>(options->backend->data);
 
     // this blocks any further calls to `crashpad_backend_flush_scope`
-    state->crashed.test_and_set(std::memory_order_relaxed);
+    state->crashed.store(true);
 
     // busy-wait until any in-progress scope flushes are finished
-    while (state->scope_flush_in_progress.test_and_set(
-        std::memory_order_acquire)) {
-#if defined(__cpp_lib_atomic_flag_test)
-        while (lock.test(std::memory_order_relaxed)) // test lock
-#endif
-            ;
+    bool expected = false;
+    while (!state->scope_flush.compare_exchange_strong(expected, true)) {
+        expected = false;
     }
 
     // now we are the sole flusher and can flush into the crash event
@@ -560,7 +556,7 @@ crashpad_backend_free(sentry_backend_t *backend)
     sentry__path_free(data->event_path);
     sentry__path_free(data->breadcrumb1_path);
     sentry__path_free(data->breadcrumb2_path);
-    delete data;
+    sentry_free(data);
 }
 
 static void
@@ -635,11 +631,14 @@ sentry__backend_new(void)
     }
     memset(backend, 0, sizeof(sentry_backend_t));
 
-    auto *data = new (std::nothrow) crashpad_state_t;
+    auto *data = SENTRY_MAKE(crashpad_state_t);
     if (!data) {
         sentry_free(backend);
         return nullptr;
     }
+    memset(data, 0, sizeof(crashpad_state_t));
+    data->scope_flush = false;
+    data->crashed = false;
 
     backend->startup_func = crashpad_backend_startup;
     backend->shutdown_func = crashpad_backend_shutdown;

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -59,7 +59,19 @@ def assert_meta(
     sdk_override=None,
 ):
     event = envelope.get_event()
+    assert_event_meta(
+        event, release, integration, transaction, transaction_data, sdk_override
+    )
 
+
+def assert_event_meta(
+    event,
+    release="test-example-release",
+    integration=None,
+    transaction="test-transaction",
+    transaction_data=None,
+    sdk_override=None,
+):
     extra = {
         "extra stuff": "some value",
         "…unicode key…": "őá…–🤮🚀¿ 한글 테스트",
@@ -316,8 +328,7 @@ def assert_crashpad_upload(req):
     attachments = _load_crashpad_attachments(msg)
 
     assert_overflowing_breadcrumb(attachments)
-    assert attachments.event["level"] == "fatal"
-
+    assert_event_meta(attachments.event, integration="crashpad")
     assert any(
         b'name="upload_file_minidump"' in part.as_bytes()
         and b"\n\nMDMP" in part.as_bytes()

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -121,6 +121,7 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
     # Windows throttles WER crash reporting frequency, so let's wait a bit
     time.sleep(1)
 
+
 @pytest.mark.parametrize(
     "run_args,build_args",
     [

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -118,6 +118,8 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
     assert_session(envelope, {"status": "crashed", "errors": 1})
     assert_crashpad_upload(multipart)
 
+    # Windows throttles WER crash reporting frequency, so let's wait a bit
+    time.sleep(1)
 
 @pytest.mark.parametrize(
     "run_args,build_args",

--- a/vendor/mpack.c
+++ b/vendor/mpack.c
@@ -34,6 +34,8 @@
 
 #include "mpack.h"
 
+extern void* sentry_malloc(size_t);
+extern void sentry_free(void*);
 
 /* mpack/mpack-platform.c.c */
 

--- a/vendor/mpack.h
+++ b/vendor/mpack.h
@@ -201,9 +201,8 @@
  * to grow buffers.
  */
 #if defined(MPACK_STDLIB) && MPACK_STDLIB && !defined(MPACK_MALLOC)
-#define MPACK_MALLOC malloc
-#define MPACK_REALLOC realloc
-#define MPACK_FREE free
+#define MPACK_MALLOC sentry_malloc
+#define MPACK_FREE sentry_free
 #endif
 
 /**


### PR DESCRIPTION
This change cleans up a couple of issues in the current crashpad backend:

* Via scope-flushing, we use `mpack` in the signal handler, which uses system malloc. This change configures mpack to use `sentry_malloc`, which switches to the page-allocator inside the signal handler. Fixes #687.
* We flush the scope outside the crash handler and then again inside. This is only necessary on macOS and on Windows when a crash gets handled vie the WER module. There is no need to flush the scope into `__sentry_event` outside the handler on Linux.
* The scope-flushing unnecessarily introduced a shared mutable variable between the two paths (via `crashpad_backend_flush_scope` and the signal handler), which could be called from two different threads. We can ensure that these two paths handle separate __local__ events.
* Further, the two paths could also lead to overwritten `__sentry_event` files if the scope flushing is triggered from a thread other than the signal handler thread, silently invalidating any changes to the event coming from the `before_send` and `on_crash` hooks. This is now fully synchronized in the following fashion:
  * `crashpad_backend_flush_scope` signals via `std::atomic<bool>` that a flush is in progress
  * if the application crashes and our signal handler wants to flush the scope into the crash event, it must wait until any flush-in-progress is finished
  * the signal-handler also signals that the application has crashed and prevents further flushes from outside the signal handler
* these changes fix https://github.com/getsentry/sentry-native/issues/931
* last but not least: crashpad invokes the `FirstChanceHandler` on any incoming signal (Linux) or unhandled exception (Windows). While we locked the signal handler on Linux, the Windows handler would be called twice if another thread also surfaces an exception. This is bad because the signal handler doesn't act like it will only be called once before it terminates. This adapts the code in the crashpad client to prevent second invocations to the `FirstChanceHandler`. This adapts the proposed changes by: https://github.com/getsentry/crashpad/pull/95