### PR TITLE
fix: provide non-static recursive mutex initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 - Add `traces_sampler`. ([#1108](https://github.com/getsentry/sentry-native/pull/1108))
 - Provide support for C++17 compilers when using the `crashpad` backend. ([#1110](https://github.com/getsentry/sentry-native/pull/1110), [crashpad#116](https://github.com/getsentry/crashpad/pull/116), [mini_chromium#1](https://github.com/getsentry/mini_chromium/pull/1))
 
+**Fixes**:
+
+- Provide a mutex-initializer on platforms that have no static pthread initializer for recursive mutexes. ([#1113](https://github.com/getsentry/sentry-native/pull/1113))
+
 ## 0.7.17
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Provide a mutex-initializer on platforms that have no static pthread initializer for recursive mutexes. ([#1113](https://github.com/getsentry/sentry-native/pull/1113))
+
 ## 0.8.1
 
 **Features**:
@@ -51,10 +57,6 @@
 - Add option to set debug log level. ([#1107](https://github.com/getsentry/sentry-native/pull/1107))
 - Add `traces_sampler`. ([#1108](https://github.com/getsentry/sentry-native/pull/1108))
 - Provide support for C++17 compilers when using the `crashpad` backend. ([#1110](https://github.com/getsentry/sentry-native/pull/1110), [crashpad#116](https://github.com/getsentry/crashpad/pull/116), [mini_chromium#1](https://github.com/getsentry/mini_chromium/pull/1))
-
-**Fixes**:
-
-- Provide a mutex-initializer on platforms that have no static pthread initializer for recursive mutexes. ([#1113](https://github.com/getsentry/sentry-native/pull/1113))
 
 ## 0.7.17
 

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -37,7 +37,17 @@ process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
     goto fail
 
 static bool g_initialized = false;
+#ifdef SENTRY__MUTEX_INIT_DYN
+static sentry_mutex_t g_mutex;
+static pthread_once_t g_mutex_init_once = PTHREAD_ONCE_INIT;
+static void
+init_g_mutex(void)
+{
+    sentry__mutex_init(&g_mutex);
+}
+#else
 static sentry_mutex_t g_mutex = SENTRY__MUTEX_INIT;
+#endif
 static sentry_value_t g_modules = { 0 };
 
 static sentry_slice_t LINUX_GATE = { "linux-gate.so", 13 };
@@ -722,6 +732,9 @@ load_modules(sentry_value_t modules)
 sentry_value_t
 sentry_get_modules_list(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_mutex_init_once, init_g_mutex);
+#endif
     sentry__mutex_lock(&g_mutex);
     if (!g_initialized) {
         g_modules = sentry_value_new_list();
@@ -741,6 +754,9 @@ sentry_get_modules_list(void)
 void
 sentry_clear_modulecache(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_mutex_init_once, init_g_mutex);
+#endif
     sentry__mutex_lock(&g_mutex);
     sentry_value_decref(g_modules);
     g_modules = sentry_value_new_null();

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -38,13 +38,7 @@ process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
 
 static bool g_initialized = false;
 #ifdef SENTRY__MUTEX_INIT_DYN
-static sentry_mutex_t g_mutex;
-static pthread_once_t g_mutex_init_once = PTHREAD_ONCE_INIT;
-static void
-init_g_mutex(void)
-{
-    sentry__mutex_init(&g_mutex);
-}
+SENTRY__MUTEX_INIT_DYN(g_mutex)
 #else
 static sentry_mutex_t g_mutex = SENTRY__MUTEX_INIT;
 #endif
@@ -732,9 +726,7 @@ load_modules(sentry_value_t modules)
 sentry_value_t
 sentry_get_modules_list(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_mutex_init_once, init_g_mutex);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_mutex);
     sentry__mutex_lock(&g_mutex);
     if (!g_initialized) {
         g_modules = sentry_value_new_list();
@@ -754,9 +746,7 @@ sentry_get_modules_list(void)
 void
 sentry_clear_modulecache(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_mutex_init_once, init_g_mutex);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_mutex);
     sentry__mutex_lock(&g_mutex);
     sentry_value_decref(g_modules);
     g_modules = sentry_value_new_null();

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -25,13 +25,7 @@
 
 static sentry_options_t *g_options = NULL;
 #ifdef SENTRY__MUTEX_INIT_DYN
-static sentry_mutex_t g_options_lock;
-static pthread_once_t g_options_lock_init_once = PTHREAD_ONCE_INIT;
-static void
-init_g_options_lock(void)
-{
-    sentry__mutex_init(&g_options_lock);
-}
+SENTRY__MUTEX_INIT_DYN(g_options_lock)
 #else
 static sentry_mutex_t g_options_lock = SENTRY__MUTEX_INIT;
 #endif
@@ -41,9 +35,7 @@ static int g_last_crash = -1;
 const sentry_options_t *
 sentry__options_getref(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_options_lock_init_once, init_g_options_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_options_lock);
     sentry_options_t *options;
     sentry__mutex_lock(&g_options_lock);
     options = sentry__options_incref(g_options);
@@ -54,9 +46,7 @@ sentry__options_getref(void)
 sentry_options_t *
 sentry__options_lock(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_options_lock_init_once, init_g_options_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_options_lock);
     sentry__mutex_lock(&g_options_lock);
     return g_options;
 }
@@ -64,9 +54,7 @@ sentry__options_lock(void)
 void
 sentry__options_unlock(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_options_lock_init_once, init_g_options_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_options_lock);
     sentry__mutex_unlock(&g_options_lock);
 }
 
@@ -106,9 +94,7 @@ sentry__should_skip_upload(void)
 int
 sentry_init(sentry_options_t *options)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_options_lock_init_once, init_g_options_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_options_lock);
     // this function is to be called only once, so we do not allow more than one
     // caller
     sentry__mutex_lock(&g_options_lock);
@@ -247,9 +233,7 @@ sentry_flush(uint64_t timeout)
 int
 sentry_close(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_options_lock_init_once, init_g_options_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_options_lock);
     // this function is to be called only once, so we do not allow more than one
     // caller
     sentry__mutex_lock(&g_options_lock);

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -22,7 +22,17 @@
 
 static bool g_scope_initialized = false;
 static sentry_scope_t g_scope = { 0 };
+#ifdef SENTRY__MUTEX_INIT_DYN
+static sentry_mutex_t g_lock;
+static pthread_once_t g_lock_init_once = PTHREAD_ONCE_INIT;
+static void
+init_g_lock(void)
+{
+    sentry__mutex_init(&g_lock);
+}
+#else
 static sentry_mutex_t g_lock = SENTRY__MUTEX_INIT;
+#endif
 
 static sentry_value_t
 get_client_sdk(void)
@@ -87,6 +97,9 @@ get_scope(void)
 void
 sentry__scope_cleanup(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_lock_init_once, init_g_lock);
+#endif
     sentry__mutex_lock(&g_lock);
     if (g_scope_initialized) {
         g_scope_initialized = false;
@@ -107,6 +120,9 @@ sentry__scope_cleanup(void)
 sentry_scope_t *
 sentry__scope_lock(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_lock_init_once, init_g_lock);
+#endif
     sentry__mutex_lock(&g_lock);
     return get_scope();
 }
@@ -114,6 +130,9 @@ sentry__scope_lock(void)
 void
 sentry__scope_unlock(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_lock_init_once, init_g_lock);
+#endif
     sentry__mutex_unlock(&g_lock);
 }
 

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -23,13 +23,7 @@
 static bool g_scope_initialized = false;
 static sentry_scope_t g_scope = { 0 };
 #ifdef SENTRY__MUTEX_INIT_DYN
-static sentry_mutex_t g_lock;
-static pthread_once_t g_lock_init_once = PTHREAD_ONCE_INIT;
-static void
-init_g_lock(void)
-{
-    sentry__mutex_init(&g_lock);
-}
+SENTRY__MUTEX_INIT_DYN(g_lock)
 #else
 static sentry_mutex_t g_lock = SENTRY__MUTEX_INIT;
 #endif
@@ -97,9 +91,7 @@ get_scope(void)
 void
 sentry__scope_cleanup(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_lock_init_once, init_g_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_lock);
     sentry__mutex_lock(&g_lock);
     if (g_scope_initialized) {
         g_scope_initialized = false;
@@ -120,9 +112,7 @@ sentry__scope_cleanup(void)
 sentry_scope_t *
 sentry__scope_lock(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_lock_init_once, init_g_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_lock);
     sentry__mutex_lock(&g_lock);
     return get_scope();
 }
@@ -130,9 +120,7 @@ sentry__scope_lock(void)
 void
 sentry__scope_unlock(void)
 {
-#ifdef SENTRY__MUTEX_INIT_DYN
-    pthread_once(&g_lock_init_once, init_g_lock);
-#endif
+    SENTRY__MUTEX_INIT_DYN_ONCE(g_lock);
     sentry__mutex_unlock(&g_lock);
 }
 

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -7,6 +7,9 @@
 #include <assert.h>
 #include <stdio.h>
 
+// This is a NOP for platforms that support static mutex initialization.
+#    define SENTRY__MUTEX_INIT_DYN_ONCE(Mutex) ((void)0)
+
 #ifdef _MSC_VER
 #    define THREAD_FUNCTION_API __stdcall
 #else
@@ -228,8 +231,7 @@ void sentry__leave_signal_handler(void);
 typedef pthread_t sentry_threadid_t;
 typedef pthread_mutex_t sentry_mutex_t;
 typedef pthread_cond_t sentry_cond_t;
-// This is a NOP for platforms that support static mutex initialization.
-#    define SENTRY__MUTEX_INIT_DYN_ONCE(Mutex) ((void)0)
+
 #    ifdef SENTRY_PLATFORM_LINUX
 #        ifndef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
 // In particular musl libc does not define a recursive initializer itself.

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -263,9 +263,8 @@ typedef pthread_cond_t sentry_cond_t;
                 }                                                              \
             }
 #    elif defined(__FreeBSD__)
-// Don't define SENTRY__MUTEX_INIT for platforms that require dynamic
-// initialization, but instead create a new definition that can be used by
-// platforms requiring dynamic recursive mutex initialization.
+// Don't define `SENTRY__MUTEX_INIT` but instead provide a new definition that
+// can be used by platforms requiring dynamic recursive mutex initialization.
 #        define SENTRY__MUTEX_INIT_DYN
 #    else
 #        define SENTRY__MUTEX_INIT PTHREAD_RECURSIVE_MUTEX_INITIALIZER

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 // This is a NOP for platforms that support static mutex initialization.
-#    define SENTRY__MUTEX_INIT_DYN_ONCE(Mutex) ((void)0)
+#define SENTRY__MUTEX_INIT_DYN_ONCE(Mutex) ((void)0)
 
 #ifdef _MSC_VER
 #    define THREAD_FUNCTION_API __stdcall

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -262,10 +262,15 @@ typedef pthread_cond_t sentry_cond_t;
                         PTHREAD_MUTEX_RECURSIVE                                \
                 }                                                              \
             }
+#    elif defined(__FreeBSD__)
+// Don't define SENTRY__MUTEX_INIT for platforms that require dynamic
+// initialization, but instead create a new definition that can be used by
+// platforms requiring dynamic recursive mutex initialization.
+#        define SENTRY__MUTEX_INIT_DYN
 #    else
 #        define SENTRY__MUTEX_INIT PTHREAD_RECURSIVE_MUTEX_INITIALIZER
 #    endif
-#    ifndef __FreeBSD__
+#    ifdef SENTRY__MUTEX_INIT_DYN
 #        define sentry__mutex_init(Mutex)                                      \
             do {                                                               \
                 pthread_mutexattr_t attr;                                      \

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -271,7 +271,7 @@ typedef pthread_cond_t sentry_cond_t;
                 pthread_mutexattr_t attr;                                      \
                 pthread_mutexattr_init(&attr);                                 \
                 pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);     \
-                pthread_mutex_init(Mutex, &attr);                           \
+                pthread_mutex_init(Mutex, &attr);                              \
                 pthread_mutexattr_destroy(&attr);                              \
             } while (0)
 #    else


### PR DESCRIPTION
Potentially fixes #1090 by providing another mutex initializer that manually constructs a recursive mutex instead of relying on a static initialization formula (which either the `pthread` library or we provide).