### PR TITLE
feat: add option to attach view hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 **Features**:
-- Provide the option to attach a view hierarchy file. ([#1191](https://github.com/getsentry/sentry-native/pull/1191))
+
+- Provide an option for downstream SDKs to attach a view hierarchy file. ([#1191](https://github.com/getsentry/sentry-native/pull/1191))
 
 ## 0.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add option to attach screenshots on Windows to fatal error events. ([#1170](https://github.com/getsentry/sentry-native/pull/1170))
 - Add an option for `Crashpad` on Linux to delay application shutdown until the upload of the crash report in the `crashpad_handler` is complete. This is useful for deployment in `Docker` or `systemd`, where the life cycle of additional processes is bound by the application life cycle. ([#1153](https://github.com/getsentry/sentry-native/pull/1153), [crashpad#121](https://github.com/getsentry/crashpad/pull/121))
+- Allow specifying `attachment_type` and `content_type` for attachments. ([#1191](https://github.com/getsentry/sentry-native/pull/1191))
 
 ## 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add option to attach screenshots on Windows to fatal error events. ([#1170](https://github.com/getsentry/sentry-native/pull/1170))
 - Add an option for `Crashpad` on Linux to delay application shutdown until the upload of the crash report in the `crashpad_handler` is complete. This is useful for deployment in `Docker` or `systemd`, where the life cycle of additional processes is bound by the application life cycle. ([#1153](https://github.com/getsentry/sentry-native/pull/1153), [crashpad#121](https://github.com/getsentry/crashpad/pull/121))
-- Allow specifying `attachment_type` and `content_type` for attachments. ([#1191](https://github.com/getsentry/sentry-native/pull/1191))
+- Provide the option to attach a view hierarchy file. ([#1191](https://github.com/getsentry/sentry-native/pull/1191))
 
 ## 0.8.2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,9 @@ if(SENTRY_BUILD_EXAMPLES)
 	add_custom_command(TARGET sentry_example POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/minidump.dmp" "$<TARGET_FILE_DIR:sentry_example>/minidump.dmp")
 
+	add_custom_command(TARGET sentry_example POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/view-hierarchy.json" "$<TARGET_FILE_DIR:sentry_example>/view-hierarchy.json")
+
 	add_test(NAME sentry_example COMMAND sentry_example)
 endif()
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,8 @@ The example currently supports the following commands:
 - `socks5-proxy`: Uses a localhost `SOCKS5` proxy on port 1080.
 - `capture-transaction`: Captures a transaction.
 - `traces-sampler`: Installs a traces sampler callback function when used alongside `capture-transaction`.
-
+- `attach-view-hierarchy`: Adds an attachment as if it was a `view-hierarchy.json` file, giving it the proper `attachment_type` and `content_type`. It is currently defined as the
+  `CMakeCache.txt` file, which is part of the CMake build folder.
  
 Only on Linux using crashpad:
 - `crashpad-wait-for-upload`: Couples application shutdown to complete the upload in the `crashpad_handler`. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,8 +156,8 @@ The example currently supports the following commands:
 - `socks5-proxy`: Uses a localhost `SOCKS5` proxy on port 1080.
 - `capture-transaction`: Captures a transaction.
 - `traces-sampler`: Installs a traces sampler callback function when used alongside `capture-transaction`.
-- `attach-view-hierarchy`: Adds an attachment as if it was a `view-hierarchy.json` file, giving it the proper `attachment_type` and `content_type`. It is currently defined as the
-  `CMakeCache.txt` file, which is part of the CMake build folder.
+- `attach-view-hierarchy`: Adds a `view-hierarchy.json` attachment file, giving it the proper `attachment_type` and `content_type`. 
+ This file can be found in `./tests/fixtures/view-hierachy.json`.
  
 Only on Linux using crashpad:
 - `crashpad-wait-for-upload`: Couples application shutdown to complete the upload in the `crashpad_handler`. 

--- a/examples/example.c
+++ b/examples/example.c
@@ -291,10 +291,10 @@ main(int argc, char **argv)
     }
 
     if (has_arg(argc, argv, "attach-view-hierarchy")) {
-        // TODO we assume the file lives one directory up;
-        //  should we add it to GH?
-        sentry_options_add_typed_attachment(options, "../view-hierarchy.json",
-            VIEW_HIERARCHY, "application/json");
+        // assuming the example / test is run directly from the cmake build
+        // directory
+        sentry_options_add_typed_attachment(
+            options, "./CMakeCache.txt", VIEW_HIERARCHY, "application/json");
     }
 
     sentry_init(options);

--- a/examples/example.c
+++ b/examples/example.c
@@ -290,6 +290,13 @@ main(int argc, char **argv)
         sentry_options_set_crashpad_wait_for_upload(options, true);
     }
 
+    if (has_arg(argc, argv, "attach-view-hierarchy")) {
+        // TODO we assume the file lives one directory up;
+        //  should we add it to GH?
+        sentry_options_add_typed_attachment(options, "../view-hierarchy.json",
+            VIEW_HIERARCHY, "application/json");
+    }
+
     sentry_init(options);
 
     if (!has_arg(argc, argv, "no-setup")) {

--- a/examples/example.c
+++ b/examples/example.c
@@ -293,7 +293,7 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "attach-view-hierarchy")) {
         // assuming the example / test is run directly from the cmake build
         // directory
-        sentry_options_add_view_hierarchy(options, "./CMakeCache.txt");
+        sentry_options_add_view_hierarchy(options, "./view-hierarchy.json");
     }
 
     sentry_init(options);

--- a/examples/example.c
+++ b/examples/example.c
@@ -293,8 +293,7 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "attach-view-hierarchy")) {
         // assuming the example / test is run directly from the cmake build
         // directory
-        sentry_options_add_typed_attachment(
-            options, "./CMakeCache.txt", VIEW_HIERARCHY, "application/json");
+        sentry_options_add_view_hierarchy(options, "./CMakeCache.txt");
     }
 
     sentry_init(options);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1195,18 +1195,16 @@ typedef enum {
     VIEW_HIERARCHY,
 } sentry_attachment_type_t;
 /**
- * Adds a new attachment to be sent, along with a given attachment and content
- * type.
+ * Adds a new view hierarchy attachment to be sent along.
  *
- * The attachment_type must be either ATTACHMENT, MINIDUMP or VIEW_HIERARCHY
- * The content_type can be left empty
+ * `path` is assumed to be in platform-specific filesystem path encoding.
+ * API Users on windows are encouraged to use
+ * `sentry_options_add_view_hierarchyw` instead.
  */
-SENTRY_API void sentry_options_add_typed_attachment(sentry_options_t *opts,
-    const char *path, sentry_attachment_type_t attachment_type,
-    const char *content_type);
-SENTRY_API void sentry_options_add_typed_attachment_n(sentry_options_t *opts,
-    const char *path, size_t path_len, sentry_attachment_type_t attachment_type,
-    const char *content_type, size_t content_type_len);
+SENTRY_API void sentry_options_add_view_hierarchy(
+    sentry_options_t *opts, const char *path);
+SENTRY_API void sentry_options_add_view_hierarchy_n(
+    sentry_options_t *opts, const char *path, size_t path_len);
 
 /**
  * Enables or disables attaching screenshots to fatal error events. Disabled by
@@ -1279,6 +1277,14 @@ SENTRY_API void sentry_options_set_database_path_n(
 SENTRY_API void sentry_options_add_attachmentw(
     sentry_options_t *opts, const wchar_t *path);
 SENTRY_API void sentry_options_add_attachmentw_n(
+    sentry_options_t *opts, const wchar_t *path, size_t path_len);
+
+/**
+ * Wide char version of `sentry_options_add_view_hierarchy`.
+ */
+SENTRY_API void sentry_options_add_view_hierarchyw(
+    sentry_options_t *opts, const wchar_t *path);
+SENTRY_API void sentry_options_add_view_hierarchyw_n(
     sentry_options_t *opts, const wchar_t *path, size_t path_len);
 
 /**

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1206,7 +1206,7 @@ SENTRY_API void sentry_options_add_typed_attachment(sentry_options_t *opts,
     const char *content_type);
 SENTRY_API void sentry_options_add_typed_attachment_n(sentry_options_t *opts,
     const char *path, size_t path_len, sentry_attachment_type_t attachment_type,
-    const char *content_type);
+    const char *content_type, size_t content_type_len);
 
 /**
  * Enables or disables attaching screenshots to fatal error events. Disabled by

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1186,15 +1186,19 @@ SENTRY_API void sentry_options_add_attachment(
 SENTRY_API void sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len);
 
-/**
- *
- */
+// TODO add some docstrings
+typedef enum {
+    ATTACHMENT,
+    MINIDUMP,
+    VIEW_HIERARCHY,
+} sentry_attachment_type_t;
+
 SENTRY_API void sentry_options_add_typed_attachment(sentry_options_t *opts,
     const char *path, sentry_attachment_type_t attachment_type,
     const char *content_type);
 SENTRY_API void sentry_options_add_typed_attachment_n(sentry_options_t *opts,
     const char *path, size_t path_len, sentry_attachment_type_t attachment_type,
-    const char *content_type, size_t content_type_len);
+    const char *content_type);
 
 /**
  * Enables or disables attaching screenshots to fatal error events. Disabled by

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1189,6 +1189,10 @@ SENTRY_API void sentry_options_add_attachment_n(
 /**
  * Adds a new view hierarchy attachment to be sent along.
  *
+ * The primary use-case is for downstream SDKs (like sentry-godot). The
+ * view-hierarchy.json file should follow the representation defined in RFC#33
+ * https://github.com/getsentry/rfcs/blob/main/text/0033-view-hierarchy.md
+ *
  * `path` is assumed to be in platform-specific filesystem path encoding.
  * API Users on windows are encouraged to use
  * `sentry_options_add_view_hierarchyw` instead.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1187,14 +1187,6 @@ SENTRY_API void sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len);
 
 /**
- * The attachment_type.
- */
-typedef enum {
-    ATTACHMENT,
-    MINIDUMP,
-    VIEW_HIERARCHY,
-} sentry_attachment_type_t;
-/**
  * Adds a new view hierarchy attachment to be sent along.
  *
  * `path` is assumed to be in platform-specific filesystem path encoding.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1187,6 +1187,16 @@ SENTRY_API void sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len);
 
 /**
+ *
+ */
+SENTRY_API void sentry_options_add_typed_attachment(sentry_options_t *opts,
+    const char *path, sentry_attachment_type_t attachment_type,
+    const char *content_type);
+SENTRY_API void sentry_options_add_typed_attachment_n(sentry_options_t *opts,
+    const char *path, size_t path_len, sentry_attachment_type_t attachment_type,
+    const char *content_type, size_t content_type_len);
+
+/**
  * Enables or disables attaching screenshots to fatal error events. Disabled by
  * default.
  *

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1186,13 +1186,21 @@ SENTRY_API void sentry_options_add_attachment(
 SENTRY_API void sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len);
 
-// TODO add some docstrings
+/**
+ * The attachment_type.
+ */
 typedef enum {
     ATTACHMENT,
     MINIDUMP,
     VIEW_HIERARCHY,
 } sentry_attachment_type_t;
-
+/**
+ * Adds a new attachment to be sent, along with a given attachment and content
+ * type.
+ *
+ * The attachment_type must be either ATTACHMENT, MINIDUMP or VIEW_HIERARCHY
+ * The content_type can be left empty
+ */
 SENTRY_API void sentry_options_add_typed_attachment(sentry_options_t *opts,
     const char *path, sentry_attachment_type_t attachment_type,
     const char *content_type);

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -502,7 +502,7 @@ static
     return send;
 }
 
-const char *
+static const char *
 str_from_attachment_type(sentry_attachment_type_t attachment_type)
 {
     switch (attachment_type) {
@@ -561,7 +561,7 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
         if (!item) {
             continue;
         }
-        if (attachment->type) {
+        if (attachment->type != ATTACHMENT) { // don't need to set the default
             sentry__envelope_item_set_header(item, "attachment_type",
                 sentry_value_new_string(
                     str_from_attachment_type(attachment->type)));

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -556,10 +556,15 @@ sentry__prepare_event(const sentry_options_t *options, sentry_value_t event,
     SENTRY_DEBUG("adding attachments to envelope");
     for (sentry_attachment_t *attachment = options->attachments; attachment;
         attachment = attachment->next) {
-        sentry_envelope_item_t *item = sentry__envelope_add_from_path(envelope,
-            attachment->path, str_from_attachment_type(attachment->type));
+        sentry_envelope_item_t *item = sentry__envelope_add_from_path(
+            envelope, attachment->path, "attachment");
         if (!item) {
             continue;
+        }
+        if (attachment->type) {
+            sentry__envelope_item_set_header(item, "attachment_type",
+                sentry_value_new_string(
+                    str_from_attachment_type(attachment->type)));
         }
         if (attachment->content_type) {
             sentry__envelope_item_set_header(item, "content_type",

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -499,8 +499,9 @@ static void
 add_attachment(sentry_options_t *opts, sentry_path_t *path,
     sentry_attachment_type_t attachment_type, const char *content_type)
 {
+    size_t content_type_len = content_type ? strlen(content_type) : 0;
     add_attachment_n(
-        opts, path, attachment_type, content_type, strlen(content_type));
+        opts, path, attachment_type, content_type, content_type_len);
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -590,7 +590,7 @@ void
 sentry_options_add_typed_attachmentw_n(sentry_options_t *opts,
     const wchar_t *path, size_t path_len,
     sentry_attachment_type_t attachment_type, const wchar_t *content_type,
-    size_t content_len)
+    size_t content_type_len)
 {
     add_attachment_n(opts, sentry__path_from_wstr_n(path, path_len),
         attachment_type, content_type, content_type_len);
@@ -602,10 +602,9 @@ sentry_options_add_typed_attachmentw(sentry_options_t *opts,
     const wchar_t *content_type)
 {
     size_t path_len = path ? wcslen(path) : 0;
-    size_t content_type_len = content_type
-        ? wcslen(content_type)
-        : 0 sentry_options_add_typed_attachmentw_n(opts, path, path_len,
-              attachment_type, content_type, content_type_len);
+    size_t content_type_len = content_type ? wcslen(content_type) : 0;
+    sentry_options_add_typed_attachmentw_n(
+        opts, path, path_len, attachment_type, content_type, content_type_len);
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -564,7 +564,8 @@ void
 sentry_options_add_attachmentw_n(
     sentry_options_t *opts, const wchar_t *path, size_t path_len)
 {
-    add_attachment(opts, sentry__path_from_wstr_n(path, path_len));
+    add_attachment(
+        opts, sentry__path_from_wstr_n(path, path_len), ATTACHMENT, NULL);
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -83,6 +83,7 @@ static void
 attachment_free(sentry_attachment_t *attachment)
 {
     sentry__path_free(attachment->path);
+    sentry_free(attachment->content_type);
     sentry_free(attachment);
 }
 

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -83,7 +83,6 @@ static void
 attachment_free(sentry_attachment_t *attachment)
 {
     sentry__path_free(attachment->path);
-    sentry_free(attachment->content_type);
     sentry_free(attachment);
 }
 
@@ -475,9 +474,8 @@ sentry_options_get_shutdown_timeout(sentry_options_t *opts)
 }
 
 static void
-add_attachment_n(sentry_options_t *opts, sentry_path_t *path,
-    sentry_attachment_type_t attachment_type, const char *content_type,
-    size_t content_type_len)
+add_attachment(sentry_options_t *opts, sentry_path_t *path,
+    sentry_attachment_type_t attachment_type, const char *content_type)
 {
     if (!path) {
         return;
@@ -490,18 +488,8 @@ add_attachment_n(sentry_options_t *opts, sentry_path_t *path,
     attachment->path = path;
     attachment->next = opts->attachments;
     attachment->type = attachment_type;
-    attachment->content_type
-        = sentry__string_clone_n(content_type, content_type_len);
+    attachment->content_type = content_type;
     opts->attachments = attachment;
-}
-
-static void
-add_attachment(sentry_options_t *opts, sentry_path_t *path,
-    sentry_attachment_type_t attachment_type, const char *content_type)
-{
-    size_t content_type_len = content_type ? strlen(content_type) : 0;
-    add_attachment_n(
-        opts, path, attachment_type, content_type, content_type_len);
 }
 
 void
@@ -529,8 +517,8 @@ void
 sentry_options_add_view_hierarchy_n(
     sentry_options_t *opts, const char *path, size_t path_len)
 {
-    add_attachment_n(opts, sentry__path_from_str_n(path, path_len),
-        VIEW_HIERARCHY, "application/json", strlen("application/json"));
+    add_attachment(opts, sentry__path_from_str_n(path, path_len),
+        VIEW_HIERARCHY, "application/json");
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -474,7 +474,8 @@ sentry_options_get_shutdown_timeout(sentry_options_t *opts)
 }
 
 static void
-add_attachment(sentry_options_t *opts, sentry_path_t *path)
+add_attachment(sentry_options_t *opts, sentry_path_t *path,
+    sentry_attachment_type_t attachment_type, const char *content_type)
 {
     if (!path) {
         return;
@@ -486,36 +487,40 @@ add_attachment(sentry_options_t *opts, sentry_path_t *path)
     }
     attachment->path = path;
     attachment->next = opts->attachments;
+    attachment->type = attachment_type;
+    attachment->content_type = content_type;
     opts->attachments = attachment;
 }
 
 void
 sentry_options_add_attachment(sentry_options_t *opts, const char *path)
 {
-    add_attachment(opts, sentry__path_from_str(path));
+    add_attachment(opts, sentry__path_from_str(path), ATTACHMENT, NULL);
 }
 
 void
 sentry_options_add_attachment_n(
     sentry_options_t *opts, const char *path, size_t path_len)
 {
-    add_attachment(opts, sentry__path_from_str_n(path, path_len));
+    add_attachment(
+        opts, sentry__path_from_str_n(path, path_len), ATTACHMENT, NULL);
 }
 
 void
 sentry_options_add_typed_attachment(sentry_options_t *opts, const char *path,
     sentry_attachment_type_t attachment_type, const char *content_type)
 {
-    sentry_options_add_typed_attachment_n(opts, path, strlen(path),
-        attachment_type, content_type, strlen(content_type));
+    add_attachment(opts, sentry__path_from_str_n(path, strlen(path)),
+        attachment_type, content_type);
 }
 
 void
 sentry_options_add_typed_attachment_n(sentry_options_t *opts, const char *path,
     size_t path_len, sentry_attachment_type_t attachment_type,
-    const char *content_type, size_t content_type_len)
+    const char *content_type)
 {
-    return; // TODO do stuff
+    add_attachment(opts, sentry__path_from_str_n(path, path_len),
+        attachment_type, content_type);
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -503,6 +503,22 @@ sentry_options_add_attachment_n(
 }
 
 void
+sentry_options_add_typed_attachment(sentry_options_t *opts, const char *path,
+    sentry_attachment_type_t attachment_type, const char *content_type)
+{
+    sentry_options_add_typed_attachment_n(opts, path, strlen(path),
+        attachment_type, content_type, strlen(content_type));
+}
+
+void
+sentry_options_add_typed_attachment_n(sentry_options_t *opts, const char *path,
+    size_t path_len, sentry_attachment_type_t attachment_type,
+    const char *content_type, size_t content_type_len)
+{
+    return; // TODO do stuff
+}
+
+void
 sentry_options_set_attach_screenshot(sentry_options_t *opts, int val)
 {
     opts->attach_screenshot = !!val;

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -605,10 +605,8 @@ sentry_options_add_typed_attachmentw(sentry_options_t *opts,
 {
     size_t path_len = path ? wcslen(path) : 0;
     size_t content_type_len = content_type ? wcslen(content_type) : 0;
-    char *content_type_str = sentry__string_from_wstr(content_type);
-    sentry_options_add_typed_attachmentw_n(opts, path, path_len,
-        attachment_type, content_type_str, content_type_len);
-    sentry_free(content_type_str);
+    sentry_options_add_typed_attachmentw_n(
+        opts, path, path_len, attachment_type, content_type, content_type_len);
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -518,20 +518,18 @@ sentry_options_add_attachment_n(
 }
 
 void
-sentry_options_add_typed_attachment(sentry_options_t *opts, const char *path,
-    sentry_attachment_type_t attachment_type, const char *content_type)
+sentry_options_add_view_hierarchy(sentry_options_t *opts, const char *path)
 {
     add_attachment(
-        opts, sentry__path_from_str(path), attachment_type, content_type);
+        opts, sentry__path_from_str(path), VIEW_HIERARCHY, "application/json");
 }
 
 void
-sentry_options_add_typed_attachment_n(sentry_options_t *opts, const char *path,
-    size_t path_len, sentry_attachment_type_t attachment_type,
-    const char *content_type, size_t content_type_len)
+sentry_options_add_view_hierarchy_n(
+    sentry_options_t *opts, const char *path, size_t path_len)
 {
     add_attachment_n(opts, sentry__path_from_str_n(path, path_len),
-        attachment_type, content_type, content_type_len);
+        VIEW_HIERARCHY, "application/json", strlen("application/json"));
 }
 
 void
@@ -587,26 +585,17 @@ sentry_options_add_attachmentw(sentry_options_t *opts, const wchar_t *path)
 }
 
 void
-sentry_options_add_typed_attachmentw_n(sentry_options_t *opts,
-    const wchar_t *path, size_t path_len,
-    sentry_attachment_type_t attachment_type, const wchar_t *content_type,
-    size_t content_type_len)
-{
-    char *content_type_str = sentry__string_from_wstr(content_type);
-    add_attachment_n(opts, sentry__path_from_wstr_n(path, path_len),
-        attachment_type, content_type_str, content_type_len);
-    sentry_free(content_type_str);
-}
-
-void
-sentry_options_add_typed_attachmentw(sentry_options_t *opts,
-    const wchar_t *path, sentry_attachment_type_t attachment_type,
-    const wchar_t *content_type)
+sentry_options_add_view_hierarchyw(sentry_options_t *opts, const wchar_t *path)
 {
     size_t path_len = path ? wcslen(path) : 0;
-    size_t content_type_len = content_type ? wcslen(content_type) : 0;
-    sentry_options_add_typed_attachmentw_n(
-        opts, path, path_len, attachment_type, content_type, content_type_len);
+    sentry_options_add_view_hierarchyw_n(opts, path, path_len);
+}
+void
+sentry_options_add_view_hierarchyw_n(
+    sentry_options_t *opts, const wchar_t *path, size_t path_len)
+{
+    add_attachment(opts, sentry__path_from_wstr_n(path, path_len),
+        VIEW_HIERARCHY, "application/json");
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -474,8 +474,9 @@ sentry_options_get_shutdown_timeout(sentry_options_t *opts)
 }
 
 static void
-add_attachment(sentry_options_t *opts, sentry_path_t *path,
-    sentry_attachment_type_t attachment_type, const char *content_type)
+add_attachment_n(sentry_options_t *opts, sentry_path_t *path,
+    sentry_attachment_type_t attachment_type, const char *content_type,
+    size_t content_type_len)
 {
     if (!path) {
         return;
@@ -488,8 +489,17 @@ add_attachment(sentry_options_t *opts, sentry_path_t *path,
     attachment->path = path;
     attachment->next = opts->attachments;
     attachment->type = attachment_type;
-    attachment->content_type = content_type;
+    attachment->content_type
+        = sentry__string_clone_n(content_type, content_type_len);
     opts->attachments = attachment;
+}
+
+static void
+add_attachment(sentry_options_t *opts, sentry_path_t *path,
+    sentry_attachment_type_t attachment_type, const char *content_type)
+{
+    add_attachment_n(
+        opts, path, attachment_type, content_type, strlen(content_type));
 }
 
 void
@@ -510,17 +520,17 @@ void
 sentry_options_add_typed_attachment(sentry_options_t *opts, const char *path,
     sentry_attachment_type_t attachment_type, const char *content_type)
 {
-    add_attachment(opts, sentry__path_from_str_n(path, strlen(path)),
-        attachment_type, content_type);
+    add_attachment(
+        opts, sentry__path_from_str(path), attachment_type, content_type);
 }
 
 void
 sentry_options_add_typed_attachment_n(sentry_options_t *opts, const char *path,
     size_t path_len, sentry_attachment_type_t attachment_type,
-    const char *content_type)
+    const char *content_type, size_t content_type_len)
 {
-    add_attachment(opts, sentry__path_from_str_n(path, path_len),
-        attachment_type, content_type);
+    add_attachment_n(opts, sentry__path_from_str_n(path, path_len),
+        attachment_type, content_type, content_type_len);
 }
 
 void
@@ -573,6 +583,28 @@ sentry_options_add_attachmentw(sentry_options_t *opts, const wchar_t *path)
 {
     size_t path_len = path ? wcslen(path) : 0;
     sentry_options_add_attachmentw_n(opts, path, path_len);
+}
+
+void
+sentry_options_add_typed_attachmentw_n(sentry_options_t *opts,
+    const wchar_t *path, size_t path_len,
+    sentry_attachment_type_t attachment_type, const wchar_t *content_type,
+    size_t content_len)
+{
+    add_attachment_n(opts, sentry__path_from_wstr_n(path, path_len),
+        attachment_type, content_type, content_type_len);
+}
+
+void
+sentry_options_add_typed_attachmentw(sentry_options_t *opts,
+    const wchar_t *path, sentry_attachment_type_t attachment_type,
+    const wchar_t *content_type)
+{
+    size_t path_len = path ? wcslen(path) : 0;
+    size_t content_type_len = content_type
+        ? wcslen(content_type)
+        : 0 sentry_options_add_typed_attachmentw_n(opts, path, path_len,
+              attachment_type, content_type, content_type_len);
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -592,8 +592,10 @@ sentry_options_add_typed_attachmentw_n(sentry_options_t *opts,
     sentry_attachment_type_t attachment_type, const wchar_t *content_type,
     size_t content_type_len)
 {
+    char *content_type_str = sentry__string_from_wstr(content_type);
     add_attachment_n(opts, sentry__path_from_wstr_n(path, path_len),
-        attachment_type, content_type, content_type_len);
+        attachment_type, content_type_str, content_type_len);
+    sentry_free(content_type_str);
 }
 
 void
@@ -603,8 +605,10 @@ sentry_options_add_typed_attachmentw(sentry_options_t *opts,
 {
     size_t path_len = path ? wcslen(path) : 0;
     size_t content_type_len = content_type ? wcslen(content_type) : 0;
-    sentry_options_add_typed_attachmentw_n(
-        opts, path, path_len, attachment_type, content_type, content_type_len);
+    char *content_type_str = sentry__string_from_wstr(content_type);
+    sentry_options_add_typed_attachmentw_n(opts, path, path_len,
+        attachment_type, content_type_str, content_type_len);
+    sentry_free(content_type_str);
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -21,6 +21,8 @@ struct sentry_backend_s;
 typedef struct sentry_attachment_s sentry_attachment_t;
 struct sentry_attachment_s {
     sentry_path_t *path;
+    sentry_attachment_type_t type;
+    const char *content_type;
     sentry_attachment_t *next;
 };
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -29,7 +29,7 @@ typedef struct sentry_attachment_s sentry_attachment_t;
 struct sentry_attachment_s {
     sentry_path_t *path;
     sentry_attachment_type_t type;
-    char *content_type;
+    const char *content_type;
     sentry_attachment_t *next;
 };
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -22,7 +22,7 @@ typedef struct sentry_attachment_s sentry_attachment_t;
 struct sentry_attachment_s {
     sentry_path_t *path;
     sentry_attachment_type_t type;
-    const char *content_type;
+    char *content_type;
     sentry_attachment_t *next;
 };
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -13,7 +13,14 @@
 #define SENTRY_DEFAULT_SHUTDOWN_TIMEOUT 2000
 
 struct sentry_backend_s;
-
+/**
+ * The attachment_type.
+ */
+typedef enum {
+    ATTACHMENT,
+    MINIDUMP,
+    VIEW_HIERARCHY,
+} sentry_attachment_type_t;
 /**
  * This is a linked list of all the attachments registered via
  * `sentry_options_add_attachment`.

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -200,7 +200,7 @@ def assert_attachment(envelope):
 def assert_attachment_view_hierarchy(envelope):
     expected = {
         "type": "attachment",
-        "filename": "CMakeCache.txt",
+        "filename": "view-hierarchy.json",
         "attachment_type": "event.view_hierarchy",
         "content_type": "application/json",
     }

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,5 +1,6 @@
 import email
 import gzip
+import json
 import platform
 import re
 import sys
@@ -207,6 +208,24 @@ def assert_attachment_view_hierarchy(envelope):
     assert any(matches(item.headers, expected) for item in envelope)
 
 
+def assert_attachment_content_view_hierarchy(attachment):
+    expected = {
+        "rendering_system": "android_view_system",
+        "windows": [
+            {
+                "alpha": 1.0,
+                "height": 1280.0,
+                "type": "com.android.internal.policy.DecorView",
+                "visibility": "visible",
+                "width": 768.0,
+                "x": 0.0,
+                "y": 0.0,
+            }
+        ],
+    }
+    assert matches(attachment, expected)
+
+
 def assert_minidump(envelope):
     expected = {
         "type": "attachment",
@@ -283,6 +302,7 @@ class CrashpadAttachments:
     event: dict
     breadcrumb1: list
     breadcrumb2: list
+    view_hierarchy: dict
 
 
 def _unpack_breadcrumbs(payload):
@@ -295,6 +315,7 @@ def _load_crashpad_attachments(msg):
     event = {}
     breadcrumb1 = []
     breadcrumb2 = []
+    view_hierarchy = {}
     for part in msg.walk():
         if part.get_filename() is not None:
             assert part.get("Content-Type") is None
@@ -306,8 +327,10 @@ def _load_crashpad_attachments(msg):
                 breadcrumb1 = _unpack_breadcrumbs(part.get_payload(decode=True))
             case "__sentry-breadcrumb2":
                 breadcrumb2 = _unpack_breadcrumbs(part.get_payload(decode=True))
+            case "view-hierarchy.json":
+                view_hierarchy = json.loads(part.get_payload(decode=True))
 
-    return CrashpadAttachments(event, breadcrumb1, breadcrumb2)
+    return CrashpadAttachments(event, breadcrumb1, breadcrumb2, view_hierarchy)
 
 
 def is_valid_timestamp(timestamp):
@@ -335,13 +358,15 @@ def assert_overflowing_breadcrumb(attachments):
         assert_breadcrumb_inner(attachments.breadcrumb1)
 
 
-def assert_crashpad_upload(req):
+def assert_crashpad_upload(req, expect_view_hierarchy=False):
     multipart = gzip.decompress(req.get_data())
     msg = email.message_from_bytes(bytes(str(req.headers), encoding="utf8") + multipart)
     attachments = _load_crashpad_attachments(msg)
 
     assert_overflowing_breadcrumb(attachments)
     assert_event_meta(attachments.event, integration="crashpad")
+    if expect_view_hierarchy:
+        assert_attachment_content_view_hierarchy(attachments.view_hierarchy)
     assert any(
         b'name="upload_file_minidump"' in part.as_bytes()
         and b"\n\nMDMP" in part.as_bytes()

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -197,6 +197,16 @@ def assert_attachment(envelope):
     assert any(matches(item.headers, expected) for item in envelope)
 
 
+def assert_attachment_view_hierarchy(envelope):
+    expected = {
+        "type": "attachment",
+        "filename": "CMakeCache.txt",
+        "attachment_type": "event.view_hierarchy",
+        "content_type": "application/json",
+    }
+    assert any(matches(item.headers, expected) for item in envelope)
+
+
 def assert_minidump(envelope):
     expected = {
         "type": "attachment",

--- a/tests/fixtures/view-hierarchy.json
+++ b/tests/fixtures/view-hierarchy.json
@@ -1,0 +1,14 @@
+{
+  "rendering_system":"android_view_system",
+  "windows":[
+    {
+      "type": "com.android.internal.policy.DecorView",
+      "width": 768.0,
+      "height": 1280.0,
+      "x": 0.0,
+      "y": 0.0,
+      "visibility": "visible",
+      "alpha": 1.0
+    }
+  ]
+}

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -246,7 +246,14 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
         child = run(
             tmp_path,
             "sentry_example",
-            ["log", "start-session", "attachment", "overflow-breadcrumbs"] + run_args,
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "attach-view-hierarchy",
+                "overflow-breadcrumbs",
+            ]
+            + run_args,
             env=env,
         )
         assert child.returncode  # well, it's a crash after all
@@ -270,7 +277,7 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
     envelope = Envelope.deserialize(session)
 
     assert_session(envelope, {"status": "crashed", "errors": 1})
-    assert_crashpad_upload(multipart)
+    assert_crashpad_upload(multipart, expect_view_hierarchy=True)
 
     # Windows throttles WER crash reporting frequency, so let's wait a bit
     time.sleep(2)
@@ -317,7 +324,14 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
         child = run(
             tmp_path,
             "sentry_example",
-            ["log", "start-session", "attachment", "overflow-breadcrumbs", "crash"]
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "attach-view-hierarchy",
+                "overflow-breadcrumbs",
+                "crash",
+            ]
             + run_args,
             env=env,
         )
@@ -343,7 +357,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
 
     envelope = Envelope.deserialize(session.get_data())
     assert_session(envelope, {"status": "crashed", "errors": 1})
-    assert_crashpad_upload(multipart)
+    assert_crashpad_upload(multipart, expect_view_hierarchy=True)
 
 
 def test_crashpad_dumping_stack_overflow(cmake, httpserver):
@@ -360,7 +374,13 @@ def test_crashpad_dumping_stack_overflow(cmake, httpserver):
         child = run(
             tmp_path,
             "sentry_example",
-            ["log", "start-session", "attachment", "stack-overflow"],
+            [
+                "log",
+                "start-session",
+                "attachment",
+                "attach-view-hierarchy",
+                "stack-overflow",
+            ],
             env=env,
         )
         assert child.returncode  # well, it's a crash after all
@@ -382,7 +402,7 @@ def test_crashpad_dumping_stack_overflow(cmake, httpserver):
 
     envelope = Envelope.deserialize(session.get_data())
     assert_session(envelope, {"status": "crashed", "errors": 1})
-    assert_crashpad_upload(multipart)
+    assert_crashpad_upload(multipart, expect_view_hierarchy=True)
 
 
 def is_session_envelope(data):

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -35,6 +35,7 @@ from .assertions import (
     assert_gzip_content_encoding,
     assert_gzip_file_header,
     assert_failed_proxy_auth_request,
+    assert_attachment_view_hierarchy,
 )
 from .conditions import has_http, has_breakpad, has_files, has_crashpad
 
@@ -284,7 +285,7 @@ def test_inproc_crash_http(cmake, httpserver, build_args):
     child = run(
         tmp_path,
         "sentry_example",
-        ["log", "start-session", "attachment", "crash"],
+        ["log", "start-session", "attachment", "attach-view-hierarchy", "crash"],
         env=env,
     )
     assert child.returncode  # well, it's a crash after all
@@ -312,6 +313,7 @@ def test_inproc_crash_http(cmake, httpserver, build_args):
     assert_meta(envelope, integration="inproc")
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
+    assert_attachment_view_hierarchy(envelope)
 
     assert_inproc_crash(envelope)
 
@@ -384,7 +386,7 @@ def test_breakpad_crash_http(cmake, httpserver, build_args):
     child = run(
         tmp_path,
         "sentry_example",
-        ["log", "start-session", "attachment", "crash"],
+        ["log", "start-session", "attachment", "attach-view-hierarchy", "crash"],
         env=env,
     )
     assert child.returncode  # well, it's a crash after all
@@ -412,6 +414,7 @@ def test_breakpad_crash_http(cmake, httpserver, build_args):
     assert_meta(envelope, integration="breakpad")
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
+    assert_attachment_view_hierarchy(envelope)
 
     assert_breakpad_crash(envelope)
     assert_minidump(envelope)
@@ -604,7 +607,7 @@ def test_capture_minidump(cmake, httpserver):
     run(
         tmp_path,
         "sentry_example",
-        ["log", "attachment", "capture-minidump"],
+        ["log", "attachment", "attach-view-hierarchy", "capture-minidump"],
         check=True,
         env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
     )
@@ -618,6 +621,7 @@ def test_capture_minidump(cmake, httpserver):
 
     assert_breadcrumb(envelope)
     assert_attachment(envelope)
+    assert_attachment_view_hierarchy(envelope)
 
     assert_minidump(envelope)
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-native/issues/1188

- [x] add new option
- [x] make it work for Crashpad <- through Relay inference
- [x] infer attachment_type in Relay ([implement](https://github.com/getsentry/relay/blob/90f67c6fbfb8728168f871a9296d9253ef9b0574/relay-server/src/endpoints/minidump.rs#L122-L130) [test](https://github.com/getsentry/relay/blame/90f67c6fbfb8728168f871a9296d9253ef9b0574/relay-server/src/endpoints/minidump.rs#L355)) https://github.com/getsentry/relay/pull/4624
- [x] add to docs -> warning about needing the filename `view-hierarchy.json` or it won't work on Crashpad, linking to [RFC#33](https://github.com/getsentry/rfcs/blob/main/text/0033-view-hierarchy.md) https://github.com/getsentry/sentry-docs/pull/13191
- [x] update changelog
- [x] update contributing.md
- [x] add tests
