### PR TITLE
chore: add clang-format to venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          sudo apt update
-          sudo apt install clang-format-15
-          make style-15
+      - run: make style
 
   build-ios:
     name: Xcode Build for iOS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Building and testing `sentry-native` currently requires the following tools:
 - **clang-format** and **black**, to format the C/C++ and python code respectively.
 - **curl** and **zlib** libraries (e.g. on Ubuntu: libcurl4-openssl-dev, libz-dev)
 
-`pytest` and `black` are installed as virtualenv dependencies automatically.
+`pytest`, `clang-format` and `black` are installed as virtualenv dependencies automatically.
 
 ## Setting up Environment
 
@@ -142,12 +142,12 @@ The example currently supports the following commands:
 - `disable-backend`: Disables the build-configured crash-handler backend.
 - `before-send`: Installs a `before_send()` callback that retains the event.
 - `discarding-before-send`: Installs a `before_send()` callback that discards the event.
-- `on-crash`: Installs an `on_crash()` callback that retains the crash event. 
+- `on-crash`: Installs an `on_crash()` callback that retains the crash event.
 - `discarding-on-crash`: Installs an `on_crash()` callback that discards the crash event.
 - `override-sdk-name`: Changes the SDK name via the options at runtime.
 - `stack-overflow`: Provokes a stack-overflow.
 
-Only on Windows using crashpad with its WER handler module: 
+Only on Windows using crashpad with its WER handler module:
 
 - `fastfail`: Crashes the application using the `__fastfail` intrinsic directly, thus by-passing SEH.
 - `stack-buffer-overrun`: Triggers the Windows Control Flow Guard, which also fast fails and in turn by-passes SEH.

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ setup-venv: .venv/bin/python
 	.venv/bin/pip install --upgrade --requirement tests/requirements.txt
 
 format: setup-venv
-	@clang-format -i \
+	@.venv/bin/clang-format -i \
 		examples/*.c \
 		include/*.h \
 		src/*.c \
@@ -80,6 +80,8 @@ format: setup-venv
 .PHONY: format
 
 style: setup-venv
-	@.venv/bin/python ./scripts/check-clang-format.py -r examples include src tests/unit
+	@.venv/bin/python ./scripts/check-clang-format.py \
+		--clang-format-executable .venv/bin/clang-format \
+		-r examples include src tests/unit
 	@.venv/bin/black --diff --check tests
 .PHONY: style

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,3 @@ style: setup-venv
 	@.venv/bin/python ./scripts/check-clang-format.py -r examples include src tests/unit
 	@.venv/bin/black --diff --check tests
 .PHONY: style
-
-# TODO: workaround for clang-format 15+ where local formatting breaks with clang-format-14 based style checks on CI
-style-15: setup-venv
-	@.venv/bin/python ./scripts/check-clang-format.py --clang-format-executable /usr/bin/clang-format-15 -r examples include src tests/unit
-	@.venv/bin/black --diff --check tests
-.PHONY: style-15

--- a/examples/example.c
+++ b/examples/example.c
@@ -19,7 +19,7 @@
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <malloc.h>
 #    include <synchapi.h>
-#    define sleep_s(SECONDS) Sleep((SECONDS)*1000)
+#    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
 #else
 
 #    include <signal.h>

--- a/scripts/git-precommit-hook.sh
+++ b/scripts/git-precommit-hook.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-CFILES=`git diff-index --cached --name-only HEAD | grep -E "^(examples|include|src|tests/unit).*\.(c|h|cpp)$"`
-PYFILES=`git diff-index --cached --name-only HEAD | grep -E "^tests.*\.py$"`
+CFILES=$(git diff-index --cached --name-only HEAD | grep -E "^(examples|include|src|tests/unit).*\.(c|h|cpp)$")
+PYFILES=$(git diff-index --cached --name-only HEAD | grep -E "^tests.*\.py$")
 
 if [ -n "$CFILES" ]; then
-    clang-format -i $CFILES
+    .venv/bin/clang-format -i $CFILES
 fi
 if [ -n "$PYFILES" ]; then
     .venv/bin/black $PYFILES

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -406,7 +406,7 @@ crashpad_backend_startup(
 
     // register attachments
     for (sentry_attachment_t *attachment = options->attachments; attachment;
-         attachment = attachment->next) {
+        attachment = attachment->next) {
         attachments.emplace_back(attachment->path->path);
     }
 

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -37,10 +37,7 @@
  * Both breakpad and crashpad are way more defensive in the setup of their
  * signal stacks and take existing stacks into account (or reuse them).
  */
-#define SIGNAL_DEF(Sig, Desc)                                                  \
-    {                                                                          \
-        Sig, #Sig, Desc                                                        \
-    }
+#define SIGNAL_DEF(Sig, Desc) { Sig, #Sig, Desc }
 
 #define MAX_FRAMES 128
 

--- a/src/modulefinder/sentry_modulefinder_apple.c
+++ b/src/modulefinder/sentry_modulefinder_apple.c
@@ -55,9 +55,9 @@ add_image(const struct mach_header *mh, intptr_t UNUSED(vmaddr_slide))
     bool has_uuid = false;
 
     for (size_t i = 0; cmd && (i < header->ncmds) && (!has_uuid || !has_size);
-         ++i,
+        ++i,
                 cmd
-         = (const struct load_command *)((const char *)cmd + cmd->cmdsize)) {
+        = (const struct load_command *)((const char *)cmd + cmd->cmdsize)) {
         if (cmd->cmd == CMD_SEGMENT) {
             const mach_segment_command_type *seg
                 = (const mach_segment_command_type *)cmd;

--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -18,8 +18,8 @@
 static const size_t MAX_READ_TO_BUFFER = 134217728;
 
 #ifndef __MINGW32__
-#    define S_ISREG(m) (((m)&_S_IFMT) == _S_IFREG)
-#    define S_ISDIR(m) (((m)&_S_IFMT) == _S_IFDIR)
+#    define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
+#    define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
 #endif
 
 struct sentry_pathiter_s {

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -501,7 +501,7 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
 
     SENTRY_TRACE("adding attachments to envelope");
     for (sentry_attachment_t *attachment = options->attachments; attachment;
-         attachment = attachment->next) {
+        attachment = attachment->next) {
         sentry_envelope_item_t *item = sentry__envelope_add_from_path(
             envelope, attachment->path, "attachment");
         if (!item) {

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -112,7 +112,7 @@ void sentry__options_unlock(void);
 
 #define SENTRY_WITH_OPTIONS(Options)                                           \
     for (const sentry_options_t *Options = sentry__options_getref(); Options;  \
-         sentry_options_free((sentry_options_t *)Options), Options = NULL)
+        sentry_options_free((sentry_options_t *)Options), Options = NULL)
 
 // these for now are only needed outside of core for tests
 #ifdef SENTRY_UNITTEST

--- a/src/sentry_scope.h
+++ b/src/sentry_scope.h
@@ -86,13 +86,13 @@ void sentry__scope_apply_to_event(const sentry_scope_t *scope,
  */
 #define SENTRY_WITH_SCOPE(Scope)                                               \
     for (const sentry_scope_t *Scope = sentry__scope_lock(); Scope;            \
-         sentry__scope_unlock(), Scope = NULL)
+        sentry__scope_unlock(), Scope = NULL)
 #define SENTRY_WITH_SCOPE_MUT(Scope)                                           \
     for (sentry_scope_t *Scope = sentry__scope_lock(); Scope;                  \
-         sentry__scope_flush_unlock(), Scope = NULL)
+        sentry__scope_flush_unlock(), Scope = NULL)
 #define SENTRY_WITH_SCOPE_MUT_NO_FLUSH(Scope)                                  \
     for (sentry_scope_t *Scope = sentry__scope_lock(); Scope;                  \
-         sentry__scope_unlock(), Scope = NULL)
+        sentry__scope_unlock(), Scope = NULL)
 
 #endif
 

--- a/src/sentry_string.h
+++ b/src/sentry_string.h
@@ -213,6 +213,6 @@ size_t sentry__unichar_to_utf8(uint32_t c, char *buf);
 #define sentry__is_lead_surrogate(c) ((c) >= 0xd800 && (c) < 0xdc00)
 #define sentry__is_trail_surrogate(c) ((c) >= 0xdc00 && (c) < 0xe000)
 #define sentry__surrogate_value(lead, trail)                                   \
-    (((((lead)-0xd800) << 10) | ((trail)-0xdc00)) + 0x10000)
+    (((((lead) - 0xd800) << 10) | ((trail) - 0xdc00)) + 0x10000)
 
 #endif

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -35,10 +35,7 @@
 
 #    if _WIN32_WINNT < 0x0600
 
-#        define INIT_ONCE_STATIC_INIT                                          \
-            {                                                                  \
-                0                                                              \
-            }
+#        define INIT_ONCE_STATIC_INIT { 0 }
 
 typedef union {
     PVOID Ptr;
@@ -165,13 +162,7 @@ sentry__winmutex_lock(struct sentry__winmutex_s *mutex)
 
 typedef HANDLE sentry_threadid_t;
 typedef struct sentry__winmutex_s sentry_mutex_t;
-#    define SENTRY__MUTEX_INIT                                                 \
-        {                                                                      \
-            INIT_ONCE_STATIC_INIT,                                             \
-            {                                                                  \
-                0                                                              \
-            }                                                                  \
-        }
+#    define SENTRY__MUTEX_INIT { INIT_ONCE_STATIC_INIT, { 0 } }
 #    define sentry__mutex_init(Lock) sentry__winmutex_init(Lock)
 #    define sentry__mutex_lock(Lock) sentry__winmutex_lock(Lock)
 #    define sentry__mutex_unlock(Lock)                                         \

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ pytest==8.1.1
 pytest-httpserver==1.0.10
 msgpack==1.0.8
 pytest-xdist==3.5.0
+clang-format==19.1.3

--- a/tests/unit/test_sync.c
+++ b/tests/unit/test_sync.c
@@ -4,7 +4,7 @@
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <windows.h>
-#    define sleep_s(SECONDS) Sleep((SECONDS)*1000)
+#    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
 #else
 #    include <unistd.h>
 #    define sleep_s(SECONDS) sleep(SECONDS)


### PR DESCRIPTION
I've run `make format` as instructed by the contributing.md and linter complained in CI. Later, I've found out it's because of a different version of clang-format so I've added it to .venv so that everyone is on the same version.

#skip-changelog