### PR TITLE
fix: warnings in the Android NDK build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ if(WIN32)
 else()
 	# The Android tools ship with this ancient version, which we need to support.
 	cmake_minimum_required (VERSION 3.10)
+	cmake_policy(SET CMP0077 NEW)
 endif()
 
 #read sentry-native version

--- a/ndk/README.md
+++ b/ndk/README.md
@@ -1,7 +1,7 @@
 # Android NDK support for sentry-native
 
 | Package                       | Maven Central                                                                                                                                                                            | Minimum Android API Level | Supported ABIs                              |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------- |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------|---------------------------------------------|
 | `io.sentry:sentry-native-ndk` | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-native-ndk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.sentry/sentry-native-ndk) | 19                        | "x86", "armeabi-v7a", "x86_64", "arm64-v8a" |
 
 ## Resources
@@ -29,46 +29,46 @@ The `ndk` project uses the Gradle build system in combination with CMake. You ca
 1. Set a custom `versionName` in the `ndk/gradle.properties` file
 2. Publish the package locally
 
-```shell
-cd ndk
-./gradlew :sentry-native-ndk:publishToMavenLocal
-```
+   ```shell
+   cd ndk
+   ./gradlew :sentry-native-ndk:publishToMavenLocal
+   ```
 
 3. Consume the build in your app
 
-```
-// usually settings.gradle
-allprojects {
-  repositories {
-    mavenLocal()
-  }
-}
+   ```
+   // usually settings.gradle
+   allprojects {
+     repositories {
+       mavenLocal()
+     }
+   }
 
-// usually app/build.gradle
-android {
-    buildFeatures {
-        prefab = true
-    }
-}
+   // usually app/build.gradle
+   android {
+       buildFeatures {
+           prefab = true
+       }
+   }
 
-dependencies {
-     implementation("io.sentry:sentry-native-ndk:<version>")
-}
-```
+   dependencies {
+        implementation("io.sentry:sentry-native-ndk:<version>")
+   }
+   ```
 
 4. Link the pre-built packages with your native code
 
-```cmake
-# usually app/CMakeLists.txt
+   ```cmake
+   # usually app/CMakeLists.txt
 
-find_package(sentry-native-ndk REQUIRED CONFIG)
+   find_package(sentry-native-ndk REQUIRED CONFIG)
 
-target_link_libraries(<app> PRIVATE
-    ${LOG_LIB}
-    sentry-native-ndk::sentry-android
-    sentry-native-ndk::sentry
-)
-```
+   target_link_libraries(<app> PRIVATE
+       ${LOG_LIB}
+       sentry-native-ndk::sentry-android
+       sentry-native-ndk::sentry
+   )
+   ```
 
 ## Development
 

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -9,12 +9,17 @@
 #if defined(_MSC_VER)
 #    pragma warning(push)
 #    pragma warning(disable : 4127) // conditional expression is constant
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstatic-in-inline"
 #endif
 
 #include "../vendor/mpack.h"
 
 #if defined(_MSC_VER)
 #    pragma warning(pop)
+#elif defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
 #include "sentry_alloc.h"

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -10,8 +10,8 @@
 #    pragma warning(push)
 #    pragma warning(disable : 4127) // conditional expression is constant
 #elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wstatic-in-inline"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wstatic-in-inline"
 #endif
 
 #include "../vendor/mpack.h"
@@ -19,7 +19,7 @@
 #if defined(_MSC_VER)
 #    pragma warning(pop)
 #elif defined(__clang__)
-#pragma clang diagnostic pop
+#    pragma clang diagnostic pop
 #endif
 
 #include "sentry_alloc.h"


### PR DESCRIPTION
fixes #1085

It also includes the disabled warnings in the `libunwindstack` submodule (https://github.com/getsentry/libunwindstack-ndk/pull/9) and minor markdown fixes in the `ndk` readme.

#skip-changelog