### PR TITLE
feat: add `sentry_trigger_dump()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add `sentry_trigger_dump()` a function allowing application to trigger non-fatal minidumps when using the `crashpad` backend. ([#1144](https://github.com/getsentry/sentry-native/pull/1144))
+
 ## 0.7.20
 
 **Features**:

--- a/examples/example.c
+++ b/examples/example.c
@@ -367,6 +367,9 @@ main(int argc, char **argv)
         sleep_s(10);
     }
 
+    if (has_arg(argc, argv, "trigger-dump")) {
+        sentry_trigger_dump();
+    }
     if (has_arg(argc, argv, "crash")) {
         trigger_crash();
     }

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1425,6 +1425,18 @@ SENTRY_EXPERIMENTAL_API void sentry_handle_exception(
     const sentry_ucontext_t *uctx);
 
 /**
+ * Captures a minidump for non-fatal errors. The program can continue after
+ * this call safely. It will produce a minidump context on the spot and crash-
+ * events will appear with log-level `error`.
+ *
+ * This trigger will also invoke the crash-handler, meaning it will call
+ * the `before_send` or `on_crash` hooks.
+ *
+ * Note: currently only works with the `crashpad` backend on Windows and Linux.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_trigger_dump(void);
+
+/**
  * Adds the breadcrumb to be sent in case of an event.
  */
 SENTRY_API void sentry_add_breadcrumb(sentry_value_t breadcrumb);

--- a/src/sentry_backend.h
+++ b/src/sentry_backend.h
@@ -17,6 +17,7 @@ struct sentry_backend_s {
     void (*shutdown_func)(sentry_backend_t *);
     void (*free_func)(sentry_backend_t *);
     void (*except_func)(sentry_backend_t *, const struct sentry_ucontext_s *);
+    void (*trigger_dump_func)(sentry_backend_t *);
     void (*flush_scope_func)(
         sentry_backend_t *, const sentry_options_t *options);
     // NOTE: The breadcrumb is not moved into the hook and does not need to be

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -609,6 +609,17 @@ sentry_handle_exception(const sentry_ucontext_t *uctx)
     }
 }
 
+void
+sentry_trigger_dump(void)
+{
+    SENTRY_WITH_OPTIONS (options) {
+        SENTRY_INFO("triggering dump");
+        if (options->backend && options->backend->except_func) {
+            options->backend->trigger_dump_func(options->backend);
+        }
+    }
+}
+
 sentry_uuid_t
 sentry__new_event_id(void)
 {


### PR DESCRIPTION
A recurring wish from our users is to trigger a minidump for non-fatal situations in the code. This implementation provides this for users of the `crashpad` backend.