### PR TITLE
fix: set default `max_spans` to 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Fixes**:
 
 - Allow older toolchains with assemblers that don't support PAC-stripping instructions on `aarch64` to compile `crashpad`. ([#1125](https://github.com/getsentry/sentry-native/pull/1125), [crashpad#118](https://github.com/getsentry/crashpad/pull/118))
+- Set default `max_spans` to 1000. ([#1132](https://github.com/getsentry/sentry-native/pull/1132))
 
 ## 0.7.19
 

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -62,7 +62,7 @@ sentry_options_new(void)
     opts->refcount = 1;
     opts->shutdown_timeout = SENTRY_DEFAULT_SHUTDOWN_TIMEOUT;
     opts->traces_sample_rate = 0.0;
-    opts->max_spans = 0;
+    opts->max_spans = SENTRY_SPANS_MAX;
     opts->handler_strategy = SENTRY_HANDLER_STRATEGY_DEFAULT;
 
     return opts;
@@ -605,10 +605,6 @@ sentry_options_set_traces_sample_rate(
         sample_rate = 1.0;
     }
     opts->traces_sample_rate = sample_rate;
-
-    if (sample_rate > 0 && opts->max_spans == 0) {
-        opts->max_spans = SENTRY_SPANS_MAX;
-    }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-native/issues/1131

- [x] set default for `sentry_options_new`
- [x] think about other occurrences of `SENTRY_SPANS_MAX` 
