### PR TITLE
fix: initialize local variable to prevent c4701 warning on windows arm

### DIFF
--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -406,6 +406,8 @@ sentry__roll_dice(double probability)
 sentry_uuid_t
 sentry__capture_event(sentry_value_t event)
 {
+    // `event_id` is only used as an argument to pure output parameters.
+    // Initialization only happens to prevent compiler warnings.
     sentry_uuid_t event_id = sentry_uuid_nil();
     sentry_envelope_t *envelope = NULL;
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -406,7 +406,7 @@ sentry__roll_dice(double probability)
 sentry_uuid_t
 sentry__capture_event(sentry_value_t event)
 {
-    sentry_uuid_t event_id;
+    sentry_uuid_t event_id = sentry_uuid_nil();
     sentry_envelope_t *envelope = NULL;
 
     bool was_captured = false;


### PR DESCRIPTION
When trying to build the sentry toolchain on windows arm, I am seeing the following warning:

```
1>------ Build started: Project: sentry, Configuration: Debug ARM64 ------
1>sentry_core.c
sentry-native\src\sentry_core.c(404,1): error C2220: the following warning is treated as an error
sentry-native\src\sentry_core.c(404,1): warning C4701: potentially uninitialized local variable 'event_id' used
1>Done building project "sentry.vcxproj" -- FAILED.
```

When we compile the sentry code, we enable warnings as errors globally and hit this warning which fails our builds unless we disable it. It looks like a simple fix. It appears on arm, a separate optimization path is hit and spits out this warning, but it doesn't create the same warning in an x86_64 build. Would like to just get this updated as I think it is also more "correct" this way as well!

#skip-changelog