### PR TITLE
fix: timestamp resolution to microseconds on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Correct the timestamp resolution to microseconds on Windows. ([#1039](https://github.com/getsentry/sentry-native/pull/1039))
+
 ## 0.7.9
 
 **Fixes**:

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -106,7 +106,11 @@ sentry__usec_time(void)
     // Contains a 64-bit value representing the number of 100-nanosecond
     // intervals since January 1, 1601 (UTC).
     FILETIME file_time;
+#    if _WIN32_WINNT >= 0x0602
+    GetSystemTimePreciseAsFileTime(&file_time);
+#    else
     GetSystemTimeAsFileTime(&file_time);
+#    endif
 
     uint64_t timestamp = (uint64_t)file_time.dwLowDateTime
         + ((uint64_t)file_time.dwHighDateTime << 32);

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -106,9 +106,7 @@ sentry__usec_time(void)
     // Contains a 64-bit value representing the number of 100-nanosecond
     // intervals since January 1, 1601 (UTC).
     FILETIME file_time;
-    SYSTEMTIME system_time;
-    GetSystemTime(&system_time);
-    SystemTimeToFileTime(&system_time, &file_time);
+    GetSystemTimeAsFileTime(&file_time);
 
     uint64_t timestamp = (uint64_t)file_time.dwLowDateTime
         + ((uint64_t)file_time.dwHighDateTime << 32);


### PR DESCRIPTION
The timestamp resolution was changed to microseconds in https://github.com/getsentry/sentry-native/pull/995. However, this has never correctly worked on Windows because `SYSTEMTIME`, a return value from the underlying call to `GetSystemTime()`, contains only milliseconds, not microseconds: https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime.

Instead, `GetSystemTimeAsFileTime()` can be used as its return value "contains a 64-bit value representing the number of 100-nanosecond intervals". This also helps in reducing two API calls to just one.