### PR TITLE
feat: thread context from breakpad on macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 **Features**:
 
 - Android NDK: Add `.loadNativeLibraries()` method to allow pre-loading .so files ([#1082](https://github.com/getsentry/sentry-native/pull/1082))
+- Fill the `ucontext_t` field in the `sentry_ucontext_t` `[on_crash|before_send]`-hook parameter on `macOS` from the `breakpad` backend. ([#1083](https://github.com/getsentry/sentry-native/pull/1083), [breakpad#39](https://github.com/getsentry/breakpad/pull/39))
+
+**Thank you**:
+
+[saf-e](https://github.com/saf-e)
 
 ## 0.7.13
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,6 +479,7 @@ if(SENTRY_BACKEND_CRASHPAD)
 elseif(SENTRY_BACKEND_BREAKPAD)
 	option(SENTRY_BREAKPAD_SYSTEM "Use system breakpad" OFF)
 	if(SENTRY_BREAKPAD_SYSTEM)
+		target_compile_definitions(sentry PRIVATE SENTRY_BREAKPAD_SYSTEM)
 		# system breakpad is using pkg-config, see `external/breakpad/breakpad-client.pc.in`
 		find_package(PkgConfig REQUIRED)
 		pkg_check_modules(BREAKPAD REQUIRED IMPORTED_TARGET breakpad-client)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -128,6 +128,7 @@ add_library(breakpad_client STATIC)
 set_property(TARGET breakpad_client PROPERTY CXX_STANDARD 17)
 set_property(TARGET breakpad_client PROPERTY CXX_STANDARD_REQUIRED On)
 target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON})
+target_compile_definitions(breakpad_client PRIVATE SENTRY_BACKEND_BREAKPAD)
 
 if(LINUX OR ANDROID)
     target_sources(breakpad_client PRIVATE ${BREAKPAD_SOURCES_COMMON_LINUX} ${BREAKPAD_SOURCES_CLIENT_LINUX})

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -42,7 +42,7 @@ extern "C" {
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 static bool
-sentry__breakpad_backend_callback(const wchar_t *breakpad_dump_path,
+breakpad_backend_callback(const wchar_t *breakpad_dump_path,
     const wchar_t *minidump_id, void *UNUSED(context),
     EXCEPTION_POINTERS *exinfo, MDRawAssertionInfo *UNUSED(assertion),
     bool succeeded)
@@ -227,7 +227,7 @@ breakpad_backend_startup(
 #ifdef SENTRY_PLATFORM_WINDOWS
     sentry__reserve_thread_stack();
     backend->data = new google_breakpad::ExceptionHandler(
-        current_run_folder->path, NULL, sentry__breakpad_backend_callback, NULL,
+        current_run_folder->path, NULL, breakpad_backend_callback, NULL,
         google_breakpad::ExceptionHandler::HANDLER_EXCEPTION);
 #elif defined(SENTRY_PLATFORM_MACOS)
     // If process is being debugged and there are breakpoints set it will cause
@@ -238,11 +238,11 @@ breakpad_backend_startup(
 #elif defined(SENTRY_PLATFORM_IOS)
     backend->data
         = new google_breakpad::ExceptionHandler(current_run_folder->path,
-            nullptr, sentry__breakpad_backend_callback, nullptr, true, nullptr);
+            nullptr, breakpad_backend_callback, nullptr, true, nullptr);
 #else
     google_breakpad::MinidumpDescriptor descriptor(current_run_folder->path);
-    backend->data = new google_breakpad::ExceptionHandler(descriptor, nullptr,
-        sentry__breakpad_backend_callback, nullptr, true, -1);
+    backend->data = new google_breakpad::ExceptionHandler(
+        descriptor, nullptr, breakpad_backend_callback, nullptr, true, -1);
 #endif
     return backend->data == nullptr;
 }

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #elif defined(SENTRY_PLATFORM_MACOS)
 #    include "client/mac/handler/exception_handler.h"
 #    include <sys/sysctl.h>
+#    include <unistd.h>
 #elif defined(SENTRY_PLATFORM_IOS)
 #    include "client/ios/exception_handler_no_mach.h"
 #else
@@ -46,13 +47,19 @@ sentry__breakpad_backend_callback(const wchar_t *breakpad_dump_path,
     EXCEPTION_POINTERS *exinfo, MDRawAssertionInfo *UNUSED(assertion),
     bool succeeded)
 #elif defined(SENTRY_PLATFORM_DARWIN)
+#    ifdef SENTRY_BREAKPAD_SYSTEM
 static bool
-sentry__breakpad_backend_callback(const char *breakpad_dump_path,
+breakpad_backend_callback(const char *breakpad_dump_path,
     const char *minidump_id, void *UNUSED(context), bool succeeded)
+#    else
+static bool
+breakpad_backend_callback(const char *breakpad_dump_path,
+    const char *minidump_id, void *UNUSED(context),
+    breakpad_ucontext_t *user_context, bool succeeded)
+#    endif
 #else
 static bool
-sentry__breakpad_backend_callback(
-    const google_breakpad::MinidumpDescriptor &descriptor,
+breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
     void *UNUSED(context), bool succeeded)
 #endif
 {
@@ -105,6 +112,12 @@ sentry__breakpad_backend_callback(
 
         if (options->on_crash_func) {
             sentry_ucontext_t *uctx = nullptr;
+
+#if defined(SENTRY_PLATFORM_DARWIN) && !defined(SENTRY_BREAKPAD_SYSTEM)
+            sentry_ucontext_t uctx_data;
+            uctx_data.user_context = user_context;
+            uctx = &uctx_data;
+#endif
 
 #ifdef SENTRY_PLATFORM_WINDOWS
             sentry_ucontext_t uctx_data;
@@ -206,7 +219,7 @@ IsDebuggerActive()
 #endif
 
 static int
-sentry__breakpad_backend_startup(
+breakpad_backend_startup(
     sentry_backend_t *backend, const sentry_options_t *options)
 {
     sentry_path_t *current_run_folder = options->run->run_path;
@@ -219,36 +232,35 @@ sentry__breakpad_backend_startup(
 #elif defined(SENTRY_PLATFORM_MACOS)
     // If process is being debugged and there are breakpoints set it will cause
     // task_set_exception_ports to crash the whole process and debugger
-    backend->data
-        = new google_breakpad::ExceptionHandler(current_run_folder->path, NULL,
-            sentry__breakpad_backend_callback, NULL, !IsDebuggerActive(), NULL);
+    backend->data = new google_breakpad::ExceptionHandler(
+        current_run_folder->path, nullptr, breakpad_backend_callback, nullptr,
+        !IsDebuggerActive(), nullptr);
 #elif defined(SENTRY_PLATFORM_IOS)
     backend->data
-        = new google_breakpad::ExceptionHandler(current_run_folder->path, NULL,
-            sentry__breakpad_backend_callback, NULL, true, NULL);
+        = new google_breakpad::ExceptionHandler(current_run_folder->path,
+            nullptr, sentry__breakpad_backend_callback, nullptr, true, nullptr);
 #else
     google_breakpad::MinidumpDescriptor descriptor(current_run_folder->path);
-    backend->data = new google_breakpad::ExceptionHandler(
-        descriptor, NULL, sentry__breakpad_backend_callback, NULL, true, -1);
+    backend->data = new google_breakpad::ExceptionHandler(descriptor, nullptr,
+        sentry__breakpad_backend_callback, nullptr, true, -1);
 #endif
-    return backend->data == NULL;
+    return backend->data == nullptr;
 }
 
 static void
-sentry__breakpad_backend_shutdown(sentry_backend_t *backend)
+breakpad_backend_shutdown(sentry_backend_t *backend)
 {
-    google_breakpad::ExceptionHandler *eh
-        = (google_breakpad::ExceptionHandler *)backend->data;
-    backend->data = NULL;
+    const auto *eh
+        = static_cast<google_breakpad::ExceptionHandler *>(backend->data);
+    backend->data = nullptr;
     delete eh;
 }
 
 static void
-sentry__breakpad_backend_except(
+breakpad_backend_except(
     sentry_backend_t *backend, const sentry_ucontext_t *context)
 {
-    google_breakpad::ExceptionHandler *eh
-        = (google_breakpad::ExceptionHandler *)backend->data;
+    auto *eh = static_cast<google_breakpad::ExceptionHandler *>(backend->data);
 
 #ifdef SENTRY_PLATFORM_WINDOWS
     eh->WriteMinidumpForException(
@@ -274,15 +286,15 @@ extern "C" {
 sentry_backend_t *
 sentry__backend_new(void)
 {
-    sentry_backend_t *backend = SENTRY_MAKE(sentry_backend_t);
+    auto *backend = SENTRY_MAKE(sentry_backend_t);
     if (!backend) {
-        return NULL;
+        return nullptr;
     }
     memset(backend, 0, sizeof(sentry_backend_t));
 
-    backend->startup_func = sentry__breakpad_backend_startup;
-    backend->shutdown_func = sentry__breakpad_backend_shutdown;
-    backend->except_func = sentry__breakpad_backend_except;
+    backend->startup_func = breakpad_backend_startup;
+    backend->shutdown_func = breakpad_backend_shutdown;
+    backend->except_func = breakpad_backend_except;
 
     return backend;
 }


### PR DESCRIPTION
Upstream `breakpad` doesn't provide the thread context to the handler callbacks (it does write it to the minidump, though). This change fills the context of the crashed thread and passes it on to the handler callback (which in turn passes it on to the `on_crash` and `before_send` callbacks).

The change keeps compatibility between upstream and our fork in both directions even though this breaks one of the public interfaces:
* our `breakpad` backend in the Native SDK uses the upstream interface if `SENTRY_BREAKPAD_SYSTEM` is defined
* our `breakpad` fork provides the modified interface only if compiled with the Native SDK (i.e., `SENTRY_BACKEND_BREAKPAD` is defined in the `breakpad_client` target).