### PR TITLE
docs: rectify description of hook event handling

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -845,11 +845,14 @@ SENTRY_API void sentry_options_set_before_send(
  * `sentry_value_decref` on the provided event, and return a
  * `sentry_value_new_null()` instead.
  *
- * Only the `inproc` backend currently fills the passed-in event with useful
- * data and processes any modifications to the return value. Since both
- * `breakpad` and `crashpad` use minidumps to capture the crash state, the
- * passed-in event is empty when using these backends, and they ignore any
- * changes to the return value.
+ * Only the `inproc` backend currently fills the passed-in event with crash
+ * meta-data. Since both `breakpad` and `crashpad` use minidumps to capture the
+ * crash state, the passed-in event is empty when using these backends. Changes
+ * to the event from inside the hooks will be passed along, but in the case of
+ * the minidump backends might be amenable to overwriting during server-side
+ * ingestion and processing. This primarily affects the exception payloads which
+ * are auto-generated from the minidump content. See
+ * https://github.com/getsentry/sentry-native/issues/1147 for details.
  *
  * If you set this callback in the options, it prevents a concurrently enabled
  * `before_send` callback from being invoked in the crash case. This allows for

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -849,7 +849,7 @@ SENTRY_API void sentry_options_set_before_send(
  * meta-data. Since both `breakpad` and `crashpad` use minidumps to capture the
  * crash state, the passed-in event is empty when using these backends. Changes
  * to the event from inside the hooks will be passed along, but in the case of
- * the minidump backends might be amenable to overwriting during server-side
+ * the minidump backends these changes might get overwritten during server-side
  * ingestion and processing. This primarily affects the exception payloads which
  * are auto-generated from the minidump content. See
  * https://github.com/getsentry/sentry-native/issues/1147 for details.


### PR DESCRIPTION
The inline docs are no longer correct when handling the data inside the hook events when using the `breakpad` and `crashpad` backend.

Raised here: https://github.com/getsentry/sentry-unreal/issues/817#issuecomment-2713275183

#skip-changelog