### PR TITLE
Fix Xbox OS name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Fixes**:
 
 - Ensure that `sentry_capture_minidump()` fails if the provided minidump path cannot be attached, instead of sending a crash event without minidump. ([#1138](https://github.com/getsentry/sentry-native/pull/1138))
+- Fix Xbox OS name being reported incorrectly ([#1148](https://github.com/getsentry/sentry-native/pull/1148))
 
 **Thank you**:
 

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -117,7 +117,7 @@ sentry__get_os_context(void)
 #    if defined(_GAMING_XBOX_SCARLETT)
 #        pragma warning(push)
 #        pragma warning(disable : 4996)
-    sentry_value_set_by_key(os, "name", sentry_value_new_string("Windows"));
+    sentry_value_set_by_key(os, "name", sentry_value_new_string("Xbox"));
     OSVERSIONINFO os_ver = { 0 };
     char buf[128];
     buf[0] = 0;


### PR DESCRIPTION
This change fixes an issue where the os name on Xbox was being reported as Windows. 