### PR TITLE
upload debug files for ndk build

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -26,5 +26,9 @@ targets:
       distDirRegex: /^(sentry-native-ndk).*$/
       fileReplaceeRegex: /\d+\.\d+\.\d+(-\w+(\.\d+)?)?(-SNAPSHOT)?/
       fileReplacerStr: release.aar
+  - name: symbol-collector
+    includeNames: /libsentry(-android)?\.so/
+    batchType: android
+    bundleIdPrefix: sentry-unreal-android-ndk-
 requireNames:
   - /^sentry-native.zip$/


### PR DESCRIPTION
While looking at this diff I realized we're no longer uploading debug symbols from the NDK build since we're no longer compiling it: https://github.com/getsentry/sentry-unreal/pull/783/files

But since we're downloading from here. We should upload debug files via [symbol collector](https://github.com/getsentry/symbol-collector/) when making releases.

Note: I didn't test if paths etc match. This is how it was set up before when compiling on the sentry-java repo