### PR TITLE
test: add path-prefix for tests that write to FS

### DIFF
--- a/tests/unit/sentry_testsupport.h
+++ b/tests/unit/sentry_testsupport.h
@@ -58,3 +58,14 @@
 #else
 #    define TEST_VISIBLE
 #endif
+
+#ifdef SENTRY_TEST_PATH_PREFIX
+#    define SENTRY_TEST_OPTIONS_NEW(Varname)                                   \
+        sentry_options_t *Varname = sentry_options_new();                      \
+        sentry_options_set_database_path(                                      \
+            Varname, SENTRY_TEST_PATH_PREFIX ".sentry-native");
+#else
+#    define SENTRY_TEST_PATH_PREFIX ""
+#    define SENTRY_TEST_OPTIONS_NEW(Varname)                                   \
+        sentry_options_t *Varname = sentry_options_new();
+#endif

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -17,19 +17,13 @@ send_envelope_test_attachments(const sentry_envelope_t *envelope, void *_data)
         envelope, &data->serialized_envelope);
 }
 
-#ifdef __ANDROID__
-#    define PREFIX "/data/local/tmp/"
-#else
-#    define PREFIX ""
-#endif
-
 SENTRY_TEST(lazy_attachments)
 {
     sentry_attachments_testdata_t testdata;
     testdata.called = 0;
     sentry__stringbuilder_init(&testdata.serialized_envelope);
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_auto_session_tracking(options, false);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(options,
@@ -38,13 +32,14 @@ SENTRY_TEST(lazy_attachments)
     char rel[] = { 't', 'e', 's', 't' };
     sentry_options_set_release_n(options, rel, sizeof(rel));
 
-    sentry_options_add_attachment(options, PREFIX ".existing-file-attachment");
     sentry_options_add_attachment(
-        options, PREFIX ".non-existing-file-attachment");
-    sentry_path_t *existing
-        = sentry__path_from_str(PREFIX ".existing-file-attachment");
-    sentry_path_t *non_existing
-        = sentry__path_from_str(PREFIX ".non-existing-file-attachment");
+        options, SENTRY_TEST_PATH_PREFIX ".existing-file-attachment");
+    sentry_options_add_attachment(
+        options, SENTRY_TEST_PATH_PREFIX ".non-existing-file-attachment");
+    sentry_path_t *existing = sentry__path_from_str(
+        SENTRY_TEST_PATH_PREFIX ".existing-file-attachment");
+    sentry_path_t *non_existing = sentry__path_from_str(
+        SENTRY_TEST_PATH_PREFIX ".non-existing-file-attachment");
 
     sentry_init(options);
 

--- a/tests/unit/test_concurrency.c
+++ b/tests/unit/test_concurrency.c
@@ -20,7 +20,7 @@ send_envelope_test_concurrent(const sentry_envelope_t *envelope, void *data)
 static void
 init_framework(long *called)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(options,
         sentry_new_function_transport(send_envelope_test_concurrent, called));

--- a/tests/unit/test_consent.c
+++ b/tests/unit/test_consent.c
@@ -4,13 +4,8 @@
 static void
 init_consenting_sentry(void)
 {
-#ifdef __ANDROID__
-#    define PREFIX "/data/local/tmp/"
-#else
-#    define PREFIX ""
-#endif
     sentry_options_t *opts = sentry_options_new();
-    sentry_options_set_database_path(opts, PREFIX ".test-db");
+    sentry_options_set_database_path(opts, SENTRY_TEST_PATH_PREFIX ".test-db");
     sentry_options_set_dsn(opts, "http://foo@127.0.0.1/42");
     sentry_options_set_require_user_consent(opts, true);
     sentry_init(opts);
@@ -18,7 +13,8 @@ init_consenting_sentry(void)
 
 SENTRY_TEST(basic_consent_tracking)
 {
-    sentry_path_t *path = sentry__path_from_str(PREFIX ".test-db");
+    sentry_path_t *path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".test-db");
     sentry__path_remove_all(path);
 
     init_consenting_sentry();

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -177,7 +177,7 @@ SENTRY_TEST(basic_http_request_preparation_for_minidump)
 sentry_envelope_t *
 create_test_envelope()
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_init(options);
 
@@ -219,9 +219,9 @@ SENTRY_TEST(serialize_envelope)
 SENTRY_TEST(basic_write_envelope_to_file)
 {
     sentry_envelope_t *envelope = create_test_envelope();
-    const char *test_file_str = "sentry_test_envelope";
-    sentry_path_t *test_file_path = sentry__path_from_str(test_file_str);
-    int rv = sentry_envelope_write_to_file(envelope, test_file_str);
+    sentry_path_t *test_file_path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "sentry_test_envelope");
+    int rv = sentry_envelope_write_to_file(envelope, test_file_path->path);
     TEST_CHECK_INT_EQUAL(rv, 0);
     TEST_ASSERT(sentry__path_is_file(test_file_path));
 
@@ -257,11 +257,11 @@ SENTRY_TEST(write_envelope_to_file_null)
 SENTRY_TEST(write_envelope_to_invalid_path)
 {
     sentry_envelope_t *envelope = create_test_envelope();
-    const char *test_file_str
-        = "./directory_that_does_not_exist/sentry_test_envelope";
-    sentry_path_t *test_file_path = sentry__path_from_str(test_file_str);
+    sentry_path_t *test_file_path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX
+            "./directory_that_does_not_exist/sentry_test_envelope");
 
-    int rv = sentry_envelope_write_to_file(envelope, test_file_str);
+    int rv = sentry_envelope_write_to_file(envelope, test_file_path->path);
     TEST_CHECK_INT_EQUAL(rv, 1);
 
     sentry__path_remove(test_file_path);

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -219,9 +219,9 @@ SENTRY_TEST(serialize_envelope)
 SENTRY_TEST(basic_write_envelope_to_file)
 {
     sentry_envelope_t *envelope = create_test_envelope();
-    sentry_path_t *test_file_path
-        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "sentry_test_envelope");
-    int rv = sentry_envelope_write_to_file(envelope, test_file_path->path);
+    const char *test_file_str = SENTRY_TEST_PATH_PREFIX "sentry_test_envelope";
+    sentry_path_t *test_file_path = sentry__path_from_str(test_file_str);
+    int rv = sentry_envelope_write_to_file(envelope, test_file_str);
     TEST_CHECK_INT_EQUAL(rv, 0);
     TEST_ASSERT(sentry__path_is_file(test_file_path));
 
@@ -257,11 +257,10 @@ SENTRY_TEST(write_envelope_to_file_null)
 SENTRY_TEST(write_envelope_to_invalid_path)
 {
     sentry_envelope_t *envelope = create_test_envelope();
-    sentry_path_t *test_file_path
-        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX
-            "./directory_that_does_not_exist/sentry_test_envelope");
-
-    int rv = sentry_envelope_write_to_file(envelope, test_file_path->path);
+    const char *test_file_str = SENTRY_TEST_PATH_PREFIX
+        "./directory_that_does_not_exist/sentry_test_envelope";
+    sentry_path_t *test_file_path = sentry__path_from_str(test_file_str);
+    int rv = sentry_envelope_write_to_file(envelope, test_file_str);
     TEST_CHECK_INT_EQUAL(rv, 1);
 
     sentry__path_remove(test_file_path);

--- a/tests/unit/test_failures.c
+++ b/tests/unit/test_failures.c
@@ -19,7 +19,7 @@ SENTRY_TEST(init_failure)
         = sentry_new_function_transport(noop_send, NULL);
     sentry_transport_set_startup_func(transport, transport_startup_fail);
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_transport(options, transport);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     int rv = sentry_init(options);

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -28,7 +28,7 @@ SENTRY_TEST(custom_logger)
 {
     logger_test_t data = { 0, false };
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_debug(options, true);
     sentry_options_set_logger(options, test_logger, &data);
 

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -28,22 +28,26 @@ SENTRY_TEST(custom_logger)
 {
     logger_test_t data = { 0, false };
 
-    SENTRY_TEST_OPTIONS_NEW(options);
-    sentry_options_set_debug(options, true);
-    sentry_options_set_logger(options, test_logger, &data);
+    {
+        SENTRY_TEST_OPTIONS_NEW(options);
+        sentry_options_set_debug(options, true);
+        sentry_options_set_logger(options, test_logger, &data);
 
-    sentry_init(options);
+        sentry_init(options);
 
-    data.assert_now = true;
-    SENTRY_WARNF("Oh this is %s", "bad");
-    data.assert_now = false;
+        data.assert_now = true;
+        SENTRY_WARNF("Oh this is %s", "bad");
+        data.assert_now = false;
 
-    sentry_close();
+        sentry_close();
+    }
 
     TEST_CHECK_INT_EQUAL(data.called, 1);
 
-    // *really* clear the logger instance
-    options = sentry_options_new();
-    sentry_init(options);
-    sentry_close();
+    {
+        // *really* clear the logger instance
+        SENTRY_TEST_OPTIONS_NEW(options);
+        sentry_init(options);
+        sentry_close();
+    }
 }

--- a/tests/unit/test_mpack.c
+++ b/tests/unit/test_mpack.c
@@ -16,7 +16,7 @@ SENTRY_TEST(mpack_removed_tags)
     sentry_set_extra("int", sentry_value_new_int32(1234));
     sentry_set_extra("double", sentry_value_new_double(12.34));
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     SENTRY_WITH_SCOPE (scope) {
         sentry__scope_apply_to_event(scope, options, obj, SENTRY_SCOPE_NONE);
     }
@@ -30,12 +30,6 @@ SENTRY_TEST(mpack_removed_tags)
     sentry__scope_cleanup();
 }
 
-#ifdef __ANDROID__
-#    define PREFIX "/data/local/tmp/"
-#else
-#    define PREFIX ""
-#endif
-
 SENTRY_TEST(mpack_newlines)
 {
     sentry_value_t o = sentry_value_new_object();
@@ -46,7 +40,8 @@ SENTRY_TEST(mpack_newlines)
     size_t size;
     char *buf = sentry_value_to_msgpack(o, &size);
 
-    sentry_path_t *file = sentry__path_from_str(PREFIX ".mpack-buf");
+    sentry_path_t *file
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".mpack-buf");
     sentry__path_append_buffer(file, buf, size);
 
     size_t size_rt;

--- a/tests/unit/test_options.c
+++ b/tests/unit/test_options.c
@@ -3,7 +3,7 @@
 
 SENTRY_TEST(options_sdk_name_defaults)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     // when nothing is set
 
     // then both sdk name and user agent should default to the build time
@@ -18,7 +18,7 @@ SENTRY_TEST(options_sdk_name_defaults)
 
 SENTRY_TEST(options_sdk_name_custom)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
 
     // when the sdk name is set to a custom string
     const int result
@@ -37,7 +37,7 @@ SENTRY_TEST(options_sdk_name_custom)
 
 SENTRY_TEST(options_sdk_name_invalid)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
 
     // when the sdk name is set to an invalid value
     const char *sdk_name = NULL;

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -4,7 +4,7 @@
 
 SENTRY_TEST(recursive_paths)
 {
-    sentry_path_t *base = sentry__path_from_str(".foo");
+    sentry_path_t *base = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".foo");
     sentry_path_t *nested = sentry__path_join_str(base, "bar");
     sentry_path_t *nested2 = sentry__path_join_str(nested, "baz");
     sentry_path_t *file =
@@ -141,7 +141,7 @@ SENTRY_TEST(path_basics)
 {
     size_t items = 0;
     const sentry_path_t *p;
-    sentry_path_t *path = sentry__path_from_str(".");
+    sentry_path_t *path = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".");
     TEST_CHECK(!!path);
 
     sentry_pathiter_t *piter = sentry__path_iter_directory(path);
@@ -166,10 +166,13 @@ SENTRY_TEST(path_current_exe)
 
 SENTRY_TEST(path_directory)
 {
-    sentry_path_t *path_1 = sentry__path_from_str("foo");
-    sentry_path_t *path_2 = sentry__path_from_str("foo/bar");
+    sentry_path_t *path_1
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "foo");
+    sentry_path_t *path_2
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "foo/bar");
 #ifdef SENTRY_PLATFORM_WINDOWS
-    sentry_path_t *path_3 = sentry__path_from_str("foo/bar\\baz");
+    sentry_path_t *path_3
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "foo/bar\\baz");
 
     // `%TEMP%\sentry_test_unit`
     wchar_t temp_folder[MAX_PATH];

--- a/tests/unit/test_sampling.c
+++ b/tests/unit/test_sampling.c
@@ -46,7 +46,7 @@ traces_sampler_callback(const sentry_transaction_context_t *transaction_ctx,
 
 SENTRY_TEST(sampling_transaction)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     TEST_CHECK(sentry_init(options) == 0);
 
     sentry_transaction_context_t *tx_ctx

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -55,7 +55,7 @@ send_envelope(const sentry_envelope_t *envelope, void *data)
 SENTRY_TEST(session_basics)
 {
     uint64_t called = 0;
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(
         options, sentry_new_function_transport(send_envelope, &called));
@@ -139,7 +139,7 @@ SENTRY_TEST(count_sampled_events)
 {
     session_assertion_t assertion = { false, 0 };
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(options,
         sentry_new_function_transport(send_sampled_envelope, &assertion));

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -1298,7 +1298,7 @@ SENTRY_TEST(set_tag_cuts_value_at_length_200)
 
 SENTRY_TEST(set_trace)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_init(options);
 
@@ -1367,7 +1367,7 @@ apply_scope_and_check_trace_context(
 SENTRY_TEST(set_trace_id_with_txn)
 {
     // initialize SDK so we have a scope
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_options_set_sample_rate(options, 1.0);
     sentry_init(options);

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -135,7 +135,7 @@ SENTRY_TEST(transaction_name_backfill_on_finish)
 {
     uint64_t called = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport = sentry_transport_new(check_backfilled_name);
@@ -185,7 +185,7 @@ run_basic_function_transport_transaction(bool timestamped)
 {
     uint64_t called = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport
@@ -271,7 +271,7 @@ SENTRY_TEST(transport_sampling_transactions)
 {
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport
@@ -316,7 +316,7 @@ SENTRY_TEST(transactions_skip_before_send)
     uint64_t called_beforesend = 0;
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport
@@ -354,7 +354,7 @@ SENTRY_TEST(multiple_transactions)
 {
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport = sentry_transport_new(before_transport);
@@ -399,7 +399,7 @@ SENTRY_TEST(multiple_transactions)
 
 SENTRY_TEST(basic_spans)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_init(options);
 
@@ -453,7 +453,7 @@ SENTRY_TEST(basic_spans)
 
 SENTRY_TEST(spans_on_scope)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_init(options);
 
@@ -505,7 +505,7 @@ SENTRY_TEST(spans_on_scope)
 void
 run_child_spans_test(bool timestamped)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_options_set_max_spans(options, 3);
     sentry_init(options);
@@ -596,7 +596,7 @@ SENTRY_TEST(child_spans_ts) { run_child_spans_test(true); }
 
 SENTRY_TEST(overflow_spans)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_options_set_max_spans(options, 1);
     sentry_init(options);
@@ -647,7 +647,7 @@ SENTRY_TEST(overflow_spans)
 
 SENTRY_TEST(unsampled_spans)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_init(options);
 
@@ -733,7 +733,7 @@ SENTRY_TEST(drop_unfinished_spans)
 {
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport = sentry_transport_new(check_spans);
@@ -793,7 +793,7 @@ SENTRY_TEST(update_from_header_null_ctx)
 
 SENTRY_TEST(update_from_header_no_sampled_flag)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_options_set_traces_sample_rate(options, 1.0);
@@ -824,7 +824,7 @@ SENTRY_TEST(update_from_header_no_sampled_flag)
 
 SENTRY_TEST(distributed_headers_invalid_traceid)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_init(options);
@@ -878,7 +878,7 @@ SENTRY_TEST(distributed_headers_invalid_traceid)
 
 SENTRY_TEST(distributed_headers_invalid_spanid)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_init(options);
@@ -941,7 +941,7 @@ SENTRY_TEST(distributed_headers_invalid_spanid)
 
 SENTRY_TEST(distributed_headers)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_options_set_traces_sample_rate(options, 1.0);

--- a/tests/unit/test_uninit.c
+++ b/tests/unit/test_uninit.c
@@ -32,7 +32,7 @@ SENTRY_TEST(uninitialized)
 
 SENTRY_TEST(empty_transport)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_transport(options, NULL);
 
     TEST_CHECK(sentry_init(options) == 0);
@@ -47,7 +47,7 @@ SENTRY_TEST(empty_transport)
 
 SENTRY_TEST(invalid_dsn)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "not a valid dsn");
 
     TEST_CHECK(sentry_init(options) == 0);
@@ -62,7 +62,7 @@ SENTRY_TEST(invalid_dsn)
 
 SENTRY_TEST(invalid_proxy)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_proxy(options, "invalid");
 
     TEST_CHECK(sentry_init(options) == 0);


### PR DESCRIPTION
This helps with running unit tests on platforms that need to specify a custom directory to use for writing.

#skip-changelog - purely an internal change