### PR TITLE
fix: don't fail `crashpad` startup on invalid `DSN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Reject invalid trace- and span-ids in context update from header ([#1046](https://github.com/getsentry/sentry-native/pull/1046))
 - Lookup `GetSystemTimePreciseAsFileTime()` at runtime and fall back to `GetSystemTimeAsFileTime()` to allow running on Windows < 8. ([#1051](https://github.com/getsentry/sentry-native/pull/1051))
+- Allow for empty DSN to still initialize crash handler ([#1059](https://github.com/getsentry/sentry-native/pull/1059))
 
 ## 0.7.10
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -443,7 +443,7 @@ crashpad_backend_startup(
             "failed to construct minidump URL (check DSN or user-agent)");
     }
     bool success = data->client->StartHandler(handler, database, database, 
-        minidump_url ? mindump_url : "",
+        minidump_url ? minidump_url : "",
         options->http_proxy ? options->http_proxy : "", annotations, arguments,
         /* restartable */ true,
         /* asynchronous_start */ false, attachments);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -442,13 +442,12 @@ crashpad_backend_startup(
         SENTRY_WARN(
             "failed to construct minidump URL (check DSN or user-agent)");
     }
-    const std::string url
-        = minidump_url ? std::string(minidump_url) : std::string();
-    sentry_free(minidump_url);
-    bool success = data->client->StartHandler(handler, database, database, url,
+    bool success = data->client->StartHandler(handler, database, database, 
+        minidump_url ? mindump_url : "",
         options->http_proxy ? options->http_proxy : "", annotations, arguments,
         /* restartable */ true,
         /* asynchronous_start */ false, attachments);
+    sentry_free(minidump_url);
 
 #ifdef SENTRY_PLATFORM_WINDOWS
     crashpad_register_wer_module(absolute_handler_path, data);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -406,7 +406,7 @@ crashpad_backend_startup(
 
     // register attachments
     for (sentry_attachment_t *attachment = options->attachments; attachment;
-        attachment = attachment->next) {
+         attachment = attachment->next) {
         attachments.emplace_back(attachment->path->path);
     }
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -434,23 +434,20 @@ crashpad_backend_startup(
     // `sentry_init` will persist the upload flag.
     data->db = crashpad::CrashReportDatabase::Initialize(database).release();
     data->client = new crashpad::CrashpadClient;
-    bool success;
     char *minidump_url
         = sentry__dsn_get_minidump_url(options->dsn, options->user_agent);
     if (minidump_url) {
         SENTRY_TRACEF("using minidump URL \"%s\"", minidump_url);
-        success = data->client->StartHandler(handler, database, database,
-            minidump_url, options->http_proxy ? options->http_proxy : "",
-            annotations, arguments,
-            /* restartable */ true,
-            /* asynchronous_start */ false, attachments);
-        sentry_free(minidump_url);
     } else {
         SENTRY_WARN(
             "failed to construct minidump URL (check DSN or user-agent)");
-        crashpad_state_dtor(data);
-        return 1;
     }
+    const std::string url = minidump_url ? std::string(minidump_url) : std::string();
+    sentry_free(minidump_url);
+    bool success = data->client->StartHandler(handler, database, database, url,
+        options->http_proxy ? options->http_proxy : "", annotations, arguments,
+        /* restartable */ true,
+        /* asynchronous_start */ false, attachments);
 
 #ifdef SENTRY_PLATFORM_WINDOWS
     crashpad_register_wer_module(absolute_handler_path, data);

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -406,7 +406,7 @@ crashpad_backend_startup(
 
     // register attachments
     for (sentry_attachment_t *attachment = options->attachments; attachment;
-         attachment = attachment->next) {
+        attachment = attachment->next) {
         attachments.emplace_back(attachment->path->path);
     }
 
@@ -442,7 +442,8 @@ crashpad_backend_startup(
         SENTRY_WARN(
             "failed to construct minidump URL (check DSN or user-agent)");
     }
-    const std::string url = minidump_url ? std::string(minidump_url) : std::string();
+    const std::string url
+        = minidump_url ? std::string(minidump_url) : std::string();
     sentry_free(minidump_url);
     bool success = data->client->StartHandler(handler, database, database, url,
         options->http_proxy ? options->http_proxy : "", annotations, arguments,

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -439,7 +439,7 @@ crashpad_backend_startup(
     if (minidump_url) {
         SENTRY_TRACEF("using minidump URL \"%s\"", minidump_url);
     }
-    bool success = data->client->StartHandler(handler, database, database, 
+    bool success = data->client->StartHandler(handler, database, database,
         minidump_url ? minidump_url : "",
         options->http_proxy ? options->http_proxy : "", annotations, arguments,
         /* restartable */ true,

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -438,9 +438,6 @@ crashpad_backend_startup(
         = sentry__dsn_get_minidump_url(options->dsn, options->user_agent);
     if (minidump_url) {
         SENTRY_TRACEF("using minidump URL \"%s\"", minidump_url);
-    } else {
-        SENTRY_WARN(
-            "failed to construct minidump URL (check DSN or user-agent)");
     }
     bool success = data->client->StartHandler(handler, database, database, 
         minidump_url ? minidump_url : "",


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-native/issues/1056

When leaving the DSN empty, the crashpad handler wouldn't start. This PR fixes this by warning the user about the empty DSN and not failing the initialization anymore.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
