### PR TITLE
fix: crashpad_handler proxy-upload semaphore-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 **Features**:
 
 - Provide version information for non-static Windows binaries. ([#1076](https://github.com/getsentry/sentry-native/pull/1076), [crashpad#110](https://github.com/getsentry/crashpad/pull/110))
- 
+
+**Fixes**:
+
+- Correct the timeout specified for the upload-task awaiting `dispatch_semaphore_wait()` when using an HTTP-proxy on macOS. ([#1077](https://github.com/getsentry/sentry-native/pull/1077), [crashpad#111](https://github.com/getsentry/crashpad/pull/111))
+
 **Thank you**:
 
 [olback](https://github.com/olback)


### PR DESCRIPTION
Fixes an incorrectly set up timeout value when waiting for a `dispatch_semaphore_signal()` from the HTTP-proxy upload task on macOS. See: https://github.com/getsentry/crashpad/pull/111