### PR TITLE
fix: allow test discovery to handle one-liner unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: test
 
 update-test-discovery:
-	@perl -ne 'print if s/SENTRY_TEST\(([^)]+)\)/XX(\1)/' tests/unit/*.c | sort | grep -v define | uniq > tests/unit/tests.inc
+	@perl -ne 'print if s/SENTRY_TEST\(([^)]+)\).*/XX(\1)/' tests/unit/*.c | sort | grep -v define | uniq > tests/unit/tests.inc
 .PHONY: update-test-discovery
 
 build/Makefile: CMakeLists.txt

--- a/scripts/update_test_discovery.ps1
+++ b/scripts/update_test_discovery.ps1
@@ -1,7 +1,11 @@
-Get-ChildItem -Path 'tests/unit/*.c' | ForEach-Object {
+$lines = Get-ChildItem -Path 'tests/unit/*.c' | ForEach-Object {
     Get-Content $_.FullName | ForEach-Object {
         if ($_ -match 'SENTRY_TEST\(([^)]+)\)') {
-            $_ -replace 'SENTRY_TEST\(([^)]+)\)', 'XX($1)'
+            $_ -replace 'SENTRY_TEST\(([^)]+)\).*', 'XX($1)'
         }
     }
-} | Sort-Object | Where-Object { $_ -notmatch 'define' } | Get-Unique | Set-Content 'tests/unit/tests.inc'
+}
+
+[System.Array]::Sort($lines, [System.StringComparer]::Ordinal)
+
+$lines | Where-Object { $_ -notmatch 'define' } | Get-Unique | Set-Content 'tests/unit/tests.inc'


### PR DESCRIPTION
#1093 recently broke our make/bash/powershell unit-test runner (i.e., the ones not running via `pytest`, which we use in CI) because `clang-format` decided to put the test body on the same line as the test header. Test discovery supports this now 😅 

#skip-changelog