### PR TITLE
fix: Improve TEST_VISIBLE macro for Windows - fixes failing unwinder test on Release configuration.

### DIFF
--- a/tests/unit/sentry_testsupport.h
+++ b/tests/unit/sentry_testsupport.h
@@ -54,7 +54,7 @@
 // NOTE: On Windows, pointers to non-static functions seem to resolve
 // to an indirection table. This causes a mismatch in tests. With static
 // functions, this does not happen.
-#    define TEST_VISIBLE static
+#    define TEST_VISIBLE static __declspec(noinline)
 #else
 #    define TEST_VISIBLE
 #endif


### PR DESCRIPTION
Using `Release` configuration on Windows leads to crash in `sentry_test_unit` on `unwinder` test.

```
cmake -B build_vs2019 -T v142  -DSENTRY_BUILD_SHARED_LIBS=OFF -DSENTRY_BUILD_RUNTIMESTATIC=ON -DSENTRY_BACKEND=inproc -DSENTRY_BUILD_TESTS=ON -DSENTRY_BUILD_EXAMPLES=OFF -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="ProgramDatabase" -DCMAKE_EXE_LINKER_FLAGS_RELEASE="/DEBUG" -DCMAKE_SHARED_LINKER_FLAGS_RELEASE="/DEBUG"
```

```
Exception thrown: read access violation.
uctx was nullptr.
```
```
>	sentry_test_unit.exe!sentry__unwind_stack_dbghelp(void * addr, const sentry_ucontext_s * uctx, void * * ptrs, unsigned __int64 max_frames) Line 46	C
 	[Inline Frame] sentry_test_unit.exe!unwind_stack(void *) Line 30	C
 	sentry_test_unit.exe!sentry_unwind_stack(void * addr, void * * stacktrace_out, unsigned __int64 max_len) Line 38	C
 	sentry_test_unit.exe!test_sentry_unwinder() Line 69	C
 	sentry_test_unit.exe!test_do_run__(const test__ * test, int index) Line 936	C
 	sentry_test_unit.exe!test_run__(const test__ * test, int index, int master_index) Line 1104	C
 	sentry_test_unit.exe!main(int argc, char * * argv) Line 1608	C
```

It happens because MSVC compiler inlines `invoke_unwinder` function:
```
 	sentry_test_unit.exe!sentry_unwind_stack(void * addr, void * * stacktrace_out, unsigned __int64 max_len) Line 37	C
>	[Inline Frame] sentry_test_unit.exe!invoke_unwinder(void * *) Line 13	C
 	sentry_test_unit.exe!test_sentry_unwinder() Line 45	C

```
Even though function is marked with `TEST_VISIBLE` macro. But that macro adds `noinline` attribute only on GCC, not on MSVC.

```cpp
TEST_VISIBLE size_t
invoke_unwinder(void **backtrace)
{
    // capture a stacktrace from within this function, which means that the
    // trace will include a frame of this very function that we will test
    // against.
    size_t frame_count = sentry_unwind_stack(NULL, backtrace, MAX_FRAMES);
    // this assertion here makes sure the function is not inlined.
    TEST_CHECK(frame_count > 0);
    return frame_count;
}
```

With improved `TEST_VISIBLE` macro, `invoke_unwinder` is no longer inlined on Release configuration:
```
	sentry_test_unit.exe!sentry_unwind_stack(void * addr, void * * stacktrace_out, unsigned __int64 max_len) Line 37	C
>	sentry_test_unit.exe!invoke_unwinder(void * * backtrace) Line 15	C
 	sentry_test_unit.exe!test_sentry_unwinder() Line 45	C
```

#skip-changelog