### PR TITLE
chore: Added .NET specific directories to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ local.properties
 .cxx
 build
 
+# .NET
+bin/
+obj/


### PR DESCRIPTION
Added these because the repo will always be "dirty" when used as a submodule as part of the .NET or Unity SDK.

#skip-changelog

Sidenote: 
Should these not be `/build*` and `/install*` instead?
https://github.com/getsentry/sentry-native/blob/ce9d742d5374d1902f52aa303d776a5d4dee2785/.gitignore#L8-L9
If I read that correct, the pattern matching is already excluding `/bin` inadvertently.