### PR TITLE
feat: Add `sentry_value_get_key(value, index)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add `sentry_value_get_key(value, index)` function. ([#1142](https://github.com/getsentry/sentry-native/pull/1142))
+
 ## 0.7.20
 
 **Features**:

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -291,6 +291,12 @@ SENTRY_API sentry_value_t sentry_value_get_by_key_owned_n(
     sentry_value_t value, const char *k, size_t k_len);
 
 /**
+ * Returns a key in a map by index.  If missing or value is not a map,
+ * an empty string is returned.
+ */
+SENTRY_API const char *sentry_value_get_key(sentry_value_t value, size_t index);
+
+/**
  * Looks up a value in a list by index.  If missing a null value is returned.
  * The returned value is borrowed.
  */

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -778,6 +778,18 @@ sentry_value_get_by_key_owned(sentry_value_t value, const char *k)
     return rv;
 }
 
+const char *
+sentry_value_get_key(sentry_value_t value, size_t index) {
+    const thing_t *thing = value_as_thing(value);
+    if (thing && thing_get_type(thing) == THING_TYPE_OBJECT) {
+        obj_t *o = thing->payload._ptr;
+        if (index < o->len) {
+            return o->pairs[index].k;
+        }
+    }
+    return "";
+}
+
 sentry_value_t
 sentry_value_get_by_index(sentry_value_t value, size_t index)
 {

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -779,7 +779,8 @@ sentry_value_get_by_key_owned(sentry_value_t value, const char *k)
 }
 
 const char *
-sentry_value_get_key(sentry_value_t value, size_t index) {
+sentry_value_get_key(sentry_value_t value, size_t index)
+{
     const thing_t *thing = value_as_thing(value);
     if (thing && thing_get_type(thing) == THING_TYPE_OBJECT) {
         obj_t *o = thing->payload._ptr;

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -252,8 +252,10 @@ SENTRY_TEST(value_object)
         sentry_value_t child = sentry_value_get_by_key(val, key);
         if (i < 10) {
             TEST_CHECK(sentry_value_as_int32(child) == (int32_t)i);
+            TEST_CHECK(strcmp(sentry_value_get_key(val, i), key) == 0);
         } else {
             TEST_CHECK(sentry_value_is_null(child));
+            TEST_CHECK(strlen(sentry_value_get_key(val, i)) == 0);
         }
     }
 


### PR DESCRIPTION
This PR introduces the `sentry_value_get_key(value, index)` function.

## Rationale

There is currently no way to get the keys of a map object. We need such a function to build a proper representation in upstream SDKs (like `sentry-godot`). We can potentialy improve [existing code in other SDKs](https://github.com/getsentry/sentry-unreal/blob/8e159cec39ef22eeef536ad650a7fe8233e02dfe/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp#L140-L167) if we add this function. It can also be used to find which contexts or tags are added to a sentry event and present such data through `SentryEvent` class.

`sentry_value_get_length(value)` is already set up to return the number of elements in a map. This PR simply adds the last missing piece - the `sentry_value_get_key(value, index)` function.

## How we will use it
WIP upstream SDK code that benefits from these changes:
- https://github.com/getsentry/sentry-godot/blob/2fae26ef6151ef983b45d5c97280f66545c3b64d/src/sentry/native/native_breadcrumb.cpp#L47-L54
- https://github.com/getsentry/sentry-godot/blob/2fae26ef6151ef983b45d5c97280f66545c3b64d/src/sentry/native/native_util.cpp#L85-L95
