### PR TITLE
feat(crashpad): add option to delay shutdown until upload thread completes

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1272,11 +1272,20 @@ SENTRY_API void sentry_options_set_system_crash_reporter_enabled(
     sentry_options_t *opts, int enabled);
 
 /**
- * Sets the maximum time (in milliseconds) to wait for the asynchronous tasks to
- * end on shutdown, before attempting a forced termination.
+ * Enables a wait for the crash report upload to be finished before shutting
+ * down. This is disabled by default.
+ *
+ * This setting only has an effect when using the crashpad backend.
  */
-SENTRY_API void sentry_options_set_shutdown_timeout(
-    sentry_options_t *opts, uint64_t shutdown_timeout);
+SENTRY_API void sentry_options_set_on_crash_wait_for_upload(
+    sentry_options_t *opts, int wait_for_upload)
+
+    /**
+     * Sets the maximum time (in milliseconds) to wait for the asynchronous
+     * tasks to end on shutdown, before attempting a forced termination.
+     */
+    SENTRY_API void sentry_options_set_shutdown_timeout(
+        sentry_options_t *opts, uint64_t shutdown_timeout);
 
 /**
  * Gets the maximum time (in milliseconds) to wait for the asynchronous tasks to

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -47,6 +47,7 @@ sentry_options_new(void)
     opts->user_consent = SENTRY_USER_CONSENT_UNKNOWN;
     opts->auto_session_tracking = true;
     opts->system_crash_reporter_enabled = false;
+    opts->on_crash_wait_for_upload = false;
     opts->symbolize_stacktraces =
     // AIX doesn't have reliable debug IDs for server-side symbolication,
     // and the diversity of Android makes it infeasible to have access to debug
@@ -449,6 +450,13 @@ sentry_options_set_system_crash_reporter_enabled(
     sentry_options_t *opts, int enabled)
 {
     opts->system_crash_reporter_enabled = !!enabled;
+}
+
+void
+sentry_options_set_on_crash_wait_for_upload(
+    sentry_options_t *opts, int wait_for_upload)
+{
+    opts->on_crash_wait_for_upload = !!wait_for_upload;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -49,6 +49,7 @@ typedef struct sentry_options_s {
     bool require_user_consent;
     bool symbolize_stacktraces;
     bool system_crash_reporter_enabled;
+    bool on_crash_wait_for_upload;
 
     sentry_attachment_t *attachments;
     sentry_run_t *run;


### PR DESCRIPTION
See https://github.com/getsentry/crashpad/pull/121

- [x] add Sentry option
- [ ] implement option passthrough into Crashpad
- [ ] add wait for all platforms
- [ ] add tests 