### PR TITLE
feat: add option to set debug log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 **Features**:
-- Add `sentry_init` and global logger log levels ([#1107](https://github.com/getsentry/sentry-native/pull/1107))
+
+- Add option to set debug log level. ([#1107](https://github.com/getsentry/sentry-native/pull/1107))
 
 ## 0.7.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+- Add `sentry_init` and global logger log levels ([#1107](https://github.com/getsentry/sentry-native/pull/1107))
+
 ## 0.7.17
 
 **Features**:

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1079,6 +1079,12 @@ SENTRY_API void sentry_options_set_debug(sentry_options_t *opts, int debug);
 SENTRY_API int sentry_options_get_debug(const sentry_options_t *opts);
 
 /**
+ * Sets the level of the logger
+ */
+SENTRY_API void sentry_options_set_logger_level(
+    sentry_options_t *opts, sentry_level_t level);
+
+/**
  * Sets the number of breadcrumbs being tracked and attached to events.
  *
  * Defaults to 100.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1069,7 +1069,8 @@ SENTRY_API const char *sentry_options_get_user_agent(
     const sentry_options_t *opts);
 
 /**
- * Enables or disables debug printing mode.
+ * Enables or disables debug printing mode. To change the log level from the
+ * default DEBUG level, use `sentry_options_set_logger_level`.
  */
 SENTRY_API void sentry_options_set_debug(sentry_options_t *opts, int debug);
 
@@ -1079,15 +1080,9 @@ SENTRY_API void sentry_options_set_debug(sentry_options_t *opts, int debug);
 SENTRY_API int sentry_options_get_debug(const sentry_options_t *opts);
 
 /**
- * Sets the level of the logger
+ * Sets the level of the logger. Has no effect if `debug` is not set to true.
  */
 SENTRY_API void sentry_options_set_logger_level(
-    sentry_options_t *opts, sentry_level_t level);
-
-/**
- * Sets the log level for the sentry_init function
- */
-SENTRY_API void sentry_options_set_init_log_level(
     sentry_options_t *opts, sentry_level_t level);
 
 /**

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1085,6 +1085,12 @@ SENTRY_API void sentry_options_set_logger_level(
     sentry_options_t *opts, sentry_level_t level);
 
 /**
+ * Sets the log level for the sentry_init function
+ */
+SENTRY_API void sentry_options_set_init_log_level(
+    sentry_options_t *opts, sentry_level_t level);
+
+/**
  * Sets the number of breadcrumbs being tracked and attached to events.
  *
  * Defaults to 100.

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -63,7 +63,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
     void *UNUSED(context), bool succeeded)
 #endif
 {
-    SENTRY_DEBUG("entering breakpad minidump callback");
+    SENTRY_INFO("entering breakpad minidump callback");
 
     // this is a bit strange, according to docs, `succeeded` should be true when
     // a minidump file was successfully generated. however, when running our
@@ -125,7 +125,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
             uctx = &uctx_data;
 #endif
 
-            SENTRY_TRACE("invoking `on_crash` hook");
+            SENTRY_DEBUG("invoking `on_crash` hook");
             sentry_value_t result
                 = options->on_crash_func(uctx, event, options->on_crash_data);
             should_handle = !sentry_value_is_null(result);
@@ -167,7 +167,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
             sentry__path_remove(dump_path);
             sentry__path_free(dump_path);
         } else {
-            SENTRY_TRACE("event was discarded by the `on_crash` hook");
+            SENTRY_DEBUG("event was discarded by the `on_crash` hook");
             sentry_value_decref(event);
         }
 
@@ -176,7 +176,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
         sentry__transport_dump_queue(options->transport, options->run);
         // and restore the old transport
     }
-    SENTRY_DEBUG("crash has been captured");
+    SENTRY_INFO("crash has been captured");
 
 #ifndef SENTRY_PLATFORM_WINDOWS
     sentry__leave_signal_handler();

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -186,7 +186,7 @@ crashpad_backend_flush_scope_to_event(const sentry_path_t *event_path,
     sentry_free(mpack);
 
     if (rv != 0) {
-        SENTRY_INFO("flushing scope to msgpack failed");
+        SENTRY_WARN("flushing scope to msgpack failed");
     }
 }
 
@@ -545,7 +545,7 @@ crashpad_backend_add_breadcrumb(sentry_backend_t *backend,
     sentry_free(mpack);
 
     if (rv != 0) {
-        SENTRY_INFO("flushing breadcrumb to msgpack failed");
+        SENTRY_WARN("flushing breadcrumb to msgpack failed");
     }
 }
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -139,7 +139,7 @@ crashpad_register_wer_module(
     }
 
     if (wer_path && sentry__path_is_file(wer_path)) {
-        SENTRY_TRACEF("registering crashpad WER handler "
+        SENTRY_DEBUGF("registering crashpad WER handler "
                       "\"%" SENTRY_PATH_PRI "\"",
             wer_path->path);
 
@@ -186,7 +186,7 @@ crashpad_backend_flush_scope_to_event(const sentry_path_t *event_path,
     sentry_free(mpack);
 
     if (rv != 0) {
-        SENTRY_DEBUG("flushing scope to msgpack failed");
+        SENTRY_INFO("flushing scope to msgpack failed");
     }
 }
 
@@ -257,7 +257,7 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
 {
     sentry__page_allocator_enable();
 #    endif
-    SENTRY_DEBUG("flushing session and queue before crashpad handler");
+    SENTRY_INFO("flushing session and queue before crashpad handler");
 
     bool should_dump = true;
 
@@ -276,11 +276,11 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
             uctx.user_context = user_context;
 #    endif
 
-            SENTRY_TRACE("invoking `on_crash` hook");
+            SENTRY_DEBUG("invoking `on_crash` hook");
             crash_event = options->on_crash_func(
                 &uctx, crash_event, options->on_crash_data);
         } else if (options->before_send_func) {
-            SENTRY_TRACE("invoking `before_send` hook");
+            SENTRY_DEBUG("invoking `before_send` hook");
             crash_event = options->before_send_func(
                 crash_event, nullptr, options->before_send_data);
         }
@@ -305,12 +305,12 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
                 sentry_transport_free(disk_transport);
             }
         } else {
-            SENTRY_TRACE("event was discarded");
+            SENTRY_DEBUG("event was discarded");
         }
         sentry__transport_dump_queue(options->transport, options->run);
     }
 
-    SENTRY_DEBUG("handing control over to crashpad");
+    SENTRY_INFO("handing control over to crashpad");
     // If we __don't__ want a minidump produced by crashpad we need to either
     // exit or longjmp at this point. The crashpad client handler which calls
     // back here (SetFirstChanceExceptionHandler) does the same if the
@@ -392,7 +392,7 @@ crashpad_backend_startup(
         return 1;
     }
 
-    SENTRY_TRACEF("starting crashpad backend with handler "
+    SENTRY_DEBUGF("starting crashpad backend with handler "
                   "\"%" SENTRY_PATH_PRI "\"",
         absolute_handler_path->path);
     sentry_path_t *current_run_folder = options->run->run_path;
@@ -437,7 +437,7 @@ crashpad_backend_startup(
     char *minidump_url
         = sentry__dsn_get_minidump_url(options->dsn, options->user_agent);
     if (minidump_url) {
-        SENTRY_TRACEF("using minidump URL \"%s\"", minidump_url);
+        SENTRY_DEBUGF("using minidump URL \"%s\"", minidump_url);
     }
     bool success = data->client->StartHandler(handler, database, database,
         minidump_url ? minidump_url : "", options->proxy ? options->proxy : "",
@@ -453,7 +453,7 @@ crashpad_backend_startup(
     sentry__path_free(absolute_handler_path);
 
     if (success) {
-        SENTRY_DEBUG("started crashpad client handler");
+        SENTRY_INFO("started crashpad client handler");
     } else {
         SENTRY_WARN("failed to start crashpad client handler");
         // not calling `shutdown`
@@ -545,7 +545,7 @@ crashpad_backend_add_breadcrumb(sentry_backend_t *backend,
     sentry_free(mpack);
 
     if (rv != 0) {
-        SENTRY_DEBUG("flushing breadcrumb to msgpack failed");
+        SENTRY_INFO("flushing breadcrumb to msgpack failed");
     }
 }
 

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -725,9 +725,9 @@ sentry_get_modules_list(void)
     sentry__mutex_lock(&g_mutex);
     if (!g_initialized) {
         g_modules = sentry_value_new_list();
-        SENTRY_TRACE("trying to read modules from /proc/self/maps");
+        SENTRY_DEBUG("trying to read modules from /proc/self/maps");
         load_modules(g_modules);
-        SENTRY_TRACEF("read %zu modules from /proc/self/maps",
+        SENTRY_DEBUGF("read %zu modules from /proc/self/maps",
             sentry_value_get_length(g_modules));
         sentry_value_freeze(g_modules);
         g_initialized = true;

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -474,7 +474,7 @@ write_buffer_with_flags(
     int fd = open(
         path->path, flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if (fd < 0) {
-        SENTRY_WARN(
+        SENTRY_WARNF(
             "failed to open file \"%s\" for writing (errno %d, flags %x)",
             path->path, errno, flags);
         return 1;

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -474,7 +474,7 @@ write_buffer_with_flags(
     int fd = open(
         path->path, flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if (fd < 0) {
-        SENTRY_DEBUGF(
+        SENTRY_WARN(
             "failed to open file \"%s\" for writing (errno %d, flags %x)",
             path->path, errno, flags);
         return 1;

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -474,7 +474,7 @@ write_buffer_with_flags(
     int fd = open(
         path->path, flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if (fd < 0) {
-        SENTRY_TRACEF(
+        SENTRY_DEBUGF(
             "failed to open file \"%s\" for writing (errno %d, flags %x)",
             path->path, errno, flags);
         return 1;

--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -110,7 +110,7 @@ sentry__path_current_exe(void)
     sentry_path_t *path = path_with_len(MAX_PATH);
     size_t len = GetModuleFileNameW(NULL, path->path, MAX_PATH);
     if (!len) {
-        SENTRY_DEBUG("unable to get current exe path");
+        SENTRY_INFO("unable to get current exe path");
         sentry__path_free(path);
         return NULL;
     }

--- a/src/path/sentry_path_windows.c
+++ b/src/path/sentry_path_windows.c
@@ -110,7 +110,7 @@ sentry__path_current_exe(void)
     sentry_path_t *path = path_with_len(MAX_PATH);
     size_t len = GetModuleFileNameW(NULL, path->path, MAX_PATH);
     if (!len) {
-        SENTRY_INFO("unable to get current exe path");
+        SENTRY_WARN("unable to get current exe path");
         sentry__path_free(path);
         return NULL;
     }

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -100,6 +100,11 @@ sentry_init(sentry_options_t *options)
     if (options->debug) {
         logger = options->logger;
     }
+    sentry_logger_t old_logger = logger; // restore this after init
+    if (options->log_init) {
+        logger = options->logger;
+        logger.logger_level = options->init_logger_level;
+    }
     sentry__logger_set_global(logger);
 
     // we need to ensure the dir exists, otherwise `path_absolute` will fail.
@@ -199,6 +204,8 @@ sentry_init(sentry_options_t *options)
 #ifdef SENTRY_PLATFORM_WINDOWS
     sentry__init_cached_functions();
 #endif
+
+    sentry__logger_set_global(old_logger);
 
     sentry__mutex_unlock(&g_options_lock);
     return 0;

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -120,7 +120,7 @@ sentry_init(sentry_options_t *options)
     if (options->database_path) {
         sentry__path_free(database_path);
     } else {
-        SENTRY_INFO("falling back to non-absolute database path");
+        SENTRY_DEBUG("falling back to non-absolute database path");
         options->database_path = database_path;
     }
     SENTRY_INFOF("using database path \"%" SENTRY_PATH_PRI "\"",
@@ -262,7 +262,7 @@ sentry_close(void)
         }
         sentry_options_free(options);
     } else {
-        SENTRY_INFO("sentry_close() called, but options was empty");
+        SENTRY_WARN("sentry_close() called, but options was empty");
     }
 
     g_options = NULL;
@@ -363,7 +363,7 @@ sentry__capture_envelope(
 {
     bool has_consent = !sentry__should_skip_upload();
     if (!has_consent) {
-        SENTRY_DEBUG("discarding envelope due to missing user consent");
+        SENTRY_INFO("discarding envelope due to missing user consent");
         sentry_envelope_free(envelope);
         return;
     }
@@ -906,7 +906,7 @@ sentry_transaction_finish_ts(
     sentry_transaction_t *opaque_tx, uint64_t timestamp)
 {
     if (!opaque_tx || sentry_value_is_null(opaque_tx->inner)) {
-        SENTRY_INFO("no transaction available to finish");
+        SENTRY_WARN("no transaction available to finish");
         goto fail;
     }
 
@@ -1029,7 +1029,7 @@ sentry_transaction_start_child_ts_n(sentry_transaction_t *opaque_parent,
     size_t description_len, const uint64_t timestamp)
 {
     if (!opaque_parent || sentry_value_is_null(opaque_parent->inner)) {
-        SENTRY_INFO("no transaction available to create a child under");
+        SENTRY_WARN("no transaction available to create a child under");
         return NULL;
     }
     sentry_value_t parent = opaque_parent->inner;
@@ -1079,11 +1079,11 @@ sentry_span_start_child_ts_n(sentry_span_t *opaque_parent,
     size_t description_len, uint64_t timestamp)
 {
     if (!opaque_parent || sentry_value_is_null(opaque_parent->inner)) {
-        SENTRY_INFO("no parent span available to create a child span under");
+        SENTRY_WARN("no parent span available to create a child span under");
         return NULL;
     }
     if (!opaque_parent->transaction) {
-        SENTRY_INFO("no root transaction to create a child span under");
+        SENTRY_WARN("no root transaction to create a child span under");
         return NULL;
     }
     sentry_value_t parent = opaque_parent->inner;
@@ -1121,14 +1121,14 @@ void
 sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
 {
     if (!opaque_span || sentry_value_is_null(opaque_span->inner)) {
-        SENTRY_INFO("no span to finish");
+        SENTRY_WARN("no span to finish");
         goto fail;
     }
 
     sentry_transaction_t *opaque_root_transaction = opaque_span->transaction;
     if (!opaque_root_transaction
         || sentry_value_is_null(opaque_root_transaction->inner)) {
-        SENTRY_INFO(
+        SENTRY_WARN(
             "no root transaction to finish span on, aborting span finish");
         goto fail;
     }
@@ -1143,7 +1143,7 @@ sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
 
     if (!sentry_value_is_null(
             sentry_value_get_by_key(root_transaction, "timestamp"))) {
-        SENTRY_INFO("span's root transaction is already finished, aborting "
+        SENTRY_WARN("span's root transaction is already finished, aborting "
                     "span finish");
         goto fail;
     }
@@ -1175,7 +1175,7 @@ sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
     }
 
     if (!sentry_value_is_null(sentry_value_get_by_key(span, "timestamp"))) {
-        SENTRY_INFO("span is already finished, aborting span finish");
+        SENTRY_WARN("span is already finished, aborting span finish");
         sentry_value_decref(span);
         goto fail;
     }
@@ -1193,7 +1193,7 @@ sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
     sentry_value_t spans = sentry_value_get_by_key(root_transaction, "spans");
 
     if (sentry_value_get_length(spans) >= max_spans) {
-        SENTRY_INFO("reached maximum number of spans for transaction, "
+        SENTRY_WARN("reached maximum number of spans for transaction, "
                     "discarding span");
         sentry_value_decref(span);
         goto fail;
@@ -1260,7 +1260,7 @@ sentry_capture_minidump_n(const char *path, size_t path_len)
         return;
     }
 
-    SENTRY_INFOF(
+    SENTRY_DEBUGF(
         "Capturing minidump \"%" SENTRY_PATH_PRI "\"", dump_path->path);
 
     sentry_value_t event = sentry_value_new_event();

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -96,7 +96,7 @@ sentry_init(sentry_options_t *options)
 
     sentry_close();
 
-    sentry_logger_t logger = { NULL, NULL };
+    sentry_logger_t logger = { NULL, NULL, SENTRY_LEVEL_DEBUG };
     if (options->debug) {
         logger = options->logger;
     }

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -120,10 +120,10 @@ sentry_init(sentry_options_t *options)
     if (options->database_path) {
         sentry__path_free(database_path);
     } else {
-        SENTRY_DEBUG("falling back to non-absolute database path");
+        SENTRY_INFO("falling back to non-absolute database path");
         options->database_path = database_path;
     }
-    SENTRY_DEBUGF("using database path \"%" SENTRY_PATH_PRI "\"",
+    SENTRY_INFOF("using database path \"%" SENTRY_PATH_PRI "\"",
         options->database_path->path);
 
     // try to create and lock our run folder as early as possibly, since it is
@@ -155,7 +155,7 @@ sentry_init(sentry_options_t *options)
     // and then we will start the backend, since it requires a valid run
     sentry_backend_t *backend = options->backend;
     if (backend && backend->startup_func) {
-        SENTRY_TRACE("starting backend");
+        SENTRY_DEBUG("starting backend");
         if (backend->startup_func(backend, options) != 0) {
             SENTRY_WARN("failed to initialize backend");
             goto fail;
@@ -185,13 +185,13 @@ sentry_init(sentry_options_t *options)
     }
 
 #ifdef SENTRY_INTEGRATION_QT
-    SENTRY_TRACE("setting up Qt integration");
+    SENTRY_DEBUG("setting up Qt integration");
     sentry_integration_setup_qt();
 #endif
 
     // after initializing the transport, we will submit all the unsent envelopes
     // and handle remaining sessions.
-    SENTRY_TRACE("processing and pruning old runs");
+    SENTRY_DEBUG("processing and pruning old runs");
     sentry__process_old_runs(options, last_crash);
     if (backend && backend->prune_database_func) {
         backend->prune_database_func(backend);
@@ -242,7 +242,7 @@ sentry_close(void)
     if (options) {
         sentry_end_session();
         if (options->backend && options->backend->shutdown_func) {
-            SENTRY_TRACE("shutting down backend");
+            SENTRY_DEBUG("shutting down backend");
             options->backend->shutdown_func(options->backend);
         }
 
@@ -262,7 +262,7 @@ sentry_close(void)
         }
         sentry_options_free(options);
     } else {
-        SENTRY_DEBUG("sentry_close() called, but options was empty");
+        SENTRY_INFO("sentry_close() called, but options was empty");
     }
 
     g_options = NULL;
@@ -363,7 +363,7 @@ sentry__capture_envelope(
 {
     bool has_consent = !sentry__should_skip_upload();
     if (!has_consent) {
-        SENTRY_TRACE("discarding envelope due to missing user consent");
+        SENTRY_DEBUG("discarding envelope due to missing user consent");
         sentry_envelope_free(envelope);
         return;
     }
@@ -440,7 +440,7 @@ sentry__capture_event(sentry_value_t event)
 
             bool should_skip = !sentry__roll_dice(options->sample_rate);
             if (should_skip) {
-                SENTRY_DEBUG("throwing away event due to sample rate");
+                SENTRY_INFO("throwing away event due to sample rate");
                 sentry_envelope_free(envelope);
             } else {
                 sentry__capture_envelope(options->transport, envelope);
@@ -482,7 +482,7 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
     }
 
     SENTRY_WITH_SCOPE (scope) {
-        SENTRY_TRACE("merging scope into event");
+        SENTRY_DEBUG("merging scope into event");
         sentry_scope_mode_t mode = SENTRY_SCOPE_ALL;
         if (!options->symbolize_stacktraces) {
             mode &= ~SENTRY_SCOPE_STACKTRACES;
@@ -491,11 +491,11 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
     }
 
     if (options->before_send_func && invoke_before_send) {
-        SENTRY_TRACE("invoking `before_send` hook");
+        SENTRY_DEBUG("invoking `before_send` hook");
         event
             = options->before_send_func(event, NULL, options->before_send_data);
         if (sentry_value_is_null(event)) {
-            SENTRY_TRACE("event was discarded by the `before_send` hook");
+            SENTRY_DEBUG("event was discarded by the `before_send` hook");
             return NULL;
         }
     }
@@ -506,7 +506,7 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
         goto fail;
     }
 
-    SENTRY_TRACE("adding attachments to envelope");
+    SENTRY_DEBUG("adding attachments to envelope");
     for (sentry_attachment_t *attachment = options->attachments; attachment;
         attachment = attachment->next) {
         sentry_envelope_item_t *item = sentry__envelope_add_from_path(
@@ -538,7 +538,7 @@ sentry__prepare_transaction(const sentry_options_t *options,
     sentry_envelope_t *envelope = NULL;
 
     SENTRY_WITH_SCOPE (scope) {
-        SENTRY_TRACE("merging scope into transaction");
+        SENTRY_DEBUG("merging scope into transaction");
         // Don't include debugging info
         sentry_scope_mode_t mode = SENTRY_SCOPE_ALL & ~SENTRY_SCOPE_MODULES
             & ~SENTRY_SCOPE_STACKTRACES;
@@ -586,7 +586,7 @@ void
 sentry_handle_exception(const sentry_ucontext_t *uctx)
 {
     SENTRY_WITH_OPTIONS (options) {
-        SENTRY_DEBUG("handling exception");
+        SENTRY_INFO("handling exception");
         if (options->backend && options->backend->except_func) {
             options->backend->except_func(options->backend, uctx);
         }
@@ -906,7 +906,7 @@ sentry_transaction_finish_ts(
     sentry_transaction_t *opaque_tx, uint64_t timestamp)
 {
     if (!opaque_tx || sentry_value_is_null(opaque_tx->inner)) {
-        SENTRY_DEBUG("no transaction available to finish");
+        SENTRY_INFO("no transaction available to finish");
         goto fail;
     }
 
@@ -931,8 +931,8 @@ sentry_transaction_finish_ts(
     // `sentry__should_skip_transaction`.
     sentry_value_t sampled = sentry_value_get_by_key(tx, "sampled");
     if (!sentry_value_is_true(sampled)) {
-        SENTRY_DEBUG("throwing away transaction due to sample rate or "
-                     "user-provided sampling value in transaction context");
+        SENTRY_INFO("throwing away transaction due to sample rate or "
+                    "user-provided sampling value in transaction context");
         sentry_value_decref(tx);
         goto fail;
     }
@@ -1029,7 +1029,7 @@ sentry_transaction_start_child_ts_n(sentry_transaction_t *opaque_parent,
     size_t description_len, const uint64_t timestamp)
 {
     if (!opaque_parent || sentry_value_is_null(opaque_parent->inner)) {
-        SENTRY_DEBUG("no transaction available to create a child under");
+        SENTRY_INFO("no transaction available to create a child under");
         return NULL;
     }
     sentry_value_t parent = opaque_parent->inner;
@@ -1079,11 +1079,11 @@ sentry_span_start_child_ts_n(sentry_span_t *opaque_parent,
     size_t description_len, uint64_t timestamp)
 {
     if (!opaque_parent || sentry_value_is_null(opaque_parent->inner)) {
-        SENTRY_DEBUG("no parent span available to create a child span under");
+        SENTRY_INFO("no parent span available to create a child span under");
         return NULL;
     }
     if (!opaque_parent->transaction) {
-        SENTRY_DEBUG("no root transaction to create a child span under");
+        SENTRY_INFO("no root transaction to create a child span under");
         return NULL;
     }
     sentry_value_t parent = opaque_parent->inner;
@@ -1121,14 +1121,14 @@ void
 sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
 {
     if (!opaque_span || sentry_value_is_null(opaque_span->inner)) {
-        SENTRY_DEBUG("no span to finish");
+        SENTRY_INFO("no span to finish");
         goto fail;
     }
 
     sentry_transaction_t *opaque_root_transaction = opaque_span->transaction;
     if (!opaque_root_transaction
         || sentry_value_is_null(opaque_root_transaction->inner)) {
-        SENTRY_DEBUG(
+        SENTRY_INFO(
             "no root transaction to finish span on, aborting span finish");
         goto fail;
     }
@@ -1137,14 +1137,14 @@ sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
 
     if (!sentry_value_is_true(
             sentry_value_get_by_key(root_transaction, "sampled"))) {
-        SENTRY_DEBUG("root transaction is unsampled, dropping span");
+        SENTRY_INFO("root transaction is unsampled, dropping span");
         goto fail;
     }
 
     if (!sentry_value_is_null(
             sentry_value_get_by_key(root_transaction, "timestamp"))) {
-        SENTRY_DEBUG("span's root transaction is already finished, aborting "
-                     "span finish");
+        SENTRY_INFO("span's root transaction is already finished, aborting "
+                    "span finish");
         goto fail;
     }
 
@@ -1169,13 +1169,13 @@ sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
     // that's different from the span's root transaction, but let's just be safe
     // here.
     if (!sentry_value_is_true(sentry_value_get_by_key(span, "sampled"))) {
-        SENTRY_DEBUG("span is unsampled, dropping span");
+        SENTRY_INFO("span is unsampled, dropping span");
         sentry_value_decref(span);
         goto fail;
     }
 
     if (!sentry_value_is_null(sentry_value_get_by_key(span, "timestamp"))) {
-        SENTRY_DEBUG("span is already finished, aborting span finish");
+        SENTRY_INFO("span is already finished, aborting span finish");
         sentry_value_decref(span);
         goto fail;
     }
@@ -1193,8 +1193,8 @@ sentry_span_finish_ts(sentry_span_t *opaque_span, uint64_t timestamp)
     sentry_value_t spans = sentry_value_get_by_key(root_transaction, "spans");
 
     if (sentry_value_get_length(spans) >= max_spans) {
-        SENTRY_DEBUG("reached maximum number of spans for transaction, "
-                     "discarding span");
+        SENTRY_INFO("reached maximum number of spans for transaction, "
+                    "discarding span");
         sentry_value_decref(span);
         goto fail;
     }
@@ -1260,7 +1260,7 @@ sentry_capture_minidump_n(const char *path, size_t path_len)
         return;
     }
 
-    SENTRY_DEBUGF(
+    SENTRY_INFOF(
         "Capturing minidump \"%" SENTRY_PATH_PRI "\"", dump_path->path);
 
     sentry_value_t event = sentry_value_new_event();
@@ -1291,8 +1291,7 @@ sentry_capture_minidump_n(const char *path, size_t path_len)
 
             sentry__capture_envelope(options->transport, envelope);
 
-            SENTRY_DEBUGF("Minidump has been captured: \"%" SENTRY_PATH_PRI
-                          "\"",
+            SENTRY_INFOF("Minidump has been captured: \"%" SENTRY_PATH_PRI "\"",
                 dump_path->path);
         }
     }

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -100,11 +100,6 @@ sentry_init(sentry_options_t *options)
     if (options->debug) {
         logger = options->logger;
     }
-    sentry_logger_t old_logger = logger; // restore this after init
-    if (options->log_init) {
-        logger = options->logger;
-        logger.logger_level = options->init_logger_level;
-    }
     sentry__logger_set_global(logger);
 
     // we need to ensure the dir exists, otherwise `path_absolute` will fail.
@@ -204,8 +199,6 @@ sentry_init(sentry_options_t *options)
 #ifdef SENTRY_PLATFORM_WINDOWS
     sentry__init_cached_functions();
 #endif
-
-    sentry__logger_set_global(old_logger);
 
     sentry__mutex_unlock(&g_options_lock);
     return 0;

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -105,7 +105,7 @@ sentry__run_write_envelope(
     sentry__path_free(output_path);
 
     if (rv) {
-        SENTRY_INFO("writing envelope to file failed");
+        SENTRY_WARN("writing envelope to file failed");
     }
 
     // the `write_to_path` returns > 0 on failure, but we would like a real bool
@@ -131,7 +131,7 @@ sentry__run_write_session(
     sentry_free(buf);
 
     if (rv) {
-        SENTRY_INFO("writing session to file failed");
+        SENTRY_WARN("writing session to file failed");
     }
     return !rv;
 }
@@ -266,7 +266,7 @@ sentry__write_crash_marker(const sentry_options_t *options)
     sentry__path_free(marker_path);
 
     if (rv) {
-        SENTRY_INFO("writing crash timestamp to file failed");
+        SENTRY_WARN("writing crash timestamp to file failed");
     }
     return !rv;
 }
@@ -297,7 +297,7 @@ sentry__clear_crash_marker(const sentry_options_t *options)
     int rv = sentry__path_remove(marker_path);
     sentry__path_free(marker_path);
     if (rv) {
-        SENTRY_INFO("removing the crash timestamp file has failed");
+        SENTRY_WARN("removing the crash timestamp file has failed");
     }
     return !rv;
 }

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -105,7 +105,7 @@ sentry__run_write_envelope(
     sentry__path_free(output_path);
 
     if (rv) {
-        SENTRY_DEBUG("writing envelope to file failed");
+        SENTRY_INFO("writing envelope to file failed");
     }
 
     // the `write_to_path` returns > 0 on failure, but we would like a real bool
@@ -131,7 +131,7 @@ sentry__run_write_session(
     sentry_free(buf);
 
     if (rv) {
-        SENTRY_DEBUG("writing session to file failed");
+        SENTRY_INFO("writing session to file failed");
     }
     return !rv;
 }
@@ -266,7 +266,7 @@ sentry__write_crash_marker(const sentry_options_t *options)
     sentry__path_free(marker_path);
 
     if (rv) {
-        SENTRY_DEBUG("writing crash timestamp to file failed");
+        SENTRY_INFO("writing crash timestamp to file failed");
     }
     return !rv;
 }
@@ -297,7 +297,7 @@ sentry__clear_crash_marker(const sentry_options_t *options)
     int rv = sentry__path_remove(marker_path);
     sentry__path_free(marker_path);
     if (rv) {
-        SENTRY_DEBUG("removing the crash timestamp file has failed");
+        SENTRY_INFO("removing the crash timestamp file has failed");
     }
     return !rv;
 }

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -413,7 +413,7 @@ sentry__envelope_serialize_into_stringbuilder(
         return;
     }
 
-    SENTRY_TRACE("serializing envelope into buffer");
+    SENTRY_DEBUG("serializing envelope into buffer");
     sentry__envelope_serialize_headers_into_stringbuilder(envelope, sb);
 
     for (size_t i = 0; i < envelope->contents.items.item_count; i++) {

--- a/src/sentry_logger.c
+++ b/src/sentry_logger.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
-static sentry_logger_t g_logger = { NULL, NULL };
+static sentry_logger_t g_logger = { NULL, NULL, SENTRY_LEVEL_DEBUG };
 
 void
 sentry__logger_set_global(sentry_logger_t logger)
@@ -87,6 +87,10 @@ sentry__logger_describe(sentry_level_t level)
 void
 sentry__logger_log(sentry_level_t level, const char *message, ...)
 {
+    if (g_logger.logger_level != SENTRY_LEVEL_DEBUG
+        && level < g_logger.logger_level) {
+        return;
+    }
     sentry_logger_t logger = g_logger;
     if (logger.logger_func) {
         va_list args;

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -18,8 +18,6 @@ const char *sentry__logger_describe(sentry_level_t level);
 
 void sentry__logger_log(sentry_level_t level, const char *message, ...);
 
-void sentry_logger_log(sentry_level_t level, const char *message);
-
 #define SENTRY_TRACEF(message, ...)                                            \
     sentry__logger_log(SENTRY_LEVEL_DEBUG, message, __VA_ARGS__)
 

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -18,15 +18,15 @@ const char *sentry__logger_describe(sentry_level_t level);
 
 void sentry__logger_log(sentry_level_t level, const char *message, ...);
 
-#define SENTRY_TRACEF(message, ...)                                            \
+#define SENTRY_DEBUGF(message, ...)                                            \
     sentry__logger_log(SENTRY_LEVEL_DEBUG, message, __VA_ARGS__)
 
-#define SENTRY_TRACE(message) sentry__logger_log(SENTRY_LEVEL_DEBUG, message)
+#define SENTRY_DEBUG(message) sentry__logger_log(SENTRY_LEVEL_DEBUG, message)
 
-#define SENTRY_DEBUGF(message, ...)                                            \
+#define SENTRY_INFOF(message, ...)                                             \
     sentry__logger_log(SENTRY_LEVEL_INFO, message, __VA_ARGS__)
 
-#define SENTRY_DEBUG(message) sentry__logger_log(SENTRY_LEVEL_INFO, message)
+#define SENTRY_INFO(message) sentry__logger_log(SENTRY_LEVEL_INFO, message)
 
 #define SENTRY_WARNF(message, ...)                                             \
     sentry__logger_log(SENTRY_LEVEL_WARNING, message, __VA_ARGS__)

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -6,6 +6,7 @@
 typedef struct {
     sentry_logger_function_t logger_func;
     void *logger_data;
+    sentry_level_t logger_level;
 } sentry_logger_t;
 
 void sentry__logger_set_global(sentry_logger_t logger);
@@ -16,6 +17,8 @@ void sentry__logger_defaultlogger(
 const char *sentry__logger_describe(sentry_level_t level);
 
 void sentry__logger_log(sentry_level_t level, const char *message, ...);
+
+void sentry_logger_log(sentry_level_t level, const char *message);
 
 #define SENTRY_TRACEF(message, ...)                                            \
     sentry__logger_log(SENTRY_LEVEL_DEBUG, message, __VA_ARGS__)

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -367,11 +367,7 @@ sentry_options_get_user_agent(const sentry_options_t *opts)
 void
 sentry_options_set_debug(sentry_options_t *opts, int debug)
 {
-    if (!!debug) {
-        sentry_options_set_logger_level(opts, SENTRY_LEVEL_DEBUG);
-    } else {
-        opts->debug = false;
-    }
+    opts->debug = !!debug;
 }
 
 int
@@ -405,14 +401,6 @@ void
 sentry_options_set_logger_level(sentry_options_t *opts, sentry_level_t level)
 {
     opts->logger.logger_level = level;
-    opts->debug = true;
-}
-
-void
-sentry_options_set_init_log_level(sentry_options_t *opts, sentry_level_t level)
-{
-    opts->init_logger_level = level;
-    opts->log_init = true;
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -22,7 +22,8 @@ sentry_options_new(void)
     sentry_options_set_dsn(opts, getenv("SENTRY_DSN"));
     const char *debug = getenv("SENTRY_DEBUG");
     opts->debug = debug && sentry__string_eq(debug, "1");
-    sentry_logger_t logger = { sentry__logger_defaultlogger, NULL };
+    sentry_logger_t logger
+        = { sentry__logger_defaultlogger, NULL, SENTRY_LEVEL_DEBUG };
     opts->logger = logger;
     opts->transport_thread_name = sentry__string_clone("sentry-http");
 #ifdef SENTRY_PLATFORM_WINDOWS
@@ -394,6 +395,12 @@ sentry_options_set_logger(
 {
     opts->logger.logger_func = func;
     opts->logger.logger_data = userdata;
+}
+
+void
+sentry_options_set_logger_level(sentry_options_t *opts, sentry_level_t level)
+{
+    opts->logger.logger_level = level;
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -367,7 +367,11 @@ sentry_options_get_user_agent(const sentry_options_t *opts)
 void
 sentry_options_set_debug(sentry_options_t *opts, int debug)
 {
-    opts->debug = !!debug;
+    if (!!debug) {
+        sentry_options_set_logger_level(opts, SENTRY_LEVEL_DEBUG);
+    } else {
+        opts->debug = false;
+    }
 }
 
 int
@@ -401,6 +405,14 @@ void
 sentry_options_set_logger_level(sentry_options_t *opts, sentry_level_t level)
 {
     opts->logger.logger_level = level;
+    opts->debug = true;
+}
+
+void
+sentry_options_set_init_log_level(sentry_options_t *opts, sentry_level_t level)
+{
+    opts->init_logger_level = level;
+    opts->log_init = true;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -43,6 +43,8 @@ typedef struct sentry_options_s {
     sentry_path_t *database_path;
     sentry_path_t *handler_path;
     sentry_logger_t logger;
+    sentry_level_t init_logger_level;
+    bool log_init;
     size_t max_breadcrumbs;
     bool debug;
     bool auto_session_tracking;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -43,8 +43,6 @@ typedef struct sentry_options_s {
     sentry_path_t *database_path;
     sentry_path_t *handler_path;
     sentry_logger_t logger;
-    sentry_level_t init_logger_level;
-    bool log_init;
     size_t max_breadcrumbs;
     bool debug;
     bool auto_session_tracking;

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -226,7 +226,7 @@ SENTRY_THREAD_FN
 worker_thread(void *data)
 {
     sentry_bgworker_t *bgw = data;
-    SENTRY_TRACE("background worker thread started");
+    SENTRY_DEBUG("background worker thread started");
 
     // should be called inside thread itself because of MSVC issues and mac
     // https://randomascii.wordpress.com/2015/10/26/thread-naming-in-windows-time-for-something-better/
@@ -258,7 +258,7 @@ worker_thread(void *data)
         sentry__task_incref(task);
         sentry__mutex_unlock(&bgw->task_lock);
 
-        SENTRY_TRACE("executing task on worker thread");
+        SENTRY_DEBUG("executing task on worker thread");
         task->exec_func(task->task_data, bgw->state);
         // the task can have a refcount of 2, this `decref` here corresponds
         // to the `incref` above which signifies that the task _is being
@@ -277,7 +277,7 @@ worker_thread(void *data)
             sentry__task_decref(task);
         }
     }
-    SENTRY_TRACE("background worker thread shut down");
+    SENTRY_DEBUG("background worker thread shut down");
     // this decref corresponds to the one done below in `sentry__bgworker_start`
     sentry__bgworker_decref(bgw);
     return 0;
@@ -286,7 +286,7 @@ worker_thread(void *data)
 int
 sentry__bgworker_start(sentry_bgworker_t *bgw)
 {
-    SENTRY_TRACE("starting background worker thread");
+    SENTRY_DEBUG("starting background worker thread");
     sentry__atomic_store(&bgw->running, 1);
     // this incref moves the reference into the background thread
     sentry__bgworker_incref(bgw);
@@ -332,7 +332,7 @@ sentry__bgworker_flush(sentry_bgworker_t *bgw, uint64_t timeout)
         SENTRY_WARN("trying to flush non-running thread");
         return 0;
     }
-    SENTRY_TRACE("flushing background worker thread");
+    SENTRY_DEBUG("flushing background worker thread");
 
     sentry_flush_task_t *flush_task
         = sentry_malloc(sizeof(sentry_flush_task_t));
@@ -384,7 +384,7 @@ sentry__bgworker_shutdown(sentry_bgworker_t *bgw, uint64_t timeout)
         SENTRY_WARN("trying to shut down non-running thread");
         return 0;
     }
-    SENTRY_TRACE("shutting down background worker thread");
+    SENTRY_DEBUG("shutting down background worker thread");
 
     /* submit a task to shut down the queue */
     sentry__bgworker_submit(bgw, shutdown_task, NULL, bgw);
@@ -431,7 +431,7 @@ sentry__bgworker_submit(sentry_bgworker_t *bgw,
     task->cleanup_func = cleanup_func;
     task->task_data = task_data;
 
-    SENTRY_TRACE("submitting task to background worker thread");
+    SENTRY_DEBUG("submitting task to background worker thread");
     sentry__mutex_lock(&bgw->task_lock);
     if (!bgw->first_task) {
         bgw->first_task = task;

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -359,7 +359,7 @@ sentry__value_span_new_n(size_t max_spans, sentry_value_t parent,
     sentry_slice_t operation, sentry_slice_t description, uint64_t timestamp)
 {
     if (!sentry_value_is_null(sentry_value_get_by_key(parent, "timestamp"))) {
-        SENTRY_INFO("span's parent is already finished, not creating span");
+        SENTRY_WARN("span's parent is already finished, not creating span");
         goto fail;
     }
 
@@ -368,7 +368,7 @@ sentry__value_span_new_n(size_t max_spans, sentry_value_t parent,
     // number of max spans. This means that the number of in-flight spans
     // can exceed the max number of spans.
     if (sentry_value_get_length(spans) >= max_spans) {
-        SENTRY_INFO("reached maximum number of spans for transaction, not "
+        SENTRY_WARN("reached maximum number of spans for transaction, not "
                     "creating span");
         goto fail;
     }

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -359,7 +359,7 @@ sentry__value_span_new_n(size_t max_spans, sentry_value_t parent,
     sentry_slice_t operation, sentry_slice_t description, uint64_t timestamp)
 {
     if (!sentry_value_is_null(sentry_value_get_by_key(parent, "timestamp"))) {
-        SENTRY_DEBUG("span's parent is already finished, not creating span");
+        SENTRY_INFO("span's parent is already finished, not creating span");
         goto fail;
     }
 
@@ -368,8 +368,8 @@ sentry__value_span_new_n(size_t max_spans, sentry_value_t parent,
     // number of max spans. This means that the number of in-flight spans
     // can exceed the max number of spans.
     if (sentry_value_get_length(spans) >= max_spans) {
-        SENTRY_DEBUG("reached maximum number of spans for transaction, not "
-                     "creating span");
+        SENTRY_INFO("reached maximum number of spans for transaction, not "
+                    "creating span");
         goto fail;
     }
 

--- a/src/sentry_transport.c
+++ b/src/sentry_transport.c
@@ -84,7 +84,7 @@ sentry__transport_send_envelope(
         return;
     }
     if (!transport) {
-        SENTRY_DEBUG("discarding envelope due to invalid transport");
+        SENTRY_WARN("discarding envelope due to invalid transport");
         sentry_envelope_free(envelope);
         return;
     }
@@ -175,7 +175,7 @@ gzipped_with_compression(const char *body, const size_t body_len,
     int err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
         MAX_WBITS + 16, 9, Z_DEFAULT_STRATEGY);
     if (err != Z_OK) {
-        SENTRY_DEBUGF("deflateInit2 failed: %d", err);
+        SENTRY_WARNF("deflateInit2 failed: %d", err);
         return false;
     }
 
@@ -193,7 +193,7 @@ gzipped_with_compression(const char *body, const size_t body_len,
     }
 
     if (err != Z_STREAM_END) {
-        SENTRY_DEBUGF("deflate failed: %d", err);
+        SENTRY_WARNF("deflate failed: %d", err);
         sentry_free(buffer);
         buffer = NULL;
         deflateEnd(&stream);

--- a/src/sentry_transport.c
+++ b/src/sentry_transport.c
@@ -84,11 +84,11 @@ sentry__transport_send_envelope(
         return;
     }
     if (!transport) {
-        SENTRY_TRACE("discarding envelope due to invalid transport");
+        SENTRY_DEBUG("discarding envelope due to invalid transport");
         sentry_envelope_free(envelope);
         return;
     }
-    SENTRY_TRACE("sending envelope");
+    SENTRY_DEBUG("sending envelope");
     transport->send_envelope_func(envelope, transport->state);
 }
 
@@ -97,7 +97,7 @@ sentry__transport_startup(
     sentry_transport_t *transport, const sentry_options_t *options)
 {
     if (transport->startup_func) {
-        SENTRY_TRACE("starting transport");
+        SENTRY_DEBUG("starting transport");
         int rv = transport->startup_func(options, transport->state);
         transport->running = rv == 0;
         return rv;
@@ -109,7 +109,7 @@ int
 sentry__transport_flush(sentry_transport_t *transport, uint64_t timeout)
 {
     if (transport->flush_func && transport->running) {
-        SENTRY_TRACE("flushing transport");
+        SENTRY_DEBUG("flushing transport");
         return transport->flush_func(timeout, transport->state);
     }
     return 0;
@@ -119,7 +119,7 @@ int
 sentry__transport_shutdown(sentry_transport_t *transport, uint64_t timeout)
 {
     if (transport->shutdown_func && transport->running) {
-        SENTRY_TRACE("shutting down transport");
+        SENTRY_DEBUG("shutting down transport");
         transport->running = false;
         return transport->shutdown_func(timeout, transport->state);
     }
@@ -141,7 +141,7 @@ sentry__transport_dump_queue(sentry_transport_t *transport, sentry_run_t *run)
     }
     size_t dumped = transport->dump_func(run, transport->state);
     if (dumped) {
-        SENTRY_TRACEF("dumped %zu in-flight envelopes to disk", dumped);
+        SENTRY_DEBUGF("dumped %zu in-flight envelopes to disk", dumped);
     }
     return dumped;
 }
@@ -175,7 +175,7 @@ gzipped_with_compression(const char *body, const size_t body_len,
     int err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
         MAX_WBITS + 16, 9, Z_DEFAULT_STRATEGY);
     if (err != Z_OK) {
-        SENTRY_TRACEF("deflateInit2 failed: %d", err);
+        SENTRY_DEBUGF("deflateInit2 failed: %d", err);
         return false;
     }
 
@@ -193,7 +193,7 @@ gzipped_with_compression(const char *body, const size_t body_len,
     }
 
     if (err != Z_STREAM_END) {
-        SENTRY_TRACEF("deflate failed: %d", err);
+        SENTRY_DEBUGF("deflate failed: %d", err);
         sentry_free(buffer);
         buffer = NULL;
         deflateEnd(&stream);

--- a/src/transports/sentry_function_transport.c
+++ b/src/transports/sentry_function_transport.c
@@ -21,7 +21,7 @@ sentry_transport_t *
 sentry_new_function_transport(
     void (*func)(const sentry_envelope_t *envelope, void *data), void *data)
 {
-    SENTRY_DEBUG("initializing function transport");
+    SENTRY_INFO("initializing function transport");
     struct transport_state *state = SENTRY_MAKE(struct transport_state);
     if (!state) {
         return NULL;

--- a/src/transports/sentry_transport_curl.c
+++ b/src/transports/sentry_transport_curl.c
@@ -285,7 +285,7 @@ sentry__curl_dump_queue(sentry_run_t *run, void *transport_state)
 sentry_transport_t *
 sentry__transport_new_default(void)
 {
-    SENTRY_DEBUG("initializing curl transport");
+    SENTRY_INFO("initializing curl transport");
     curl_bgworker_state_t *state = sentry__curl_bgworker_state_new();
     if (!state) {
         return NULL;

--- a/src/transports/sentry_transport_winhttp.c
+++ b/src/transports/sentry_transport_winhttp.c
@@ -206,7 +206,7 @@ sentry__winhttp_send_task(void *_envelope, void *_state)
     headers = sentry__string_to_wstr(headers_buf);
     sentry_free(headers_buf);
 
-    SENTRY_TRACEF(
+    SENTRY_DEBUGF(
         "sending request using winhttp to \"%s\":\n%S", req->url, headers);
 
     if (WinHttpSendRequest(state->request, headers, (DWORD)-1,
@@ -232,7 +232,7 @@ sentry__winhttp_send_task(void *_envelope, void *_state)
                         WINHTTP_QUERY_RAW_HEADERS_CRLF,
                         WINHTTP_HEADER_NAME_BY_INDEX, lpOutBuffer, &dwSize,
                         WINHTTP_NO_HEADER_INDEX)) {
-                    SENTRY_TRACEF(
+                    SENTRY_DEBUGF(
                         "received response:\n%S", (wchar_t *)lpOutBuffer);
                 }
                 sentry_free(lpOutBuffer);
@@ -271,12 +271,12 @@ sentry__winhttp_send_task(void *_envelope, void *_state)
             sentry__rate_limiter_update_from_429(state->ratelimiter);
         }
     } else {
-        SENTRY_DEBUGF(
+        SENTRY_INFOF(
             "`WinHttpSendRequest` failed with code `%d`", GetLastError());
     }
 
     uint64_t now = sentry__monotonic_time();
-    SENTRY_TRACEF("request handled in %llums", now - started);
+    SENTRY_DEBUGF("request handled in %llums", now - started);
 
 exit:
     if (state->request) {
@@ -318,7 +318,7 @@ sentry__winhttp_dump_queue(sentry_run_t *run, void *transport_state)
 sentry_transport_t *
 sentry__transport_new_default(void)
 {
-    SENTRY_DEBUG("initializing winhttp transport");
+    SENTRY_INFO("initializing winhttp transport");
     winhttp_bgworker_state_t *state = sentry__winhttp_bgworker_state_new();
     if (!state) {
         return NULL;

--- a/src/transports/sentry_transport_winhttp.c
+++ b/src/transports/sentry_transport_winhttp.c
@@ -271,7 +271,7 @@ sentry__winhttp_send_task(void *_envelope, void *_state)
             sentry__rate_limiter_update_from_429(state->ratelimiter);
         }
     } else {
-        SENTRY_INFOF(
+        SENTRY_WARNF(
             "`WinHttpSendRequest` failed with code `%d`", GetLastError());
     }
 

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -105,11 +105,11 @@ send_sampled_envelope(const sentry_envelope_t *envelope, void *data)
 {
     session_assertion_t *assertion = data;
 
-    SENTRY_DEBUG("send_sampled_envelope");
+    SENTRY_INFO("send_sampled_envelope");
     if (assertion->assert_session) {
         assertion->called += 1;
 
-        SENTRY_DEBUG("assertion + 1");
+        SENTRY_INFO("assertion + 1");
 
         TEST_CHECK_INT_EQUAL(sentry__envelope_get_item_count(envelope), 1);
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-native/issues/888
Related to https://github.com/getsentry/sentry-cocoa/issues/4467

The main goal is to allow for outputting just the warnings from `sentry_init`. To accommodate this, we introduce log levels as a way to control what level of output the user gets. We decided against splitting up these levels into `init`-only and global levels, since this doesn't seem like a necessary feature as of yet.