### PR TITLE
feat: support 16kb page size on Android 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Let the envelope serialization stream directly to the file. ([#1021](https://github.com/getsentry/sentry-native/pull/1021))
+- Support 16kb page sizes on Android 15 ([#1028](https://github.com/getsentry/sentry-native/pull/1028))
 
 ## 0.7.7
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,4 +596,9 @@ endif()
 if(SENTRY_BUILD_SHARED_LIBS)
 	target_link_libraries(sentry PRIVATE
 			"$<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:Android>>:-Wl,--build-id=sha1,--version-script=${PROJECT_SOURCE_DIR}/src/exports.map>")
+
+	# Support 16KB page sizes
+	target_link_libraries(sentry PRIVATE
+	    "$<$<PLATFORM_ID:Android>:-Wl,-z,max-page-size=16384>"
+	)
 endif()

--- a/ndk/lib/CMakeLists.txt
+++ b/ndk/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SENTRY_BUILD_SHARED_LIBS ON)
 add_subdirectory(${SENTRY_NATIVE_SRC} sentry_build)
 
 # Link to sentry-native
-target_link_libraries(sentry-android PRIVATE
-    $<BUILD_INTERFACE:sentry::sentry>
-)
+target_link_libraries(sentry-android PRIVATE $<BUILD_INTERFACE:sentry::sentry>)
+
+# Support 16KB page sizes
+target_link_options(sentry-android PRIVATE "-Wl,-z,max-page-size=16384")

--- a/ndk/lib/build.gradle.kts
+++ b/ndk/lib/build.gradle.kts
@@ -86,6 +86,12 @@ android {
             ignore = true
         }
     }
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+    ndkVersion = "27.0.12077973"
 }
 
 dependencies {

--- a/ndk/lib/build.gradle.kts
+++ b/ndk/lib/build.gradle.kts
@@ -86,12 +86,12 @@ android {
             ignore = true
         }
     }
+
     packagingOptions {
         jniLibs {
             useLegacyPackaging = true
         }
     }
-    ndkVersion = "27.0.12077973"
 }
 
 dependencies {

--- a/ndk/sample/CMakeLists.txt
+++ b/ndk/sample/CMakeLists.txt
@@ -16,3 +16,5 @@ target_link_libraries(ndk-sample PRIVATE
     ${LOG_LIB}
     $<BUILD_INTERFACE:sentry::sentry>
 )
+# Support 16KB page sizes
+target_link_options(ndk-sample PRIVATE "-Wl,-z,max-page-size=16384")

--- a/ndk/sample/build.gradle.kts
+++ b/ndk/sample/build.gradle.kts
@@ -63,6 +63,12 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+    ndkVersion = "27.0.12077973"
 }
 
 dependencies {


### PR DESCRIPTION
This fixes #989.

I tried to reach the most minimal version I could successfully deploy to a 16kb page-size image on the emulator.

Important here:
* NDK 27 is required because the toolchain dependencies must also be compiled for 16kb page sizes. That's why I explicitly configured this
* appended new linker settings to all CMake library targets
* enable legacy packaging because we want to stay compatible with `AGP <= 8.2`: https://developer.android.com/guide/practices/page-sizes#agp_version_82_or_lower

Open topics:

- [x]  This should be tested with the NDK sample app by at least another Android developer in the team
- [x] Manual check if there are any remaining hardcoded 4096 page-size assumptions
- [x] How (and when) to integrate this in `sentry-android` since it will also have to be added there for version < 8.