### PR TITLE
fix: support crashpad PAC-stripping on older assemblers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Allow older toolchains with assemblers that don't support PAC-stripping instructions on `aarch64` to compile `crashpad`. ([#1125](https://github.com/getsentry/sentry-native/pull/1125), [crashpad#118](https://github.com/getsentry/crashpad/pull/118))
+
 ## 0.7.19
 
 **Fixes**:


### PR DESCRIPTION
fixes: #1123
details: https://github.com/getsentry/crashpad/pull/118