### PR TITLE
[NDK] Add loadNativeLibraries method to allow pre-loading .so files

### DIFF
--- a/ndk/lib/api/sentry-native-ndk.api
+++ b/ndk/lib/api/sentry-native-ndk.api
@@ -79,5 +79,6 @@ public final class io/sentry/ndk/NdkOptions {
 public final class io/sentry/ndk/SentryNdk {
 	public static fun close ()V
 	public static fun init (Lio/sentry/ndk/NdkOptions;)V
+	public static fun loadNativeLibraries ()V
 }
 

--- a/ndk/lib/src/main/java/io/sentry/ndk/SentryNdk.java
+++ b/ndk/lib/src/main/java/io/sentry/ndk/SentryNdk.java
@@ -6,16 +6,7 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SentryNdk {
 
-  static {
-    // On older Android versions, it was necessary to manually call "`System.loadLibrary` on all
-    // transitive dependencies before loading [the] main library."
-    // The dependencies of `libsentry.so` are currently `lib{c,m,dl,log}.so`.
-    // See
-    // https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#changes-to-library-dependency-resolution
-    System.loadLibrary("log");
-    System.loadLibrary("sentry");
-    System.loadLibrary("sentry-android");
-  }
+  private static volatile boolean nativeLibrariesLoaded;
 
   private SentryNdk() {}
 
@@ -29,11 +20,31 @@ public final class SentryNdk {
    * @param options the SentryAndroidOptions
    */
   public static void init(@NotNull final NdkOptions options) {
+    loadNativeLibraries();
     initSentryNative(options);
   }
 
   /** Closes the NDK integration */
   public static void close() {
+    loadNativeLibraries();
     shutdown();
+  }
+
+  /**
+   * Loads all required native libraries. This is automatically done by {@link #init(NdkOptions)},
+   * but can be called manually in case you want to preload the libraries before calling #init.
+   */
+  public static synchronized void loadNativeLibraries() {
+    if (!nativeLibrariesLoaded) {
+      // On older Android versions, it was necessary to manually call "`System.loadLibrary` on all
+      // transitive dependencies before loading [the] main library."
+      // The dependencies of `libsentry.so` are currently `lib{c,m,dl,log}.so`.
+      // See
+      // https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#changes-to-library-dependency-resolution
+      System.loadLibrary("log");
+      System.loadLibrary("sentry");
+      System.loadLibrary("sentry-android");
+      nativeLibrariesLoaded = true;
+    }
   }
 }


### PR DESCRIPTION
`sentry-java` `7.x` loads the `.so` libraries using a background thread, see https://github.com/getsentry/sentry-java/pull/3670

Instead of porting this behaviour 1:1 to `sentry-native`, I'm proposing a new `.loadNativeLibraries()` method, allowing you to pre-load the libraries if necessary. It's up to the consumer, like sentry-java `8.x` to use this method, and e.g. call it on a background thread.

This is a change in behaviour, as the `.so` files no longer get loaded during class init.