### PR TITLE
chore: update ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
-          sudo apt install cmake clang-14 clang-tools llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang-15 clang-tools llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
           # Install kcov from source
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             os: ubuntu-24.04
             CC: gcc-12
             CXX: g++-12
-          - name: Linux (GCC 14.3.0)
+          - name: Linux (GCC 14.2.0)
             os: ubuntu-24.04
             CC: gcc-14
             CXX: g++-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update
-          sudo apt install cmake gcc-7-multilib g++-7-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
+          sudo apt install cmake gcc-multilib g++-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
 
         # https://github.com/actions/runner-images/issues/9491
       - name: Decrease vm.mmap_rnd_bit to prevent ASLR ASAN issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux (GCC 9, 32-bit)
+          - name: Linux (GCC 9.5.0, 32-bit)
             os: ubuntu-22.04
             CC: gcc-9
             CXX: g++-9
             TEST_X86: 1
-          - name: Linux (GCC 9.4.0)
+          - name: Linux (GCC 9.5.0)
             os: ubuntu-22.04
             CC: gcc-9
             CXX: g++-9
             # ERROR_ON_WARNINGS: 1
-          - name: Linux (GCC 12)
+          - name: Linux (GCC 12.3.0)
             os: ubuntu-24.04
             CC: gcc-12
             CXX: g++-12
@@ -69,7 +69,7 @@ jobs:
             CXX: clang++-15
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: kcov
-          - name: Linux (gcc 12 + code-checker + valgrind)
+          - name: Linux (GCC 13.3.0 + code-checker + valgrind)
             os: ubuntu-24.04
             RUN_ANALYZER: code-checker,valgrind
           - name: macOS 14 (xcode llvm)
@@ -138,10 +138,6 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-
-      - name: GCC Version check
-        if: ${{ runner.os == 'Linux' }}
-        run: gcc --version
 
       - name: Installing Linux Dependencies
         if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,15 @@ jobs:
         run: |
           sudo apt update
           sudo apt install cmake clang-14 clang-tools llvm kcov g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
+          # Install kcov from source
+          sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
+          git clone https://github.com/SimonKagstrom/kcov.git
+          cd kcov
+          mkdir build
+          cd build
+          cmake ..
+          make
+          sudo make install
 
       - name: Installing Linux GCC 9.4.0 Dependencies
         if: ${{ runner.os == 'Linux' && matrix.os == 'ubuntu-22.04' && !env['TEST_X86'] }}
@@ -170,11 +179,11 @@ jobs:
       - name: Expose llvm@15 PATH for Mac
         if: ${{ runner.os == 'macOS' }}
         run: echo $(brew --prefix llvm@15)/bin >> $GITHUB_PATH
-             
+
       - name: Expose llvm@18 PATH for Mac
         if: ${{ runner.os == 'macOS' && matrix.os == 'macos-15-large' && matrix.RUN_ANALYZER == 'asan,llvm-cov' }}
         run: echo $(brew --prefix llvm@18)/bin >> $GITHUB_PATH
-        
+
       - name: Installing LLVM-MINGW Dependencies
         if: ${{ runner.os == 'Windows' && env['TEST_MINGW'] }}
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
-          sudo apt install cmake clang-14 clang-tools llvm kcov g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang-14 clang-tools llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
           # Install kcov from source
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
             os: ubuntu-24.04
             CC: gcc-12
             CXX: g++-12
+          - name: Linux (GCC 14.3.0)
+            os: ubuntu-24.04
+            CC: gcc-14
+            CXX: g++-14
             # ERROR_ON_WARNINGS: 1
             # The GCC analyzer 10.0.1 (as on CI) has an internal compiler error
             # currently, and is not stable enough to activate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
             CXX: clang++-19
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: llvm-cov
-          - name: Linux (clang 19 + asan)
+          - name: Linux (clang 18 + asan)
             os: ubuntu-24.04
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang
+            CXX: clang++
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan
           - name: Linux (clang 19 + kcov)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
-          sudo apt install cmake clang-15 clang-tools llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang-15 llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
           # Install kcov from source
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git
@@ -162,7 +162,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.os == 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
-          sudo apt install cmake clang-tools llvm kcov g++ valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake llvm kcov g++ valgrind zlib1g-dev libcurl4-openssl-dev
 
       - name: Installing Linux 32-bit Dependencies
         if: ${{ runner.os == 'Linux' && env['TEST_X86'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,17 @@ jobs:
       matrix:
         include:
           - name: Linux (GCC 7, 32-bit)
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             CC: gcc-7
             CXX: g++-7
             TEST_X86: 1
           - name: Linux (GCC 9.4.0)
-            os: ubuntu-20.04
-            CC: gcc
-            CXX: g++
+            os: ubuntu-22.04
+            CC: gcc-9
+            CXX: g++-9
             # ERROR_ON_WARNINGS: 1
           - name: Linux (GCC 12)
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             CC: gcc-12
             CXX: g++-12
             # ERROR_ON_WARNINGS: 1
@@ -58,19 +58,19 @@ jobs:
             # currently, and is not stable enough to activate.
             # RUN_ANALYZER: gcc
           - name: Linux (clang 15 + asan + llvm-cov)
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             CC: clang-15
             CXX: clang++-15
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang 15 + kcov)
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             CC: clang-15
             CXX: clang++-15
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: kcov
           - name: Linux (gcc 12 + code-checker + valgrind)
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             RUN_ANALYZER: code-checker,valgrind
           - name: macOS 14 (xcode llvm)
             os: macos-14
@@ -140,13 +140,13 @@ jobs:
           cache: "pip"
 
       - name: Installing Linux Dependencies
-        if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-20.04' && !env['TEST_X86'] }}
+        if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
           sudo apt install cmake clang-14 clang-tools llvm kcov g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
 
       - name: Installing Linux GCC 9.4.0 Dependencies
-        if: ${{ runner.os == 'Linux' && matrix.os == 'ubuntu-20.04' && !env['TEST_X86'] }}
+        if: ${{ runner.os == 'Linux' && matrix.os == 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
           sudo apt install cmake clang-tools llvm kcov g++ valgrind zlib1g-dev libcurl4-openssl-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,16 +61,16 @@ jobs:
             # The GCC analyzer 10.0.1 (as on CI) has an internal compiler error
             # currently, and is not stable enough to activate.
             # RUN_ANALYZER: gcc
-          - name: Linux (clang 15 + asan + llvm-cov)
+          - name: Linux (clang 19 + asan + llvm-cov)
             os: ubuntu-24.04
-            CC: clang-15
-            CXX: clang++-15
+            CC: clang-19
+            CXX: clang++-19
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
-          - name: Linux (clang 15 + kcov)
+          - name: Linux (clang 19 + kcov)
             os: ubuntu-24.04
-            CC: clang-15
-            CXX: clang++-15
+            CC: clang-19
+            CXX: clang++-19
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: kcov
           - name: Linux (GCC 13.3.0 + code-checker + valgrind)
@@ -147,7 +147,7 @@ jobs:
         if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |
           sudo apt update
-          sudo apt install cmake clang-15 llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang-19 llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
           # Install kcov from source
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
             CXX: clang++-19
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
+          - name: Linux (clang 19 + llvm-cov)
+            os: ubuntu-24.04
+            CC: clang-19
+            CXX: clang++-19
+            ERROR_ON_WARNINGS: 1
+            RUN_ANALYZER: llvm-cov
+          - name: Linux (clang 19 + asan)
+            os: ubuntu-24.04
+            CC: clang-19
+            CXX: clang++-19
+            ERROR_ON_WARNINGS: 1
+            RUN_ANALYZER: asan
           - name: Linux (clang 19 + kcov)
             os: ubuntu-24.04
             CC: clang-19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: GCC Version check
+        if: ${{ runner.os == 'Linux' }}
+        run: gcc --version
+
       - name: Installing Linux Dependencies
         if: ${{ runner.os == 'Linux' && matrix.os != 'ubuntu-22.04' && !env['TEST_X86'] }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux (GCC 7, 32-bit)
+          - name: Linux (GCC 9, 32-bit)
             os: ubuntu-22.04
-            CC: gcc-7
-            CXX: g++-7
+            CC: gcc-9
+            CXX: g++-9
             TEST_X86: 1
           - name: Linux (GCC 9.4.0)
             os: ubuntu-22.04
@@ -156,7 +156,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update
-          sudo apt install cmake gcc-multilib g++-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
+          sudo apt install cmake gcc-9-multilib g++-9-multilib zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386
 
         # https://github.com/actions/runner-images/issues/9491
       - name: Decrease vm.mmap_rnd_bit to prevent ASLR ASAN issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,18 +67,6 @@ jobs:
             CXX: clang++-19
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
-          - name: Linux (clang 19 + llvm-cov)
-            os: ubuntu-24.04
-            CC: clang-19
-            CXX: clang++-19
-            ERROR_ON_WARNINGS: 1
-            RUN_ANALYZER: llvm-cov
-          - name: Linux (clang 18 + asan)
-            os: ubuntu-24.04
-            CC: clang
-            CXX: clang++
-            ERROR_ON_WARNINGS: 1
-            RUN_ANALYZER: asan
           - name: Linux (clang 19 + kcov)
             os: ubuntu-24.04
             CC: clang-19

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The SDK currently supports and is tested on the following OS/Compiler variations
 
 - 64bit Linux with GCC 12
 - 64bit Linux with GCC 9
-- 64bit Linux with clang 15
+- 64bit Linux with clang 19
 - 32bit Linux with GCC 9 (cross compiled from 64bit host)
 - 32bit Windows with MSVC 2019
 - 64bit Windows with MSVC 2022

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The SDK bundle contains the following folders:
 
 The SDK currently supports and is tested on the following OS/Compiler variations:
 
+- 64bit Linux with GCC 14
 - 64bit Linux with GCC 12
 - 64bit Linux with GCC 9
 - 64bit Linux with clang 19

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ The SDK bundle contains the following folders:
 The SDK currently supports and is tested on the following OS/Compiler variations:
 
 - 64bit Linux with GCC 12
+- 64bit Linux with GCC 9
 - 64bit Linux with clang 15
-- 32bit Linux with GCC 7 (cross compiled from 64bit host)
+- 32bit Linux with GCC 9 (cross compiled from 64bit host)
 - 32bit Windows with MSVC 2019
 - 64bit Windows with MSVC 2022
 - macOS 13, 14, 15 with respective most recent Apple compiler toolchain and LLVM clang 15 + 18

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -88,7 +88,7 @@ def run(cwd, exe, args, env=dict(os.environ), **kwargs):
         "./{}".format(exe) if sys.platform != "win32" else "{}\\{}.exe".format(cwd, exe)
     ]
     if "asan" in os.environ.get("RUN_ANALYZER", ""):
-        env["ASAN_OPTIONS"] = "detect_leaks=1"
+        env["ASAN_OPTIONS"] = "detect_leaks=1:detect_invalid_join=0"
         env["LSAN_OPTIONS"] = "suppressions={}".format(
             os.path.join(sourcedir, "tests", "leaks.txt")
         )

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -114,7 +114,7 @@ def test_crashpad_proxy_set_empty(cmake, httpserver):
             cmake, httpserver, "http-proxy"
         )
 
-        with httpserver.wait(timeout=10) as waiting:
+        with httpserver.wait(timeout=15) as waiting:
             child = run(
                 tmp_path, "sentry_example", ["log", "crash", "proxy-empty"], env=env
             )
@@ -138,7 +138,7 @@ def test_crashpad_proxy_https_not_http(cmake, httpserver):
             cmake, httpserver, "http-proxy"
         )
 
-        with httpserver.wait(timeout=10) as waiting:
+        with httpserver.wait(timeout=15) as waiting:
             child = run(tmp_path, "sentry_example", ["log", "crash"], env=env)
             assert child.returncode  # well, it's a crash after all
         assert waiting.result
@@ -201,7 +201,7 @@ def test_crashpad_reinstall(cmake, httpserver):
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
     httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
 
-    with httpserver.wait(timeout=10) as waiting:
+    with httpserver.wait(timeout=15) as waiting:
         child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env)
         assert child.returncode  # well, it's a crash after all
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -114,7 +114,7 @@ def test_crashpad_proxy_set_empty(cmake, httpserver):
             cmake, httpserver, "http-proxy"
         )
 
-        with httpserver.wait(timeout=30) as waiting:
+        with httpserver.wait(timeout=10) as waiting:
             child = run(
                 tmp_path, "sentry_example", ["log", "crash", "proxy-empty"], env=env
             )
@@ -138,7 +138,7 @@ def test_crashpad_proxy_https_not_http(cmake, httpserver):
             cmake, httpserver, "http-proxy"
         )
 
-        with httpserver.wait(timeout=30) as waiting:
+        with httpserver.wait(timeout=10) as waiting:
             child = run(tmp_path, "sentry_example", ["log", "crash"], env=env)
             assert child.returncode  # well, it's a crash after all
         assert waiting.result
@@ -201,7 +201,7 @@ def test_crashpad_reinstall(cmake, httpserver):
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
     httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
 
-    with httpserver.wait(timeout=30) as waiting:
+    with httpserver.wait(timeout=10) as waiting:
         child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env)
         assert child.returncode  # well, it's a crash after all
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -114,7 +114,7 @@ def test_crashpad_proxy_set_empty(cmake, httpserver):
             cmake, httpserver, "http-proxy"
         )
 
-        with httpserver.wait(timeout=15) as waiting:
+        with httpserver.wait(timeout=30) as waiting:
             child = run(
                 tmp_path, "sentry_example", ["log", "crash", "proxy-empty"], env=env
             )
@@ -138,7 +138,7 @@ def test_crashpad_proxy_https_not_http(cmake, httpserver):
             cmake, httpserver, "http-proxy"
         )
 
-        with httpserver.wait(timeout=15) as waiting:
+        with httpserver.wait(timeout=30) as waiting:
             child = run(tmp_path, "sentry_example", ["log", "crash"], env=env)
             assert child.returncode  # well, it's a crash after all
         assert waiting.result
@@ -201,7 +201,7 @@ def test_crashpad_reinstall(cmake, httpserver):
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
     httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
 
-    with httpserver.wait(timeout=15) as waiting:
+    with httpserver.wait(timeout=30) as waiting:
         child = run(tmp_path, "sentry_example", ["log", "reinstall", "crash"], env=env)
         assert child.returncode  # well, it's a crash after all
 


### PR DESCRIPTION
due to [upcoming deprecation](https://github.com/actions/runner-images/issues/11101#issue-2719265843) we update our runners as such:
`ubuntu-22.04 -> ubuntu-24.04`

`ubuntu-20.04 -> ubuntu-22.04`

- [ ] we should also do this on [crashpad](https://github.com/getsentry/crashpad/blob/getsentry/.github/workflows/build.yml#L24)

fixes #1168.

#skip-changelog