### PR TITLE
chore: add send-default-pii setting for NX

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -804,9 +804,8 @@ SENTRY_API void sentry_options_set_network_connect_func(
     sentry_options_t *opts, void (*network_connect_func)(void));
 
 /**
- * If false (the default), the SDK won't include PII or other sensitive data in
- * the payload by default. For example, a pseudo-random identifier combining
- * device and application ID.
+ * If false (the default), the SDK won't add PII or other sensitive data to the
+ * payload. For example, a pseudo-random identifier combining device and app ID.
  */
 SENTRY_API void sentry_options_set_send_default_pii(
     sentry_options_t *opts, int value);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -802,6 +802,14 @@ SENTRY_API void sentry_options_set_transport(
  */
 SENTRY_API void sentry_options_set_network_connect_func(
     sentry_options_t *opts, void (*network_connect_func)(void));
+
+/**
+ * If false (the default), the SDK won't include PII or other sensitive data in
+ * the payload by default. For example, a pseudo-random identifier combining
+ * device and application ID.
+ */
+SENTRY_API void sentry_options_set_send_default_pii(
+    sentry_options_t *opts, int value);
 #endif
 
 /**

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -133,6 +133,12 @@ sentry_options_set_network_connect_func(
 {
     opts->network_connect_func = network_connect_func;
 }
+
+void
+sentry_options_set_send_default_pii(sentry_options_t *opts, int value)
+{
+    opts->send_default_pii = value;
+}
 #endif
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -86,6 +86,7 @@ struct sentry_options_s {
 
 #ifdef SENTRY_PLATFORM_NX
     void (*network_connect_func)(void);
+    bool send_default_pii;
 #endif
 };
 


### PR DESCRIPTION
This is currently not used on other platforms so I'm adding under the ifdef. 
If we, later, use it elsewhere, we can move it to sentry.h proper.

#skip-changelog
