### PR TITLE
fix: acutest on platforms where `errno` is not defined

### DIFF
--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -1445,13 +1445,15 @@ test_cmdline_callback__(int id, const char* arg)
             test_worker_index__ = atoi(arg);
             break;
         case 'x':
-#if defined ACUTEST_UNIX__
             test_xml_output__ = fopen(arg, "w");
             if (!test_xml_output__) {
+#if defined ACUTEST_UNIX__
                 fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
+#else
+                fprintf(stderr, "Unable to open '%s'\n", arg);
+#endif
                 exit(2);
             }
-#endif
             break;
 
         case 0:

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -1445,11 +1445,13 @@ test_cmdline_callback__(int id, const char* arg)
             test_worker_index__ = atoi(arg);
             break;
         case 'x':
+#if defined ACUTEST_UNIX__
             test_xml_output__ = fopen(arg, "w");
             if (!test_xml_output__) {
                 fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
                 exit(2);
             }
+#endif
             break;
 
         case 0:


### PR DESCRIPTION
```
acutest.h:1450:76: error: use of undeclared identifier 'errno'
[build]  1450 |                 fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
```

Added the same ifdef as in other code when errno is used

#skip-changelog