### PR TITLE
feat: enable debug-option by default in debug-build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Enable debug-option by default when running in a debug-build. ([#1128](https://github.com/getsentry/sentry-native/pull/1128))
+
 ## 0.7.19
 
 **Fixes**:

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -22,6 +22,11 @@ sentry_options_new(void)
     sentry_options_set_dsn(opts, getenv("SENTRY_DSN"));
     const char *debug = getenv("SENTRY_DEBUG");
     opts->debug = debug && sentry__string_eq(debug, "1");
+#if !defined(NDEBUG)
+    if (!opts->debug && (!debug || !sentry__string_eq(debug, "0"))) {
+        opts->debug = 1;
+    }
+#endif
     sentry_logger_t logger
         = { sentry__logger_defaultlogger, NULL, SENTRY_LEVEL_DEBUG };
     opts->logger = logger;


### PR DESCRIPTION
fixes: #1121

The implementation allows users to set the environment variable `SENTRY_DEBUG` to `0` to override.