### PR TITLE
ci: cancel in-progress workflow runs on same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - "release/**"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
As we talked about @JoshuaMoelans.

#skip-changelog
