### PR TITLE
fix: look up `GetSystemTime()` implementations at runtime.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Reject invalid trace- and span-ids in context update from header ([#1046](https://github.com/getsentry/sentry-native/pull/1046))
+- Lookup `GetSystemTimePreciseAsFileTime()` at runtime and fall back to `GetSystemTimeAsFileTime()` to allow running on Windows < 8. ([#1051](https://github.com/getsentry/sentry-native/pull/1051))
 
 ## 0.7.10
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -8,6 +8,7 @@
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_options.h"
+#include "sentry_os.h"
 #include "sentry_path.h"
 #include "sentry_random.h"
 #include "sentry_scope.h"
@@ -194,6 +195,10 @@ sentry_init(sentry_options_t *options)
     if (options->auto_session_tracking) {
         sentry_start_session();
     }
+
+#ifdef SENTRY_PLATFORM_WINDOWS
+    sentry__init_cached_functions();
+#endif
 
     sentry__mutex_unlock(&g_options_lock);
     return 0;

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -170,6 +170,33 @@ DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 
 #    endif // defined(SENTRY_BUILD_SHARED)
 
+static void (*g_kernel32_GetSystemTimePreciseAsFileTime)(LPFILETIME) = NULL;
+
+void
+sentry__init_cached_functions(void)
+{
+    // Retrieve GetSystemTimePreciseAsFileTime() for Windows 8+ targets.
+    // Do this at runtime, because this could still be compiled with an SDK
+    // where the function exists, but later runs on a Windows without it.
+    HINSTANCE kernel32 = GetModuleHandleW(L"kernel32.dll");
+    if (!kernel32) {
+        return;
+    }
+    g_kernel32_GetSystemTimePreciseAsFileTime = (void (*)(
+        LPFILETIME))GetProcAddress(kernel32, "GetSystemTimePreciseAsFileTime");
+}
+
+void
+sentry__get_system_time(LPFILETIME filetime)
+{
+    if (g_kernel32_GetSystemTimePreciseAsFileTime) {
+        g_kernel32_GetSystemTimePreciseAsFileTime(filetime);
+        return;
+    }
+
+    GetSystemTimeAsFileTime(filetime);
+}
+
 #elif defined(SENTRY_PLATFORM_MACOS)
 
 #    include <sys/sysctl.h>

--- a/src/sentry_os.h
+++ b/src/sentry_os.h
@@ -15,6 +15,8 @@ typedef struct {
 int sentry__get_kernel_version(windows_version_t *win_ver);
 int sentry__get_windows_version(windows_version_t *win_ver);
 void sentry__reserve_thread_stack(void);
+void sentry__init_cached_functions(void);
+void sentry__get_system_time(LPFILETIME filetime);
 
 #endif
 

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -8,6 +8,7 @@
 #    include <mach/mach.h>
 #endif
 #ifdef SENTRY_PLATFORM_WINDOWS
+#    include "sentry_os.h"
 #    include <winnt.h>
 #else
 #    include <sys/time.h>
@@ -106,12 +107,7 @@ sentry__usec_time(void)
     // Contains a 64-bit value representing the number of 100-nanosecond
     // intervals since January 1, 1601 (UTC).
     FILETIME file_time;
-#    if _WIN32_WINNT >= 0x0602
-    GetSystemTimePreciseAsFileTime(&file_time);
-#    else
-    GetSystemTimeAsFileTime(&file_time);
-#    endif
-
+    sentry__get_system_time(&file_time);
     uint64_t timestamp = (uint64_t)file_time.dwLowDateTime
         + ((uint64_t)file_time.dwHighDateTime << 32);
     timestamp -= 116444736000000000LL; // convert to unix epoch


### PR DESCRIPTION
This is a fix for the issue raised here: https://github.com/getsentry/sentry-native/pull/1039#issuecomment-2398218262

The problem is that the previous build-time condition only checks if the SDK supports the new API, but the application could later run on a Windows without support.

We look up  `GetSystemTimePreciseAsFileTime()` and runtime (during `sentry_init`, at which point it is cached) and fall back to `GetSystemTimeAsFileTime()` if we can't find it.

@dacap and @ShawnCZek, please look to see if that works for you.