### PR TITLE
Add options to set NDK handler strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+- [NDK] Expose option to set handler strategy ([#1099](https://github.com/getsentry/sentry-native/pull/1099))
+
 ## 0.7.16
 
 **Features**:

--- a/ndk/lib/api/sentry-native-ndk.api
+++ b/ndk/lib/api/sentry-native-ndk.api
@@ -64,16 +64,26 @@ public final class io/sentry/ndk/NativeScope : io/sentry/ndk/INativeScope {
 	public fun setUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 }
 
+public final class io/sentry/ndk/NdkHandlerStrategy : java/lang/Enum {
+	public static final field SENTRY_HANDLER_STRATEGY_CHAIN_AT_START Lio/sentry/ndk/NdkHandlerStrategy;
+	public static final field SENTRY_HANDLER_STRATEGY_DEFAULT Lio/sentry/ndk/NdkHandlerStrategy;
+	public fun getValue ()I
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/ndk/NdkHandlerStrategy;
+	public static fun values ()[Lio/sentry/ndk/NdkHandlerStrategy;
+}
+
 public final class io/sentry/ndk/NdkOptions {
 	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)V
 	public fun getDist ()Ljava/lang/String;
 	public fun getDsn ()Ljava/lang/String;
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getMaxBreadcrumbs ()I
+	public fun getNdkHandlerStrategy ()I
 	public fun getOutboxPath ()Ljava/lang/String;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getSdkName ()Ljava/lang/String;
 	public fun isDebug ()Z
+	public fun setNdkHandlerStrategy (Lio/sentry/ndk/NdkHandlerStrategy;)V
 }
 
 public final class io/sentry/ndk/SentryNdk {

--- a/ndk/lib/src/main/java/io/sentry/ndk/NdkHandlerStrategy.java
+++ b/ndk/lib/src/main/java/io/sentry/ndk/NdkHandlerStrategy.java
@@ -1,0 +1,17 @@
+package io.sentry.ndk;
+
+public enum NdkHandlerStrategy {
+  // Needs to match sentry_handler_strategy_t
+  SENTRY_HANDLER_STRATEGY_DEFAULT(0),
+  SENTRY_HANDLER_STRATEGY_CHAIN_AT_START(1);
+
+  private final int value;
+
+  NdkHandlerStrategy(final int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/ndk/lib/src/main/java/io/sentry/ndk/NdkOptions.java
+++ b/ndk/lib/src/main/java/io/sentry/ndk/NdkOptions.java
@@ -12,6 +12,8 @@ public final class NdkOptions {
   private final @Nullable String dist;
   private final int maxBreadcrumbs;
   private final @Nullable String sdkName;
+  private NdkHandlerStrategy ndkHandlerStrategy =
+      NdkHandlerStrategy.SENTRY_HANDLER_STRATEGY_DEFAULT;
 
   public NdkOptions(
       @NotNull String dsn,
@@ -68,5 +70,13 @@ public final class NdkOptions {
   @Nullable
   public String getSdkName() {
     return sdkName;
+  }
+
+  public void setNdkHandlerStrategy(final @NotNull NdkHandlerStrategy ndkHandlerStrategy) {
+    this.ndkHandlerStrategy = ndkHandlerStrategy;
+  }
+
+  public int getNdkHandlerStrategy() {
+    return ndkHandlerStrategy.getValue();
   }
 }

--- a/ndk/lib/src/main/jni/sentry.c
+++ b/ndk/lib/src/main/jni/sentry.c
@@ -253,6 +253,8 @@ Java_io_sentry_ndk_SentryNdk_initSentryNative(
     jmethodID native_sdk_name_mid = (*env)->GetMethodID(env, options_cls, "getSdkName",
                                                         "()Ljava/lang/String;");
 
+    jmethodID handler_strategy_mid = (*env)->GetMethodID(env, options_cls, "getNdkHandlerStrategy", "()I");
+
     (*env)->DeleteLocalRef(env, options_cls);
 
     char *outbox_path = NULL;
@@ -331,6 +333,9 @@ Java_io_sentry_ndk_SentryNdk_initSentryNative(
         sentry_options_set_sdk_name(options, native_sdk_name_str);
         sentry_free(native_sdk_name_str);
     }
+
+    jint handler_strategy = (jint) (*env)->CallIntMethod(env, sentry_ndk_options, handler_strategy_mid);
+    sentry_options_set_handler_strategy(options, handler_strategy);
 
     sentry_init(options);
     return;


### PR DESCRIPTION
[Porting the relevant changes from sentry-java 7.x.x](https://github.com/getsentry/sentry-java/pull/3671) to `ndk`, so we'll have the same feature set for upcoming sentry-java 8.x.x