### PR TITLE
fix: DLL versioning for SDK usage as CMake subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Fixes**:
 
-- Fix DLL versioning for projects that add the Native SDK as a CMake subdirectory. ([#1085](https://github.com/getsentry/sentry-native/pull/1085))
+- Fix DLL versioning for projects that add the Native SDK as a CMake subdirectory. ([#1086](https://github.com/getsentry/sentry-native/pull/1086))
 
 ## 0.7.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Fix DLL versioning for projects that add the Native SDK as a CMake subdirectory. ([#1085](https://github.com/getsentry/sentry-native/pull/1085))
+
 ## 0.7.14
 
 **Features**:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 	set(SENTRY_MAIN_PROJECT ON)
 endif()
 
+# We have 4 source directories:
+# * `CMAKE_SOURCE_DIR`: points to the directory of the top-level CMakeLists.txt of the main project.
+# * `CMAKE_CURRENT_SOURCE_DIR`: points to the directory of any CMakeLists.txt in any subdirectories.
+# * `PROJECT_SOURCE_DIR`: points to the directory of any CMakeLists.txt in any subdirectories that defined a `project`.
+# * `SENTRY_SOURCE_DIR`: points to the directory of this `CMakeLists.txt` independent of whether it was added as a
+#                        subdirectory in another project or whether we access it from one of our subdirectories.
+set(SENTRY_SOURCE_DIR ${PROJECT_SOURCE_DIR})
+
 if(NOT CMAKE_C_STANDARD)
 	set(CMAKE_C_STANDARD 11)
 endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -11,7 +11,7 @@ function(sentry_add_version_resource TGT FILE_DESCRIPTION)
     list(GET _SENTRY_VERSION_LIST 2 SENTRY_VERSION_PATCH)
 
     # Produce the resource file with configure-time replacements
-    configure_file("${CMAKE_SOURCE_DIR}/sentry.rc.in" "${RESOURCE_PATH_TMP}" @ONLY)
+    configure_file("${SENTRY_SOURCE_DIR}/sentry.rc.in" "${RESOURCE_PATH_TMP}" @ONLY)
 
     # Replace the `ORIGINAL_FILENAME` at generate-time using the generator expression `TARGET_FILE_NAME`
     file(GENERATE OUTPUT ${RESOURCE_PATH} INPUT ${RESOURCE_PATH_TMP})


### PR DESCRIPTION
This should fix the issue raised in #1084.

@dacap, can you give this a try in your setup?