### PR TITLE
refactor: sentry_utils.c locale()

### DIFF
--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -502,7 +502,7 @@ sentry__iso8601_to_usec(const char *iso)
 // if Android ever adds locale support in NDK we will have to revisit this code
 // to ensure the C locale is also used there.
 #if !defined(SENTRY_PLATFORM_ANDROID) && !defined(SENTRY_PLATFORM_IOS)         \
-    && !defined(SENTRY_PLATFORM_AIX) && !defined(SENTRY_PLATFORM_NX)
+    && !defined(SENTRY_PLATFORM_AIX)
 #    define HAS_C_LOCALE
 #endif
 


### PR DESCRIPTION
refactor ifdefs for `c_locale()` calls. There was a warning about an unused function

#skip-changelog
