### PR TITLE
Don't define sentry_add_version_resource() command when building the static version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,8 +369,8 @@ if(WIN32)
 	endif()
 endif()
 
-include(cmake/utils.cmake)
 if (WIN32 AND SENTRY_BUILD_SHARED_LIBS)
+	include(cmake/utils.cmake)
 	sentry_add_version_resource(sentry "Client Library")
 endif()
 


### PR DESCRIPTION
As crashpad now checks the existence of sentry_add_version_resource() command in:

  https://github.com/getsentry/crashpad/commit/8961424c23c2ba98eaecbee526e0b729aabea1b2

We cannot define the command if the sentry.rc file is not going to be created, i.e. only the static version of Sentry is going to be built.

Without this fix we'll get the following error:
```
CMake Error: File .../sentry.rc.in does not exist. CMake Error at sentry-native/cmake/utils.cmake:14 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  sentry-native/external/crashpad/handler/CMakeLists.txt:118 (sentry_add_version_resource)
```

This regression was introduced in #1076 