### PR TITLE
chore: add Linux arm64 runner for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
             os: ubuntu-24.04
             CC: gcc-12
             CXX: g++-12
+          - name: Linux Arm64 (GCC 14.2.0)
+            os: ubuntu-24.04-arm
+            CC: gcc-14
+            CXX: g++-14
           - name: Linux (GCC 14.2.0)
             os: ubuntu-24.04
             CC: gcc-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
             CXX: clang++-19
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
+          - name: Linux Arm64 (clang 19 + asan + llvm-cov)
+            os: ubuntu-24.04-arm
+            CC: clang-19
+            CXX: clang++-19
+            ERROR_ON_WARNINGS: 1
+            RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang 19 + kcov)
             os: ubuntu-24.04
             CC: clang-19

--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ The SDK bundle contains the following folders:
 The SDK currently supports and is tested on the following OS/Compiler variations:
 
 - 64bit Linux with GCC 14
+- Arm64 Linux with GCC 14
 - 64bit Linux with GCC 12
 - 64bit Linux with GCC 9
 - 64bit Linux with clang 19
+- Arm64 Linux with clang 19
 - 32bit Linux with GCC 9 (cross compiled from 64bit host)
 - 32bit Windows with MSVC 2019
 - 64bit Windows with MSVC 2022

--- a/README.md
+++ b/README.md
@@ -61,15 +61,13 @@ The SDK bundle contains the following folders:
 
 The SDK currently supports and is tested on the following OS/Compiler variations:
 
-- 64bit Linux with GCC 14
-- Arm64 Linux with GCC 14
-- 64bit Linux with GCC 12
-- 64bit Linux with GCC 9
-- 64bit Linux with clang 19
-- Arm64 Linux with clang 19
-- 32bit Linux with GCC 9 (cross compiled from 64bit host)
-- 32bit Windows with MSVC 2019
-- 64bit Windows with MSVC 2022
+- x64/arm64 Linux with GCC 14
+- x64 Linux with GCC 12
+- x64 Linux with GCC 9
+- x64/arm64 Linux with clang 19
+- x86 Linux with GCC 9 (cross compiled from x64 host)
+- x86 Windows with MSVC 2019
+- x64 Windows with MSVC 2022
 - macOS 13, 14, 15 with respective most recent Apple compiler toolchain and LLVM clang 15 + 18
 - Android API35 built by NDK27 toolchain
 - Android API16 built by NDK19 toolchain


### PR DESCRIPTION
As they are now [publicly available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) we can try and see how far we can get with Native on Linux arm.

Ideally we also have this for Windows, but those runners are [not available yet](https://github.com/orgs/community/discussions/19197#discussioncomment-11946571). 

Related to https://github.com/getsentry/sentry-native/issues/880

#skip-changelog