### PR TITLE
docs: update sampling context parameter description

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1548,7 +1548,7 @@ typedef double (*sentry_traces_sampler_function)(
 /**
  * Sets the traces sampler callback. Should be a function that returns a double
  * and takes in a sentry_transaction_context_t pointer, a sentry_value_t for
- * a custom sampling context and a int pointer for the parent sampled flag.
+ * a custom sampling context and an int pointer for the parent sampled flag.
  */
 SENTRY_EXPERIMENTAL_API void sentry_options_set_traces_sampler(
     sentry_options_t *opts, sentry_traces_sampler_function callback);
@@ -1736,9 +1736,7 @@ SENTRY_EXPERIMENTAL_API void sentry_transaction_context_update_from_header_n(
  * constructed by a user.
  *
  * The second parameter is a custom Sampling Context to be used with a Traces
- * Sampler to make a more informed sampling decision. The SDK does not currently
- * support a custom Traces Sampler and this parameter is ignored for the time
- * being but needs to be provided.
+ * Sampler to allow you to make a more informed sampling decision.
  *
  * Returns a Transaction, which is expected to be manually managed by the
  * caller. Manual management involves ensuring that `sentry_transaction_finish`


### PR DESCRIPTION
We forgot to remove the note that the sampling context parameter is ignored for `sentry_transaction_start()` in #1108. Mentioned here: https://github.com/getsentry/sentry-native/pull/1108#issuecomment-2591077952

#skip-changelog