### PR TITLE
test: fix tests if release is set, e.g. in an env var

### DIFF
--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -125,6 +125,8 @@ SENTRY_TEST(discarding_before_send)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
+    sentry_options_set_auto_session_tracking(options, 0);
     sentry_options_set_transport(options,
         sentry_new_function_transport(
             counting_transport_func, &called_transport));

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -137,6 +137,8 @@ SENTRY_TEST(transaction_name_backfill_on_finish)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
+    sentry_options_set_auto_session_tracking(options, 0);
 
     sentry_transport_t *transport = sentry_transport_new(check_backfilled_name);
     sentry_transport_set_state(transport, &called);
@@ -273,6 +275,8 @@ SENTRY_TEST(transport_sampling_transactions)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
+    sentry_options_set_auto_session_tracking(options, 0);
 
     sentry_transport_t *transport
         = sentry_transport_new(send_transaction_envelope_test_basic);
@@ -318,6 +322,8 @@ SENTRY_TEST(transactions_skip_before_send)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
+    sentry_options_set_auto_session_tracking(options, 0);
 
     sentry_transport_t *transport
         = sentry_transport_new(send_transaction_envelope_test_basic);
@@ -356,6 +362,8 @@ SENTRY_TEST(multiple_transactions)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
+    sentry_options_set_auto_session_tracking(options, 0);
 
     sentry_transport_t *transport = sentry_transport_new(before_transport);
     sentry_transport_set_state(transport, &called_transport);
@@ -735,6 +743,7 @@ SENTRY_TEST(drop_unfinished_spans)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    sentry_options_set_auto_session_tracking(options, 0);
 
     sentry_transport_t *transport = sentry_transport_new(check_spans);
     sentry_transport_set_state(transport, &called_transport);

--- a/tests/unit/test_tracing.c
+++ b/tests/unit/test_tracing.c
@@ -743,6 +743,7 @@ SENTRY_TEST(drop_unfinished_spans)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
     sentry_options_set_auto_session_tracking(options, 0);
 
     sentry_transport_t *transport = sentry_transport_new(check_spans);


### PR DESCRIPTION
While preparing another PR (#1204), I've faced an issue that if the downstream SDK sets release in sentry_init(), some tests that match captured envelopes using a custom transport, start failing. The same could be checked by running sentry_test_unit after seetting `SENTRY_RELEASE` env var.

I've tested the changes manually - should I also change tests or CI to test this?

#skip-changelog