### PR TITLE
feat: switch compilation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 - Add `traces_sampler` ([#1108](https://github.com/getsentry/sentry-native/pull/1108))
 - Provide support for C++17 compilers when using the `crashpad` backend. ([#1110](https://github.com/getsentry/sentry-native/pull/1110), [crashpad#116](https://github.com/getsentry/crashpad/pull/116), [mini_chromium#1](https://github.com/getsentry/mini_chromium/pull/1))
 
+**Fixes**:
+
+- Provide a mutex-initializer on platforms that have no static pthread initializer for recursive mutexes. ([#1113](https://github.com/getsentry/sentry-native/pull/1113))
+
 ## 0.7.17
 
 **Features**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Ensure that `sentry_capture_minidump()` fails if the provided minidump path cannot be attached, instead of sending a crash event without minidump. ([#1138](https://github.com/getsentry/sentry-native/pull/1138))
 - Fix Xbox OS name being reported incorrectly ([#1148](https://github.com/getsentry/sentry-native/pull/1148))
+- Provide a mutex-initializer on platforms that have no static pthread initializer for recursive mutexes. ([#1113](https://github.com/getsentry/sentry-native/pull/1113))
 
 **Thank you**:
 
@@ -41,10 +42,6 @@
 - Add option to set debug log level. ([#1107](https://github.com/getsentry/sentry-native/pull/1107))
 - Add `traces_sampler` ([#1108](https://github.com/getsentry/sentry-native/pull/1108))
 - Provide support for C++17 compilers when using the `crashpad` backend. ([#1110](https://github.com/getsentry/sentry-native/pull/1110), [crashpad#116](https://github.com/getsentry/crashpad/pull/116), [mini_chromium#1](https://github.com/getsentry/mini_chromium/pull/1))
-
-**Fixes**:
-
-- Provide a mutex-initializer on platforms that have no static pthread initializer for recursive mutexes. ([#1113](https://github.com/getsentry/sentry-native/pull/1113))
 
 ## 0.7.17
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -56,6 +56,8 @@ extern "C" {
 /* IBM i PASE is also counted as AIX */
 #    define SENTRY_PLATFORM_AIX
 #    define SENTRY_PLATFORM_UNIX
+#elif defined(__NX__)
+#    define SENTRY_PLATFORM_NX
 #else
 #    error unsupported platform
 #endif

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -37,7 +37,17 @@ process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
     goto fail
 
 static bool g_initialized = false;
+#ifdef SENTRY__MUTEX_INIT_DYN
+static sentry_mutex_t g_mutex;
+static pthread_once_t g_mutex_init_once = PTHREAD_ONCE_INIT;
+static void
+init_g_mutex(void)
+{
+    sentry__mutex_init(&g_mutex);
+}
+#else
 static sentry_mutex_t g_mutex = SENTRY__MUTEX_INIT;
+#endif
 static sentry_value_t g_modules = { 0 };
 
 static sentry_slice_t LINUX_GATE = { "linux-gate.so", 13 };
@@ -722,6 +732,9 @@ load_modules(sentry_value_t modules)
 sentry_value_t
 sentry_get_modules_list(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_mutex_init_once, init_g_mutex);
+#endif
     sentry__mutex_lock(&g_mutex);
     if (!g_initialized) {
         g_modules = sentry_value_new_list();
@@ -741,6 +754,9 @@ sentry_get_modules_list(void)
 void
 sentry_clear_modulecache(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_mutex_init_once, init_g_mutex);
+#endif
     sentry__mutex_lock(&g_mutex);
     sentry_value_decref(g_modules);
     g_modules = sentry_value_new_null();

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -52,6 +52,10 @@ write_loop(int fd, const char *buf, size_t buf_len)
 bool
 sentry__filelock_try_lock(sentry_filelock_t *lock)
 {
+#ifdef SENTRY_PLATFORM_NX
+    // TODO
+    return false;
+#endif
     lock->is_locked = false;
 
     int fd = open(lock->path->path, O_RDWR | O_CREAT | O_TRUNC,
@@ -87,6 +91,10 @@ sentry__filelock_try_lock(sentry_filelock_t *lock)
 void
 sentry__filelock_unlock(sentry_filelock_t *lock)
 {
+#ifdef SENTRY_PLATFORM_NX
+    // TODO
+    return;
+#endif
     if (!lock->is_locked) {
         return;
     }
@@ -99,6 +107,10 @@ sentry__filelock_unlock(sentry_filelock_t *lock)
 sentry_path_t *
 sentry__path_absolute(const sentry_path_t *path)
 {
+#ifdef SENTRY_PLATFORM_NX
+    // TODO
+    return sentry__path_from_str(path->path);
+#endif
     char full[PATH_MAX];
     if (!realpath(path->path, full)) {
         return NULL;

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -53,8 +53,8 @@ bool
 sentry__filelock_try_lock(sentry_filelock_t *lock)
 {
 #ifdef SENTRY_PLATFORM_NX
-    // TODO
-    return false;
+    // Nothing to do, other processes shouldn't be running at the same time.
+    return true;
 #endif
     lock->is_locked = false;
 
@@ -92,7 +92,7 @@ void
 sentry__filelock_unlock(sentry_filelock_t *lock)
 {
 #ifdef SENTRY_PLATFORM_NX
-    // TODO
+    // Nothing to do, see sentry__filelock_try_lock.
     return;
 #endif
     if (!lock->is_locked) {

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -22,7 +22,17 @@
 
 static bool g_scope_initialized = false;
 static sentry_scope_t g_scope = { 0 };
+#ifdef SENTRY__MUTEX_INIT_DYN
+static sentry_mutex_t g_lock;
+static pthread_once_t g_lock_init_once = PTHREAD_ONCE_INIT;
+static void
+init_g_lock(void)
+{
+    sentry__mutex_init(&g_lock);
+}
+#else
 static sentry_mutex_t g_lock = SENTRY__MUTEX_INIT;
+#endif
 
 static sentry_value_t
 get_client_sdk(void)
@@ -87,6 +97,9 @@ get_scope(void)
 void
 sentry__scope_cleanup(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_lock_init_once, init_g_lock);
+#endif
     sentry__mutex_lock(&g_lock);
     if (g_scope_initialized) {
         g_scope_initialized = false;
@@ -107,6 +120,9 @@ sentry__scope_cleanup(void)
 sentry_scope_t *
 sentry__scope_lock(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_lock_init_once, init_g_lock);
+#endif
     sentry__mutex_lock(&g_lock);
     return get_scope();
 }
@@ -114,6 +130,9 @@ sentry__scope_lock(void)
 void
 sentry__scope_unlock(void)
 {
+#ifdef SENTRY__MUTEX_INIT_DYN
+    pthread_once(&g_lock_init_once, init_g_lock);
+#endif
     sentry__mutex_unlock(&g_lock);
 }
 

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -222,6 +222,7 @@ sentry__symbolize_frame(const sentry_frame_info_t *info, void *data)
     }
 }
 
+#ifndef SENTRY_PLATFORM_NX
 static void
 sentry__symbolize_stacktrace(sentry_value_t stacktrace)
 {
@@ -249,6 +250,7 @@ sentry__symbolize_stacktrace(sentry_value_t stacktrace)
         sentry__symbolize((void *)addr, sentry__symbolize_frame, &frame);
     }
 }
+#endif
 
 sentry_value_t
 sentry__get_span_or_transaction(const sentry_scope_t *scope)
@@ -370,6 +372,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
         sentry_value_decref(l);
     }
 
+#ifndef SENTRY_PLATFORM_NX
     if (mode & SENTRY_SCOPE_MODULES) {
         sentry_value_t modules = sentry_get_modules_list();
         if (!sentry_value_is_null(modules)) {
@@ -382,6 +385,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
     if (mode & SENTRY_SCOPE_STACKTRACES) {
         sentry__foreach_stacktrace(event, sentry__symbolize_stacktrace);
     }
+#endif
 
 #undef PLACE_CLONED_VALUE
 #undef PLACE_VALUE

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -149,6 +149,7 @@ sentry__scope_flush_unlock(void)
     }
 }
 
+#ifndef SENTRY_PLATFORM_NX
 static void
 sentry__foreach_stacktrace(
     sentry_value_t event, void (*func)(sentry_value_t stacktrace))
@@ -222,7 +223,6 @@ sentry__symbolize_frame(const sentry_frame_info_t *info, void *data)
     }
 }
 
-#ifndef SENTRY_PLATFORM_NX
 static void
 sentry__symbolize_stacktrace(sentry_value_t stacktrace)
 {

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -490,7 +490,7 @@ sentry__bgworker_setname(sentry_bgworker_t *bgw, const char *thread_name)
     bgw->thread_name = sentry__string_clone(thread_name);
 }
 
-#ifdef SENTRY_PLATFORM_UNIX
+#if defined(SENTRY_PLATFORM_UNIX) || defined(SENTRY_PLATFORM_NX)
 #    include "sentry_unix_spinlock.h"
 
 static sig_atomic_t g_in_signal_handler = 0;

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -263,9 +263,8 @@ typedef pthread_cond_t sentry_cond_t;
                 }                                                              \
             }
 #    elif defined(__FreeBSD__)
-// Don't define SENTRY__MUTEX_INIT for platforms that require dynamic
-// initialization, but instead create a new definition that can be used by
-// platforms requiring dynamic recursive mutex initialization.
+// Don't define `SENTRY__MUTEX_INIT` but instead provide a new definition that
+// can be used by platforms requiring dynamic recursive mutex initialization.
 #        define SENTRY__MUTEX_INIT_DYN
 #    else
 #        define SENTRY__MUTEX_INIT PTHREAD_RECURSIVE_MUTEX_INITIALIZER

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -262,10 +262,15 @@ typedef pthread_cond_t sentry_cond_t;
                         PTHREAD_MUTEX_RECURSIVE                                \
                 }                                                              \
             }
+#    elif defined(__FreeBSD__)
+// Don't define SENTRY__MUTEX_INIT for platforms that require dynamic
+// initialization, but instead create a new definition that can be used by
+// platforms requiring dynamic recursive mutex initialization.
+#        define SENTRY__MUTEX_INIT_DYN
 #    else
 #        define SENTRY__MUTEX_INIT PTHREAD_RECURSIVE_MUTEX_INITIALIZER
 #    endif
-#    ifndef __FreeBSD__
+#    ifdef SENTRY__MUTEX_INIT_DYN
 #        define sentry__mutex_init(Mutex)                                      \
             do {                                                               \
                 pthread_mutexattr_t attr;                                      \

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -262,7 +262,7 @@ typedef pthread_cond_t sentry_cond_t;
                         PTHREAD_MUTEX_RECURSIVE                                \
                 }                                                              \
             }
-#    elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__) || defined(SENTRY_PLATFORM_NX)
 // Don't define `SENTRY__MUTEX_INIT` but instead provide a new definition that
 // can be used by platforms requiring dynamic recursive mutex initialization.
 #        define SENTRY__MUTEX_INIT_DYN

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -271,7 +271,7 @@ typedef pthread_cond_t sentry_cond_t;
                 pthread_mutexattr_t attr;                                      \
                 pthread_mutexattr_init(&attr);                                 \
                 pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);     \
-                pthread_mutex_init(Mutex, &attr);                           \
+                pthread_mutex_init(Mutex, &attr);                              \
                 pthread_mutexattr_destroy(&attr);                              \
             } while (0)
 #    else

--- a/src/sentry_unix_pageallocator.c
+++ b/src/sentry_unix_pageallocator.c
@@ -5,12 +5,13 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#ifndef SENTRY_PLATFORM_NX
 // some macos versions do not have this yet
-#if !defined(MAP_ANONYMOUS) && defined(SENTRY_PLATFORM_DARWIN)
-#    define MAP_ANONYMOUS MAP_ANON
-#endif
+#    if !defined(MAP_ANONYMOUS) && defined(SENTRY_PLATFORM_DARWIN)
+#        define MAP_ANONYMOUS MAP_ANON
+#    endif
 
-#define ALIGN 8
+#    define ALIGN 8
 
 struct page_header;
 struct page_header {
@@ -60,11 +61,11 @@ get_pages(size_t num_pages)
         return NULL;
     }
 
-#if defined(__has_feature)
-#    if __has_feature(memory_sanitizer)
+#    if defined(__has_feature)
+#        if __has_feature(memory_sanitizer)
     __msan_unpoison(rv, g_alloc->page_size * num_pages);
+#        endif
 #    endif
-#endif
 
     struct page_header *header = (struct page_header *)rv;
     header->next = g_alloc->last_page;
@@ -125,7 +126,7 @@ sentry__page_allocator_alloc(size_t size)
     return rv;
 }
 
-#ifdef SENTRY_UNITTEST
+#    ifdef SENTRY_UNITTEST
 void
 sentry__page_allocator_disable(void)
 {
@@ -139,4 +140,5 @@ sentry__page_allocator_disable(void)
     }
     g_alloc = NULL;
 }
+#    endif
 #endif

--- a/src/symbolizer/sentry_symbolizer_unix.c
+++ b/src/symbolizer/sentry_symbolizer_unix.c
@@ -186,6 +186,7 @@ dladdr(void *s, Dl_info *i)
 }
 #endif
 
+#ifndef SENTRY_PLATFORM_NX
 bool
 sentry__symbolize(
     void *addr, void (*func)(const sentry_frame_info_t *, void *), void *data)
@@ -204,14 +205,15 @@ sentry__symbolize(
     frame_info.symbol = info.dli_sname;
     frame_info.object_name = info.dli_fname;
     func(&frame_info, data);
-#ifdef SENTRY_PLATFORM_AIX
+#    ifdef SENTRY_PLATFORM_AIX
     // On AIX these must be freed. Hope the the callback doesn't use that
     // buffer...
     // XXX: We may just be able to stuff it into a fixed-length field of
     // Dl_info?
     free(info.dli_sname);
     free(info.dli_fname);
-#endif
+#    endif
 
     return true;
 }
+#endif

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -1,4 +1,7 @@
-#define SENTRY_TEST_DEFINE_MAIN
+#include "sentry_boot.h"
+#ifndef SENTRY_PLATFORM_NX
+#    define SENTRY_TEST_DEFINE_MAIN
+#endif
 
 #include "sentry_testsupport.h"
 

--- a/tests/unit/sentry_testsupport.h
+++ b/tests/unit/sentry_testsupport.h
@@ -58,3 +58,14 @@
 #else
 #    define TEST_VISIBLE
 #endif
+
+#ifdef SENTRY_TEST_PATH_PREFIX
+#    define SENTRY_TEST_OPTIONS_NEW(Varname)                                   \
+        sentry_options_t *Varname = sentry_options_new();                      \
+        sentry_options_set_database_path(                                      \
+            Varname, SENTRY_TEST_PATH_PREFIX ".sentry-native");
+#else
+#    define SENTRY_TEST_PATH_PREFIX ""
+#    define SENTRY_TEST_OPTIONS_NEW(Varname)                                   \
+        sentry_options_t *Varname = sentry_options_new();
+#endif

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -17,19 +17,13 @@ send_envelope_test_attachments(const sentry_envelope_t *envelope, void *_data)
         envelope, &data->serialized_envelope);
 }
 
-#ifdef __ANDROID__
-#    define PREFIX "/data/local/tmp/"
-#else
-#    define PREFIX ""
-#endif
-
 SENTRY_TEST(lazy_attachments)
 {
     sentry_attachments_testdata_t testdata;
     testdata.called = 0;
     sentry__stringbuilder_init(&testdata.serialized_envelope);
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_auto_session_tracking(options, false);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(options,
@@ -38,13 +32,14 @@ SENTRY_TEST(lazy_attachments)
     char rel[] = { 't', 'e', 's', 't' };
     sentry_options_set_release_n(options, rel, sizeof(rel));
 
-    sentry_options_add_attachment(options, PREFIX ".existing-file-attachment");
     sentry_options_add_attachment(
-        options, PREFIX ".non-existing-file-attachment");
-    sentry_path_t *existing
-        = sentry__path_from_str(PREFIX ".existing-file-attachment");
-    sentry_path_t *non_existing
-        = sentry__path_from_str(PREFIX ".non-existing-file-attachment");
+        options, SENTRY_TEST_PATH_PREFIX ".existing-file-attachment");
+    sentry_options_add_attachment(
+        options, SENTRY_TEST_PATH_PREFIX ".non-existing-file-attachment");
+    sentry_path_t *existing = sentry__path_from_str(
+        SENTRY_TEST_PATH_PREFIX ".existing-file-attachment");
+    sentry_path_t *non_existing = sentry__path_from_str(
+        SENTRY_TEST_PATH_PREFIX ".non-existing-file-attachment");
 
     sentry_init(options);
 

--- a/tests/unit/test_concurrency.c
+++ b/tests/unit/test_concurrency.c
@@ -20,7 +20,7 @@ send_envelope_test_concurrent(const sentry_envelope_t *envelope, void *data)
 static void
 init_framework(long *called)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(options,
         sentry_new_function_transport(send_envelope_test_concurrent, called));

--- a/tests/unit/test_consent.c
+++ b/tests/unit/test_consent.c
@@ -4,13 +4,8 @@
 static void
 init_consenting_sentry(void)
 {
-#ifdef __ANDROID__
-#    define PREFIX "/data/local/tmp/"
-#else
-#    define PREFIX ""
-#endif
     sentry_options_t *opts = sentry_options_new();
-    sentry_options_set_database_path(opts, PREFIX ".test-db");
+    sentry_options_set_database_path(opts, SENTRY_TEST_PATH_PREFIX ".test-db");
     sentry_options_set_dsn(opts, "http://foo@127.0.0.1/42");
     sentry_options_set_require_user_consent(opts, true);
     sentry_init(opts);
@@ -18,7 +13,8 @@ init_consenting_sentry(void)
 
 SENTRY_TEST(basic_consent_tracking)
 {
-    sentry_path_t *path = sentry__path_from_str(PREFIX ".test-db");
+    sentry_path_t *path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".test-db");
     sentry__path_remove_all(path);
 
     init_consenting_sentry();

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -177,7 +177,7 @@ SENTRY_TEST(basic_http_request_preparation_for_minidump)
 sentry_envelope_t *
 create_test_envelope()
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_init(options);
 
@@ -219,9 +219,9 @@ SENTRY_TEST(serialize_envelope)
 SENTRY_TEST(basic_write_envelope_to_file)
 {
     sentry_envelope_t *envelope = create_test_envelope();
-    const char *test_file_str = "sentry_test_envelope";
-    sentry_path_t *test_file_path = sentry__path_from_str(test_file_str);
-    int rv = sentry_envelope_write_to_file(envelope, test_file_str);
+    sentry_path_t *test_file_path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "sentry_test_envelope");
+    int rv = sentry_envelope_write_to_file(envelope, test_file_path->path);
     TEST_CHECK_INT_EQUAL(rv, 0);
     TEST_ASSERT(sentry__path_is_file(test_file_path));
 
@@ -257,11 +257,11 @@ SENTRY_TEST(write_envelope_to_file_null)
 SENTRY_TEST(write_envelope_to_invalid_path)
 {
     sentry_envelope_t *envelope = create_test_envelope();
-    const char *test_file_str
-        = "./directory_that_does_not_exist/sentry_test_envelope";
-    sentry_path_t *test_file_path = sentry__path_from_str(test_file_str);
+    sentry_path_t *test_file_path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX
+            "./directory_that_does_not_exist/sentry_test_envelope");
 
-    int rv = sentry_envelope_write_to_file(envelope, test_file_str);
+    int rv = sentry_envelope_write_to_file(envelope, test_file_path->path);
     TEST_CHECK_INT_EQUAL(rv, 1);
 
     sentry__path_remove(test_file_path);

--- a/tests/unit/test_failures.c
+++ b/tests/unit/test_failures.c
@@ -19,7 +19,7 @@ SENTRY_TEST(init_failure)
         = sentry_new_function_transport(noop_send, NULL);
     sentry_transport_set_startup_func(transport, transport_startup_fail);
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_transport(options, transport);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     int rv = sentry_init(options);

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -28,7 +28,7 @@ SENTRY_TEST(custom_logger)
 {
     logger_test_t data = { 0, false };
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_debug(options, true);
     sentry_options_set_logger(options, test_logger, &data);
 

--- a/tests/unit/test_modulefinder.c
+++ b/tests/unit/test_modulefinder.c
@@ -7,6 +7,9 @@
 
 SENTRY_TEST(module_finder)
 {
+#ifdef SENTRY_PLATFORM_NX
+    return SKIP_TEST();
+#endif
     // make sure that we are able to do multiple cleanup cycles
     sentry_value_decref(sentry_get_modules_list());
     sentry_clear_modulecache();

--- a/tests/unit/test_mpack.c
+++ b/tests/unit/test_mpack.c
@@ -16,7 +16,7 @@ SENTRY_TEST(mpack_removed_tags)
     sentry_set_extra("int", sentry_value_new_int32(1234));
     sentry_set_extra("double", sentry_value_new_double(12.34));
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     SENTRY_WITH_SCOPE (scope) {
         sentry__scope_apply_to_event(scope, options, obj, SENTRY_SCOPE_NONE);
     }
@@ -30,12 +30,6 @@ SENTRY_TEST(mpack_removed_tags)
     sentry__scope_cleanup();
 }
 
-#ifdef __ANDROID__
-#    define PREFIX "/data/local/tmp/"
-#else
-#    define PREFIX ""
-#endif
-
 SENTRY_TEST(mpack_newlines)
 {
     sentry_value_t o = sentry_value_new_object();
@@ -46,7 +40,8 @@ SENTRY_TEST(mpack_newlines)
     size_t size;
     char *buf = sentry_value_to_msgpack(o, &size);
 
-    sentry_path_t *file = sentry__path_from_str(PREFIX ".mpack-buf");
+    sentry_path_t *file
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".mpack-buf");
     sentry__path_append_buffer(file, buf, size);
 
     size_t size_rt;

--- a/tests/unit/test_options.c
+++ b/tests/unit/test_options.c
@@ -3,7 +3,7 @@
 
 SENTRY_TEST(options_sdk_name_defaults)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     // when nothing is set
 
     // then both sdk name and user agent should default to the build time
@@ -18,7 +18,7 @@ SENTRY_TEST(options_sdk_name_defaults)
 
 SENTRY_TEST(options_sdk_name_custom)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
 
     // when the sdk name is set to a custom string
     const int result
@@ -37,7 +37,7 @@ SENTRY_TEST(options_sdk_name_custom)
 
 SENTRY_TEST(options_sdk_name_invalid)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
 
     // when the sdk name is set to an invalid value
     const char *sdk_name = NULL;

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -4,7 +4,7 @@
 
 SENTRY_TEST(recursive_paths)
 {
-    sentry_path_t *base = sentry__path_from_str(".foo");
+    sentry_path_t *base = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".foo");
     sentry_path_t *nested = sentry__path_join_str(base, "bar");
     sentry_path_t *nested2 = sentry__path_join_str(nested, "baz");
     sentry_path_t *file =
@@ -141,7 +141,7 @@ SENTRY_TEST(path_basics)
 {
     size_t items = 0;
     const sentry_path_t *p;
-    sentry_path_t *path = sentry__path_from_str(".");
+    sentry_path_t *path = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".");
     TEST_CHECK(!!path);
 
     sentry_pathiter_t *piter = sentry__path_iter_directory(path);
@@ -166,10 +166,13 @@ SENTRY_TEST(path_current_exe)
 
 SENTRY_TEST(path_directory)
 {
-    sentry_path_t *path_1 = sentry__path_from_str("foo");
-    sentry_path_t *path_2 = sentry__path_from_str("foo/bar");
+    sentry_path_t *path_1
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "foo");
+    sentry_path_t *path_2
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "foo/bar");
 #ifdef SENTRY_PLATFORM_WINDOWS
-    sentry_path_t *path_3 = sentry__path_from_str("foo/bar\\baz");
+    sentry_path_t *path_3
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX "foo/bar\\baz");
 
     // `%TEMP%\sentry_test_unit`
     wchar_t temp_folder[MAX_PATH];

--- a/tests/unit/test_sampling.c
+++ b/tests/unit/test_sampling.c
@@ -46,7 +46,7 @@ traces_sampler_callback(const sentry_transaction_context_t *transaction_ctx,
 
 SENTRY_TEST(sampling_transaction)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     TEST_CHECK(sentry_init(options) == 0);
 
     sentry_transaction_context_t *tx_ctx

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -55,7 +55,7 @@ send_envelope(const sentry_envelope_t *envelope, void *data)
 SENTRY_TEST(session_basics)
 {
     uint64_t called = 0;
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(
         options, sentry_new_function_transport(send_envelope, &called));
@@ -139,7 +139,7 @@ SENTRY_TEST(count_sampled_events)
 {
     session_assertion_t assertion = { false, 0 };
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_transport(options,
         sentry_new_function_transport(send_sampled_envelope, &assertion));

--- a/tests/unit/test_symbolizer.c
+++ b/tests/unit/test_symbolizer.c
@@ -30,6 +30,9 @@ asserter(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(symbolizer)
 {
+#ifdef SENTRY_PLATFORM_NX
+    return SKIP_TEST();
+#endif
     int called = 0;
 #ifdef SENTRY_PLATFORM_AIX
     sentry__symbolize(

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -135,7 +135,7 @@ SENTRY_TEST(transaction_name_backfill_on_finish)
 {
     uint64_t called = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport = sentry_transport_new(check_backfilled_name);
@@ -185,7 +185,7 @@ run_basic_function_transport_transaction(bool timestamped)
 {
     uint64_t called = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport
@@ -271,7 +271,7 @@ SENTRY_TEST(transport_sampling_transactions)
 {
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport
@@ -316,7 +316,7 @@ SENTRY_TEST(transactions_skip_before_send)
     uint64_t called_beforesend = 0;
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport
@@ -354,7 +354,7 @@ SENTRY_TEST(multiple_transactions)
 {
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport = sentry_transport_new(before_transport);
@@ -399,7 +399,7 @@ SENTRY_TEST(multiple_transactions)
 
 SENTRY_TEST(basic_spans)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_init(options);
 
@@ -453,7 +453,7 @@ SENTRY_TEST(basic_spans)
 
 SENTRY_TEST(spans_on_scope)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_init(options);
 
@@ -505,7 +505,7 @@ SENTRY_TEST(spans_on_scope)
 void
 run_child_spans_test(bool timestamped)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_options_set_max_spans(options, 3);
     sentry_init(options);
@@ -596,7 +596,7 @@ SENTRY_TEST(child_spans_ts) { run_child_spans_test(true); }
 
 SENTRY_TEST(overflow_spans)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_options_set_max_spans(options, 1);
     sentry_init(options);
@@ -647,7 +647,7 @@ SENTRY_TEST(overflow_spans)
 
 SENTRY_TEST(unsampled_spans)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_traces_sample_rate(options, 1.0);
     sentry_init(options);
 
@@ -733,7 +733,7 @@ SENTRY_TEST(drop_unfinished_spans)
 {
     uint64_t called_transport = 0;
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_transport_t *transport = sentry_transport_new(check_spans);
@@ -793,7 +793,7 @@ SENTRY_TEST(update_from_header_null_ctx)
 
 SENTRY_TEST(update_from_header_no_sampled_flag)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_options_set_traces_sample_rate(options, 1.0);
@@ -824,7 +824,7 @@ SENTRY_TEST(update_from_header_no_sampled_flag)
 
 SENTRY_TEST(distributed_headers_invalid_traceid)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_init(options);
@@ -878,7 +878,7 @@ SENTRY_TEST(distributed_headers_invalid_traceid)
 
 SENTRY_TEST(distributed_headers_invalid_spanid)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_init(options);
@@ -941,7 +941,7 @@ SENTRY_TEST(distributed_headers_invalid_spanid)
 
 SENTRY_TEST(distributed_headers)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
 
     sentry_options_set_traces_sample_rate(options, 1.0);

--- a/tests/unit/test_uninit.c
+++ b/tests/unit/test_uninit.c
@@ -32,7 +32,7 @@ SENTRY_TEST(uninitialized)
 
 SENTRY_TEST(empty_transport)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_transport(options, NULL);
 
     TEST_CHECK(sentry_init(options) == 0);
@@ -47,7 +47,7 @@ SENTRY_TEST(empty_transport)
 
 SENTRY_TEST(invalid_dsn)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "not a valid dsn");
 
     TEST_CHECK(sentry_init(options) == 0);
@@ -62,7 +62,7 @@ SENTRY_TEST(invalid_dsn)
 
 SENTRY_TEST(invalid_proxy)
 {
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_proxy(options, "invalid");
 
     TEST_CHECK(sentry_init(options) == 0);

--- a/tests/unit/test_unwinder.c
+++ b/tests/unit/test_unwinder.c
@@ -1,3 +1,4 @@
+#include "sentry_boot.h"
 #include "sentry_symbolizer.h"
 #include "sentry_testsupport.h"
 
@@ -37,6 +38,9 @@ find_frame(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(unwinder)
 {
+#ifdef SENTRY_PLATFORM_NX
+    return SKIP_TEST();
+#endif
     void *backtrace1[MAX_FRAMES] = { 0 };
     size_t frame_count1 = invoke_unwinder(backtrace1);
     size_t invoker_frame = 0;

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -1445,11 +1445,13 @@ test_cmdline_callback__(int id, const char* arg)
             test_worker_index__ = atoi(arg);
             break;
         case 'x':
+#        if defined(ACUTEST_UNIX__)
             test_xml_output__ = fopen(arg, "w");
             if (!test_xml_output__) {
                 fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
                 exit(2);
             }
+#endif
             break;
 
         case 0:
@@ -1478,7 +1480,6 @@ test_cmdline_callback__(int id, const char* arg)
 
     return 0;
 }
-
 
 #ifdef ACUTEST_LINUX__
 static int
@@ -1528,11 +1529,11 @@ main(int argc, char** argv)
 #if defined ACUTEST_UNIX__
     test_colorize__ = isatty(STDOUT_FILENO);
 #elif defined ACUTEST_WIN__
- #if defined __BORLANDC__
+#if defined __BORLANDC__
     test_colorize__ = isatty(_fileno(stdout));
- #else
+#else
     test_colorize__ = _isatty(_fileno(stdout));
- #endif
+#endif
 #else
     test_colorize__ = 0;
 #endif
@@ -1660,12 +1661,10 @@ main(int argc, char** argv)
     return (test_stat_failed_units__ == 0) ? 0 : 1;
 }
 
-
 #endif  /* #ifndef TEST_NO_MAIN */
 
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif
-
 
 #endif  /* #ifndef ACUTEST_H__ */


### PR DESCRIPTION
Enables as to build the SDK on Switch. Doesn't actually depend on any Switch SDKs - just updates the whitelist the platform & updates a few places that use generic C APIs.

I've split out some self-contained small PRs that should be handled first:

* #1162 
* #1163 
* #1164 