### PR TITLE
feat: build-parameter for handler stack size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,23 @@
 
 ## Unreleased
 
+**Features**:
+
+- Provide a build-parameter `SENTRY_HANDLER_STACK_SIZE` that allows to change the targeted stack-size reserved for the crash handler on Linux and Windows. ([#1049](https://github.com/getsentry/sentry-native/pull/1049))
+
 **Fixes**:
 
-- Reject invalid trace- and span-ids in context update from header ([#1046](https://github.com/getsentry/sentry-native/pull/1046))
+- Reject invalid trace- and span-ids in context update from header. ([#1046](https://github.com/getsentry/sentry-native/pull/1046))
 
 ## 0.7.10
 
 **Fixes**:
 
 - Correct the timestamp resolution to microseconds on Windows. ([#1039](https://github.com/getsentry/sentry-native/pull/1039))
+
+**Thank you**:
+
+- [@ShawnCZek](https://github.com/ShawnCZek)
 
 ## 0.7.9
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,11 +156,13 @@ if(SENTRY_BACKEND_CRASHPAD AND ANDROID)
 endif()
 
 set(SENTRY_SDK_NAME "" CACHE STRING "The SDK name to report when sending events.")
+set(SENTRY_HANDLER_STACK_SIZE 64 CACHE STRING "The stack size (in KiB) that should be reserved for the crash handler.")
 
 message(STATUS "SENTRY_TRANSPORT=${SENTRY_TRANSPORT}")
 message(STATUS "SENTRY_BACKEND=${SENTRY_BACKEND}")
 message(STATUS "SENTRY_LIBRARY_TYPE=${SENTRY_LIBRARY_TYPE}")
 message(STATUS "SENTRY_SDK_NAME=${SENTRY_SDK_NAME}")
+message(STATUS "SENTRY_HANDLER_STACK_SIZE=${SENTRY_HANDLER_STACK_SIZE}")
 
 if(ANDROID)
 	set(SENTRY_WITH_LIBUNWINDSTACK TRUE)
@@ -227,6 +229,8 @@ add_library(sentry ${SENTRY_LIBRARY_TYPE} "${PROJECT_SOURCE_DIR}/vendor/mpack.c"
 target_sources(sentry PRIVATE "${PROJECT_SOURCE_DIR}/include/sentry.h")
 add_library(sentry::sentry ALIAS sentry)
 add_subdirectory(src)
+
+target_compile_definitions(sentry PRIVATE SENTRY_HANDLER_STACK_SIZE=${SENTRY_HANDLER_STACK_SIZE})
 
 if (NOT SENTRY_SDK_NAME STREQUAL "")
 	target_compile_definitions(sentry PRIVATE SENTRY_SDK_NAME="${SENTRY_SDK_NAME}")

--- a/README.md
+++ b/README.md
@@ -184,26 +184,26 @@ $ export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 The following options can be set when running the cmake generator, for example
 using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 
-- `SENTRY_BUILD_SHARED_LIBS` (Default: ON):
+- `SENTRY_BUILD_SHARED_LIBS` (Default: `ON`):
   By default, `sentry` is built as a shared library. Setting this option to
   `OFF` will build `sentry` as a static library instead.
   If sentry is used as a subdirectory of another project, the value `BUILD_SHARED_LIBS` will be inherited by default.
 
   When using `sentry` as a static library, make sure to `#define SENTRY_BUILD_STATIC 1` before including the sentry header.
 
-- `SENTRY_PIC` (Default: ON):
+- `SENTRY_PIC` (Default: `ON`):
   By default, `sentry` is built as a position independent library.
 
-- `SENTRY_EXPORT_SYMBOLS` (Default: ON):
+- `SENTRY_EXPORT_SYMBOLS` (Default: `ON`):
   By default, `sentry` exposes all symbols in the dynamic symbol table. You might want to disable it in case the program intends to `dlopen` third-party shared libraries and avoid symbol collisions.
 
-- `SENTRY_BUILD_RUNTIMESTATIC` (Default: OFF):
+- `SENTRY_BUILD_RUNTIMESTATIC` (Default: `OFF`):
   Enables linking with the static MSVC runtime. Has no effect if the compiler is not MSVC.
 
-- `SENTRY_LINK_PTHREAD` (Default: ON):
+- `SENTRY_LINK_PTHREAD` (Default: `ON`):
   Links platform threads library like `pthread` on unix targets.
 
-- `SENTRY_BUILD_FORCE32` (Default: OFF):
+- `SENTRY_BUILD_FORCE32` (Default: `OFF`):
   Forces cross-compilation from 64-bit host to 32-bit target. Only has an effect on Linux.
 
 - `CMAKE_SYSTEM_VERSION` (Default: depending on Windows SDK version):
@@ -243,14 +243,21 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
   - **none**: This builds `sentry-native` without a backend, so it does not handle
     crashes at all. It is primarily used for tests.
 
-- `SENTRY_INTEGRATION_QT` (Default: OFF):
+- `SENTRY_INTEGRATION_QT` (Default: `OFF`):
   Builds the Qt integration, which turns Qt log messages into breadcrumbs.
 
-- `SENTRY_BREAKPAD_SYSTEM` (Default: OFF):
+- `SENTRY_BREAKPAD_SYSTEM` (Default: `OFF`):
   This instructs the build system to use system-installed breakpad libraries instead of using the in-tree version.
 
-- `SENTRY_TRANSPORT_COMPRESSION` (Default: OFF):
+- `SENTRY_TRANSPORT_COMPRESSION` (Default: `OFF`):
   Adds Gzip transport compression. Requires `zlib`.
+ 
+- `SENTRY_HANDLER_STACK_SIZE` (Default: `64`):
+  This specifies the size of the stack reserved for the crash handler on Windows and Linux. Reserving the stack is
+  necessary in case of a stack-overflow, where the handler could otherwise no longer execute. This parameter allows
+  users to specify their target stack size in KiB, because some applications might require a different value from our
+  default. It is a build parameter because ideally this value is defined for each thread before interaction with our
+  API is possible.
 
 | Feature    | Windows | macOS | Linux | Android | iOS |
 | ---------- | ------- | ----- | ----- | ------- | --- |
@@ -275,12 +282,12 @@ Legend:
   Sets the sentry-native projects folder name for generators which support project hierarchy (like Microsoft Visual Studio).
   To use this feature you need to enable hierarchy via [`USE_FOLDERS` property](https://cmake.org/cmake/help/latest/prop_gbl/USE_FOLDERS.html)
 
-- `CRASHPAD_ENABLE_STACKTRACE` (Default: OFF):
+- `CRASHPAD_ENABLE_STACKTRACE` (Default: `OFF`):
   This enables client-side stackwalking when using the crashpad backend. Stack unwinding will happen on the client's machine
   and the result will be submitted to Sentry attached to the generated minidump.
   Note that this feature is still experimental.
 
-- `SENTRY_SDK_NAME` (Default: sentry.native or sentry.native.android):
+- `SENTRY_SDK_NAME` (Default: `sentry.native` or `sentry.native.android`):
   Sets the SDK name that should be included in the reported events. If you're overriding this, make sure to also define
   the same value using `target_compile_definitions()` on your own targets that include `sentry.h`.
 

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -212,7 +212,9 @@ sentry__breakpad_backend_startup(
     sentry_path_t *current_run_folder = options->run->run_path;
 
 #ifdef SENTRY_PLATFORM_WINDOWS
+#    ifndef SENTRY_BUILD_SHARED
     sentry__reserve_thread_stack();
+#    endif
     backend->data = new google_breakpad::ExceptionHandler(
         current_run_folder->path, NULL, sentry__breakpad_backend_callback, NULL,
         google_breakpad::ExceptionHandler::HANDLER_EXCEPTION);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -375,7 +375,7 @@ crashpad_backend_startup(
         }
     }
 
-#ifdef SENTRY_PLATFORM_WINDOWS
+#if defined(SENTRY_PLATFORM_WINDOWS) && !defined(SENTRY_BUILD_SHARED)
     sentry__reserve_thread_stack();
 #endif
 

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -16,7 +16,10 @@
 #include "transports/sentry_disk_transport.h"
 #include <string.h>
 
-#define SIGNAL_DEF(Sig, Desc) { Sig, #Sig, Desc }
+#define SIGNAL_DEF(Sig, Desc)                                                  \
+    {                                                                          \
+        Sig, #Sig, Desc                                                        \
+    }
 
 #define MAX_FRAMES 128
 

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -143,7 +143,7 @@ sentry__reserve_thread_stack(void)
 {
     const unsigned long expected_stack_size = SENTRY_HANDLER_STACK_SIZE * 1024;
     unsigned long stack_size = 0;
-    if (0 == SetThreadStackGuarantee(&stack_size)) {
+    if (!SetThreadStackGuarantee(&stack_size)) {
         SENTRY_WARNF(
             "`SetThreadStackGuarantee` failed with code `%d`", GetLastError());
         return;
@@ -156,7 +156,7 @@ sentry__reserve_thread_stack(void)
     }
 
     stack_size = expected_stack_size;
-    if (0 == SetThreadStackGuarantee(&stack_size)) {
+    if (!SetThreadStackGuarantee(&stack_size)) {
         SENTRY_WARNF("`SetThreadStackGuarantee` failed with code `%d` bytes",
             GetLastError());
     }


### PR DESCRIPTION
This allows users to change the currently hard-coded handler stack size during the build.

Summary:

* The default value is 64 KiB, equivalent to our current hard-coded value. This means for most users, everything stays the same.
* For Windows, the following additional changes were introduced:
  * similar to the `sigaltstack` setup on the signal-handler side, we only configure the thread stack if no one else has done that before us.
  * `sentry__reserve_thread_stack()` is only called from the backend initialization for a static build. Dynamic libraries install a `DllMain` that sets the thread stack for each thread starting after our library is loaded.

I could imagine providing two more build parameters:
* a CMake option to turn on/off the check for a previous stack configuration.
* a CMake option to turn on/off the automatic configuration of each thread's crash stack (i.e., the `DllMain`).

For the sake of simplicity, I would like to defer this decision until we have a case where someone needs to configure the stack size and can not use these mechanisms.

Beyond the configurable stack size, most users prefer not to configure any of these subtle configurations themselves. Introducing any of these build parameters later can be done non-breakingly.