### PR TITLE
feat: allow overriding init on downstream SDKs

### DIFF
--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -92,8 +92,13 @@ sentry__should_skip_upload(void)
     return skip;
 }
 
+#ifdef SENTRY_PLATFORM_NX
+int
+sentry__native_init(sentry_options_t *options)
+#else
 int
 sentry_init(sentry_options_t *options)
+#endif
 {
     SENTRY__MUTEX_INIT_DYN_ONCE(g_options_lock);
     // this function is to be called only once, so we do not allow more than one

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -129,4 +129,8 @@ bool sentry__should_send_transaction(
     sentry_value_t tx_ctx, sentry_sampling_context_t *sampling_ctx);
 #endif
 
+#ifdef SENTRY_PLATFORM_NX
+int sentry__native_init(sentry_options_t *options);
+#endif
+
 #endif


### PR DESCRIPTION
Switch SDK doesn't provide a custom init - instead, users just call `sentry_init()`. 
This PR enables us to auto-configure custom options and scope (before and after native init, respectively).

#skip-changelog