### PR TITLE
feat: screenshot capture (windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add option to attach screenshots on Windows to fatal error events. ([#1170](https://github.com/getsentry/sentry-native/pull/1170))
+
 ## 0.8.2
 
 **Fixes**:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,7 @@ endif()
 
 if(SENTRY_BUILD_TESTS)
 	add_subdirectory(tests/unit)
+	add_subdirectory(tests/fixtures/screenshot)
 endif()
 
 # ===== example, also used as integration test =====

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1187,6 +1187,17 @@ SENTRY_API void sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len);
 
 /**
+ * Enables or disables attaching screenshots to fatal error events. Disabled by
+ * default.
+ *
+ * This feature is currently supported by all backends on Windows. Only the
+ * `crashpad` backend can capture screenshots of fast-fail crashes that bypass
+ * SEH (structured exception handling).
+ */
+SENTRY_EXPERIMENTAL_API void sentry_options_set_attach_screenshot(
+    sentry_options_t *opts, int val);
+
+/**
  * Sets the path to the crashpad handler if the crashpad backend is used.
  *
  * The path defaults to the `crashpad_handler`/`crashpad_handler.exe`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ sentry_target_sources_cwd(sentry
 	sentry_sampling_context.h
 	sentry_scope.c
 	sentry_scope.h
+	sentry_screenshot.h
 	sentry_session.c
 	sentry_session.h
 	sentry_slice.c
@@ -45,6 +46,7 @@ sentry_target_sources_cwd(sentry
 	sentry_tracing.c
 	sentry_tracing.h
 	path/sentry_path.c
+	screenshot/sentry_screenshot.c
 	transports/sentry_disk_transport.c
 	transports/sentry_disk_transport.h
 	transports/sentry_function_transport.c
@@ -162,5 +164,16 @@ if(SENTRY_INTEGRATION_QT)
 	sentry_target_sources_cwd(sentry
 		integrations/sentry_integration_qt.cpp
 		integrations/sentry_integration_qt.h
+	)
+endif()
+
+# screenshot
+if(WIN32)
+	sentry_target_sources_cwd(sentry
+		screenshot/sentry_screenshot_windows.c
+	)
+else()
+	sentry_target_sources_cwd(sentry
+		screenshot/sentry_screenshot_none.c
 	)
 endif()

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #    include "sentry_os.h"
 #endif
 #include "sentry_path.h"
+#include "sentry_screenshot.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
 #include "sentry_transport.h"
@@ -162,6 +163,16 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
                     sentry_value_new_string(
 #endif
                         sentry__path_filename(dump_path)));
+            }
+
+            if (options->attach_screenshot) {
+                sentry_path_t *screenshot_path
+                    = sentry__screenshot_get_path(options);
+                if (sentry__screenshot_capture(screenshot_path)) {
+                    sentry__envelope_add_attachment(
+                        envelope, screenshot_path, NULL);
+                }
+                sentry__path_free(screenshot_path);
             }
 
             // capture the envelope with the disk transport

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #    include "sentry_os.h"
 #endif
 #include "sentry_path.h"
+#include "sentry_screenshot.h"
 #include "sentry_sync.h"
 #include "sentry_transport.h"
 #ifdef SENTRY_PLATFORM_LINUX
@@ -445,6 +446,13 @@ crashpad_backend_startup(
             base::FilePath(data->breadcrumb1_path->path),
             base::FilePath(data->breadcrumb2_path->path) });
 
+    base::FilePath screenshot;
+    if (options->attach_screenshot) {
+        sentry_path_t *screenshot_path = sentry__screenshot_get_path(options);
+        screenshot = base::FilePath(screenshot_path->path);
+        sentry__path_free(screenshot_path);
+    }
+
     std::vector<std::string> arguments { "--no-rate-limit" };
 
     // Initialize database first, flushing the consent later on as part of
@@ -471,7 +479,7 @@ crashpad_backend_startup(
     bool success = data->client->StartHandler(handler, database, database,
         minidump_url ? minidump_url : "", proxy_url, annotations, arguments,
         /* restartable */ true,
-        /* asynchronous_start */ false, attachments);
+        /* asynchronous_start */ false, attachments, screenshot);
     sentry_free(minidump_url);
 
 #ifdef SENTRY_PLATFORM_WINDOWS

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -10,6 +10,7 @@
 #    include "sentry_os.h"
 #endif
 #include "sentry_scope.h"
+#include "sentry_screenshot.h"
 #include "sentry_sync.h"
 #include "sentry_transport.h"
 #include "sentry_unix_pageallocator.h"
@@ -592,6 +593,16 @@ handle_ucontext(const sentry_ucontext_t *uctx)
             sentry_session_t *session = sentry__end_current_session_with_status(
                 SENTRY_SESSION_STATUS_CRASHED);
             sentry__envelope_add_session(envelope, session);
+
+            if (options->attach_screenshot) {
+                sentry_path_t *screenshot_path
+                    = sentry__screenshot_get_path(options);
+                if (sentry__screenshot_capture(screenshot_path)) {
+                    sentry__envelope_add_attachment(
+                        envelope, screenshot_path, NULL);
+                }
+                sentry__path_free(screenshot_path);
+            }
 
             // capture the envelope with the disk transport
             sentry_transport_t *disk_transport

--- a/src/screenshot/sentry_screenshot.c
+++ b/src/screenshot/sentry_screenshot.c
@@ -1,0 +1,13 @@
+#include "sentry_screenshot.h"
+
+#include "sentry_database.h"
+
+sentry_path_t *
+sentry__screenshot_get_path(const sentry_options_t *options)
+{
+#ifdef SENTRY_PLATFORM_WINDOWS
+    return sentry__path_join_wstr(options->run->run_path, L"screenshot.png");
+#else
+    return sentry__path_join_str(options->run->run_path, "screenshot.png");
+#endif
+}

--- a/src/screenshot/sentry_screenshot_none.c
+++ b/src/screenshot/sentry_screenshot_none.c
@@ -1,0 +1,9 @@
+#include "sentry_screenshot.h"
+
+#include "sentry_core.h"
+
+bool
+sentry__screenshot_capture(const sentry_path_t *UNUSED(path))
+{
+    return false;
+}

--- a/src/screenshot/sentry_screenshot_windows.c
+++ b/src/screenshot/sentry_screenshot_windows.c
@@ -1,0 +1,183 @@
+#include "sentry_screenshot.h"
+
+#include "sentry_logger.h"
+#include "sentry_path.h"
+
+#ifndef DWMWA_EXTENDED_FRAME_BOUNDS
+#    define DWMWA_EXTENDED_FRAME_BOUNDS 9
+#endif
+
+typedef enum { GpOk = 0 } GpStatus;
+typedef struct {
+    UINT32 GdiplusVersion;
+    PVOID DebugEventCallback;
+    BOOL SuppressBackgroundThread;
+    BOOL SuppressExternalCodecs;
+} GdiplusStartupInput;
+typedef void GpBitmap;
+typedef void GpImage;
+
+typedef GpStatus(WINAPI *GdiplusStartup_t)(
+    ULONG_PTR *token, const GdiplusStartupInput *input, void *output);
+typedef GpStatus(WINAPI *GdipCreateBitmapFromHBITMAP_t)(
+    HBITMAP hbm, HPALETTE hpal, GpBitmap **bitmap);
+typedef GpStatus(WINAPI *GdipSaveImageToFile_t)(GpImage *image,
+    const wchar_t *filename, const CLSID *encoder, const void *params);
+typedef GpStatus(WINAPI *GdipDisposeImage_t)(GpImage *image);
+
+typedef HRESULT(WINAPI *DwmGetWindowAttribute_t)(
+    HWND hwnd, DWORD dwAttribute, PVOID pvAttribute, DWORD cbAttribute);
+
+static HMODULE
+load_library(LPCWSTR name)
+{
+    HMODULE library = LoadLibraryW(name);
+    if (!library) {
+        SENTRY_WARNF(
+            "`LoadLibraryW(%S)` failed with code `%d`", name, GetLastError());
+    }
+    return library;
+}
+
+static FARPROC
+get_proc_address(HMODULE module, LPCSTR name)
+{
+    FARPROC proc = GetProcAddress(module, name);
+    if (!proc) {
+        SENTRY_WARNF(
+            "`GetProcAddress(%s)` failed with code `%d`", name, GetLastError());
+    }
+    return proc;
+}
+
+static bool
+save_bitmap(HBITMAP bitmap, const wchar_t *path)
+{
+    HMODULE gdiplus = load_library(L"gdiplus.dll");
+    if (!gdiplus) {
+        return false;
+    }
+
+    GdiplusStartup_t pGdiplusStartup
+        = (GdiplusStartup_t)get_proc_address(gdiplus, "GdiplusStartup");
+    GdipCreateBitmapFromHBITMAP_t pGdipCreateBitmapFromHBITMAP
+        = (GdipCreateBitmapFromHBITMAP_t)get_proc_address(
+            gdiplus, "GdipCreateBitmapFromHBITMAP");
+    GdipSaveImageToFile_t pGdipSaveImageToFile
+        = (GdipSaveImageToFile_t)get_proc_address(
+            gdiplus, "GdipSaveImageToFile");
+    GdipDisposeImage_t pGdipDisposeImage
+        = (GdipDisposeImage_t)get_proc_address(gdiplus, "GdipDisposeImage");
+
+    if (!pGdiplusStartup || !pGdipCreateBitmapFromHBITMAP
+        || !pGdipSaveImageToFile || !pGdipDisposeImage) {
+        FreeLibrary(gdiplus);
+        return false;
+    }
+
+    GdiplusStartupInput input;
+    ZeroMemory(&input, sizeof(input));
+    input.GdiplusVersion = 1;
+
+    ULONG_PTR token = 0;
+    if (pGdiplusStartup(&token, &input, NULL) != GpOk) {
+        SENTRY_WARNF("`GdiplusStartup` failed with code `%d`", GetLastError());
+        FreeLibrary(gdiplus);
+        return false;
+    }
+
+    GpImage *image = NULL;
+    if (pGdipCreateBitmapFromHBITMAP(bitmap, NULL, &image) != GpOk) {
+        SENTRY_WARNF("`GdipCreateBitmapFromHBITMAP` failed with code `%d`",
+            GetLastError());
+        FreeLibrary(gdiplus);
+        return false;
+    }
+
+    // CLSIDFromString(L"{557cf406-1a04-11d3-9a73-0000f81ef32e}")
+    CLSID GdiPngEncoder = { 0x557cf406, 0x1a04, 0x11d3,
+        { 0x9a, 0x73, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e } };
+    GpStatus rv = pGdipSaveImageToFile(image, path, &GdiPngEncoder, NULL);
+    if (rv != GpOk) {
+        SENTRY_WARNF(
+            "`GdipSaveImageToFile` failed with code `%d`", GetLastError());
+    }
+    pGdipDisposeImage(image);
+    FreeLibrary(gdiplus);
+    return rv == GpOk;
+}
+
+static void
+calculate_region(DWORD pid, HRGN region)
+{
+    HMODULE dwmapi = load_library(L"dwmapi.dll");
+    if (!dwmapi) {
+        return;
+    }
+    DwmGetWindowAttribute_t pDwmGetWindowAttribute
+        = (DwmGetWindowAttribute_t)get_proc_address(
+            dwmapi, "DwmGetWindowAttribute");
+    if (!pDwmGetWindowAttribute) {
+        return;
+    }
+
+    HWND hwnd = GetShellWindow();
+    while (hwnd) {
+        if (IsWindowVisible(hwnd)) {
+            RECT frame = { 0 };
+            pDwmGetWindowAttribute(
+                hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &frame, sizeof(RECT));
+            if (frame.right > frame.left && frame.bottom > frame.top) {
+                DWORD wpid = 0;
+                GetWindowThreadProcessId(hwnd, &wpid);
+                HRGN wregion = CreateRectRgnIndirect(&frame);
+                if (wpid == pid) {
+                    CombineRgn(region, region, wregion, RGN_OR);
+                } else {
+                    CombineRgn(region, region, wregion, RGN_DIFF);
+                }
+                DeleteObject(wregion);
+            }
+        }
+        hwnd = GetWindow(hwnd, GW_HWNDPREV);
+    }
+}
+
+bool
+sentry__screenshot_capture(const sentry_path_t *path)
+{
+    HRGN region = CreateRectRgn(0, 0, 0, 0);
+    calculate_region(GetCurrentProcessId(), region);
+
+    RECT box;
+    GetRgnBox(region, &box);
+    LONG width = box.right - box.left;
+    LONG height = box.bottom - box.top;
+    if (width <= 0 || height <= 0) {
+        SENTRY_INFO("no visible windows to capture");
+        DeleteObject(region);
+        return false;
+    }
+
+    HDC src = GetDC(NULL);
+    HDC hdc = CreateCompatibleDC(src);
+    HBITMAP bitmap = CreateCompatibleBitmap(src, width, height);
+    SelectObject(hdc, bitmap);
+    OffsetRgn(region, -box.left, -box.top);
+    SelectClipRgn(hdc, region);
+    BitBlt(hdc, 0, 0, width, height, src, box.left, box.top, SRCCOPY);
+
+    bool rv = save_bitmap(bitmap, path->path);
+    if (!rv) {
+        SENTRY_WARNF(
+            "Failed to save screenshot: \"%" SENTRY_PATH_PRI "\"", path->path);
+    } else {
+        SENTRY_DEBUGF("Saved screenshot: \"%" SENTRY_PATH_PRI "\"", path->path);
+    }
+
+    DeleteObject(bitmap);
+    DeleteDC(hdc);
+    ReleaseDC(NULL, src);
+    DeleteObject(region);
+    return rv;
+}

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -12,6 +12,7 @@
 #include "sentry_path.h"
 #include "sentry_random.h"
 #include "sentry_scope.h"
+#include "sentry_screenshot.h"
 #include "sentry_session.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -346,6 +346,32 @@ sentry__envelope_add_session(
 }
 
 sentry_envelope_item_t *
+sentry__envelope_add_attachment(sentry_envelope_t *envelope,
+    const sentry_path_t *attachment, const char *type)
+{
+    if (!envelope || !attachment) {
+        return NULL;
+    }
+
+    sentry_envelope_item_t *item
+        = sentry__envelope_add_from_path(envelope, attachment, "attachment");
+    if (type) {
+        sentry__envelope_item_set_header(
+            item, "attachment_type", sentry_value_new_string(type));
+    }
+
+    sentry__envelope_item_set_header(item, "filename",
+#ifdef SENTRY_PLATFORM_WINDOWS
+        sentry__value_new_string_from_wstr(
+#else
+        sentry_value_new_string(
+#endif
+            sentry__path_filename(attachment)));
+
+    return item;
+}
+
+sentry_envelope_item_t *
 sentry__envelope_add_from_buffer(sentry_envelope_t *envelope, const char *buf,
     size_t buf_len, const char *type)
 {

--- a/src/sentry_envelope.h
+++ b/src/sentry_envelope.h
@@ -55,6 +55,13 @@ sentry_envelope_item_t *sentry__envelope_add_session(
     sentry_envelope_t *envelope, const sentry_session_t *session);
 
 /**
+ * Add an attachment to this envelope.
+ */
+sentry_envelope_item_t *sentry__envelope_add_attachment(
+    sentry_envelope_t *envelope, const sentry_path_t *attachment,
+    const char *type);
+
+/**
  * This will add the file contents from `path` as an envelope item of type
  * `type`.
  */

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -47,6 +47,7 @@ sentry_options_new(void)
     opts->user_consent = SENTRY_USER_CONSENT_UNKNOWN;
     opts->auto_session_tracking = true;
     opts->system_crash_reporter_enabled = false;
+    opts->attach_screenshot = false;
     opts->symbolize_stacktraces =
     // AIX doesn't have reliable debug IDs for server-side symbolication,
     // and the diversity of Android makes it infeasible to have access to debug
@@ -491,6 +492,12 @@ sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len)
 {
     add_attachment(opts, sentry__path_from_str_n(path, path_len));
+}
+
+void
+sentry_options_set_attach_screenshot(sentry_options_t *opts, int val)
+{
+    opts->attach_screenshot = !!val;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -48,6 +48,7 @@ struct sentry_options_s {
     bool require_user_consent;
     bool symbolize_stacktraces;
     bool system_crash_reporter_enabled;
+    bool attach_screenshot;
 
     sentry_attachment_t *attachments;
     sentry_run_t *run;

--- a/src/sentry_screenshot.h
+++ b/src/sentry_screenshot.h
@@ -1,0 +1,21 @@
+#ifndef SENTRY_SCREENSHOT_H_INCLUDED
+#define SENTRY_SCREENSHOT_H_INCLUDED
+
+#include "sentry_boot.h"
+
+#include "sentry_options.h"
+#include "sentry_path.h"
+
+/**
+ * Captures a screenshot and saves it to the specified path.
+ *
+ * Returns true if the screenshot was successfully captured and saved.
+ */
+bool sentry__screenshot_capture(const sentry_path_t *path);
+
+/**
+ * Returns the path where a screenshot should be saved.
+ */
+sentry_path_t *sentry__screenshot_get_path(const sentry_options_t *options);
+
+#endif

--- a/tests/fixtures/screenshot/CMakeLists.txt
+++ b/tests/fixtures/screenshot/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10)
+project(sentry_screenshot LANGUAGES C)
+
+if(WIN32)
+	add_executable(sentry_screenshot screenshot_win32.c)
+	set_target_properties(sentry_screenshot PROPERTIES WIN32_EXECUTABLE TRUE)
+	target_compile_definitions(sentry_screenshot PRIVATE _UNICODE UNICODE)
+	target_link_libraries(sentry_screenshot PRIVATE sentry)
+
+	if(MSVC)
+		target_compile_options(sentry_screenshot PRIVATE $<BUILD_INTERFACE:/wd5105 /wd4717>)
+		if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # clang-cl
+			target_compile_options(sentry_screenshot PRIVATE $<BUILD_INTERFACE:-Wno-infinite-recursion>)
+		endif()
+
+		# to test handling SEH by-passing exceptions we need to enable the control flow guard
+		target_compile_options(sentry_screenshot PRIVATE $<BUILD_INTERFACE:/guard:cf>)
+	else()
+		# Disable all optimizations for the `sentry_screenshot` in gcc/clang. This allows us to keep crash triggers simple.
+		# The effects besides reproducible code-gen across compiler versions, will be negligible for build- and runtime.
+		target_compile_options(sentry_screenshot PRIVATE $<BUILD_INTERFACE:-O0>)
+		set_target_properties(sentry_screenshot PROPERTIES LINK_FLAGS -municode)
+	endif()
+endif()

--- a/tests/fixtures/screenshot/screenshot_win32.c
+++ b/tests/fixtures/screenshot/screenshot_win32.c
@@ -1,0 +1,133 @@
+#include <sentry.h>
+
+#include <malloc.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+    IDT_TIMER_CRASH = 1,
+    IDT_TIMER_STACK_OVERFLOW,
+    IDT_TIMER_FASTFAIL,
+};
+
+static bool
+has_arg(int argc, LPWSTR *argv, LPCWSTR arg)
+{
+    for (int i = 0; i < argc; i++) {
+        if (wcscmp(argv[i], arg) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void *invalid_mem = (void *)1;
+
+static void
+trigger_crash()
+{
+    memset((char *)invalid_mem, 1, 100);
+}
+
+static void
+trigger_stack_overflow()
+{
+    alloca(1024);
+    trigger_stack_overflow();
+}
+
+static void
+trigger_fastfail_crash()
+{
+    // this bypasses WINDOWS SEH and will only be caught with the crashpad WER
+    // module enabled
+    __fastfail(77);
+}
+
+static LRESULT CALLBACK
+wnd_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg) {
+    case WM_TIMER:
+        switch (wParam) {
+        case IDT_TIMER_CRASH:
+            trigger_crash();
+            break;
+        case IDT_TIMER_STACK_OVERFLOW:
+            trigger_stack_overflow();
+            break;
+        case IDT_TIMER_FASTFAIL:
+            trigger_fastfail_crash();
+            break;
+        }
+        break;
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}
+
+int WINAPI
+wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine,
+    int nCmdShow)
+{
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_release(options, "sentry-screenshot");
+    sentry_options_set_attach_screenshot(options, true);
+    sentry_options_set_debug(options, true);
+    sentry_init(options);
+
+    int argc = 0;
+    LPWSTR *argv = CommandLineToArgvW(lpCmdLine, &argc);
+
+#if (WINVER >= 0x0605)
+    if (has_arg(argc, argv, L"dpi-unaware")) {
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
+    } else if (has_arg(argc, argv, L"dpi-system-aware")) {
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+    } else if (has_arg(argc, argv, L"dpi-per-monitor-aware")) {
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+    } else if (has_arg(argc, argv, L"dpi-per-monitor-aware-v2")) {
+        SetProcessDpiAwarenessContext(
+            DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    } else if (has_arg(argc, argv, L"dpi-unaware-gdiscaled")) {
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED);
+    }
+#endif
+
+    WNDCLASSW wc;
+    ZeroMemory(&wc, sizeof(wc));
+    wc.lpfnWndProc = wnd_proc;
+    wc.hInstance = hInstance;
+    wc.hbrBackground = CreateSolidBrush(RGB(37, 31, 61));
+    wc.lpszClassName = L"sentry-screenshot";
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowExW(0, L"sentry-screenshot", L"Hello, Sentry!",
+        WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 300, 200, NULL, NULL,
+        hInstance, NULL);
+    ShowWindow(hwnd, nCmdShow);
+    SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+
+    UINT delay = 100;
+    if (has_arg(argc, argv, L"crash")) {
+        SetTimer(hwnd, IDT_TIMER_CRASH, delay, NULL);
+    }
+    if (has_arg(argc, argv, L"stack-overflow")) {
+        SetTimer(hwnd, IDT_TIMER_STACK_OVERFLOW, delay, NULL);
+    }
+    if (has_arg(argc, argv, L"fastfail")) {
+        SetTimer(hwnd, IDT_TIMER_FASTFAIL, delay, NULL);
+    }
+
+    MSG msg;
+    while (GetMessage(&msg, NULL, 0, 0)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    sentry_close();
+}

--- a/tests/test_integration_screenshot.py
+++ b/tests/test_integration_screenshot.py
@@ -1,0 +1,105 @@
+import email
+import gzip
+import os
+import shutil
+import sys
+
+import pytest
+
+from . import make_dsn, run
+
+
+def assert_screenshot_file(database_path):
+    run_dirs = [d for d in database_path.glob("*.run") if d.is_dir()]
+    assert (
+        len(run_dirs) == 1
+    ), f"Expected exactly one .run directory, found {len(run_dirs)}"
+    screenshot_path = run_dirs[0] / "screenshot.png"
+    assert screenshot_path.exists(), "No screenshot was captured"
+    assert screenshot_path.stat().st_size > 0, "Screenshot file is empty"
+
+
+def assert_screenshot_upload(req):
+    multipart = gzip.decompress(req.get_data())
+    msg = email.message_from_bytes(bytes(str(req.headers), encoding="utf8") + multipart)
+    payload = None
+    for part in msg.walk():
+        if part.get_filename() == "screenshot.png":
+            payload = part.get_payload(decode=True)
+            break
+    assert payload is not None
+    assert len(payload) > 0
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Screenshots are only supported on Windows",
+)
+@pytest.mark.parametrize(
+    "build_args",
+    [
+        ({"SENTRY_BACKEND": "inproc"}),
+        ({"SENTRY_BACKEND": "breakpad"}),
+    ],
+)
+def test_capture_screenshot(cmake, httpserver, build_args):
+    build_args.update({"SENTRY_TRANSPORT": "none"})
+    tmp_path = cmake(["sentry_screenshot"], build_args)
+
+    # make sure we are isolated from previous runs
+    shutil.rmtree(tmp_path / ".sentry-native", ignore_errors=True)
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    child = run(tmp_path, "sentry_screenshot", ["crash"], env=env)
+    assert child.returncode
+
+    assert_screenshot_file(tmp_path / ".sentry-native")
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Screenshots are only supported on Windows",
+)
+@pytest.mark.parametrize(
+    "run_args",
+    [
+        (["crash"]),
+    ],
+)
+def test_capture_screenshot_crashpad(cmake, httpserver, run_args):
+    tmp_path = cmake(["sentry_screenshot"], {"SENTRY_BACKEND": "crashpad"})
+
+    # make sure we are isolated from previous runs
+    shutil.rmtree(tmp_path / ".sentry-native", ignore_errors=True)
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        child = run(tmp_path, "sentry_screenshot", run_args, env=env)
+        assert child.returncode
+
+    assert waiting.result
+
+    assert len(httpserver.log) == 1
+    assert_screenshot_upload(httpserver.log[0][0])
+    assert_screenshot_file(tmp_path / ".sentry-native")
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Screenshots are only supported on Windows",
+)
+# this test currently can't run on CI because the Windows-image doesn't properly support WER, if you want to run the
+# test locally, invoke pytest with the --with_crashpad_wer option which is matched with this marker in the runtest setup
+@pytest.mark.with_crashpad_wer
+@pytest.mark.parametrize(
+    "run_args",
+    [
+        (["fastfail"]),
+    ],
+)
+def test_capture_screenshot_crashpad_wer(cmake, httpserver, run_args):
+    test_capture_screenshot_crashpad(cmake, httpserver, run_args)


### PR DESCRIPTION
This PR implements #693 for Windows - adds an option for attaching screenshots to fatal error events.

The API is similar to other Sentry SDKs:
```c
sentry_options_t *options = sentry_options_new();
sentry_options_set_attach_screenshot(options, true); // <==
// ...
sentry_init(options);
```

<img width="955" alt="sentry-native-screenshot" src="https://github.com/user-attachments/assets/015517f2-bde1-4fc9-ac2b-b74f1c636de2" />

In case of multiple application windows, the screenshot includes all windows belonging to the crashed process and has everything else masked/clipped out:

<img width="520" alt="sentry-native-screenshot-multi" src="https://github.com/user-attachments/assets/f5e06158-5d4d-48a8-95bb-5c6ac09253e1" />

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->