### PR TITLE
test: use more descriptive benchmark chart labels

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -6,18 +6,7 @@ import pytest
 from . import make_dsn, run
 
 
-@pytest.mark.parametrize(
-    "target,backend",
-    [
-        ("init", "inproc"),
-        ("init", "breakpad"),
-        ("init", "crashpad"),
-        ("backend", "inproc"),
-        ("backend", "breakpad"),
-        ("backend", "crashpad"),
-    ],
-)
-def test_benchmark(target, backend, cmake, httpserver, gbenchmark):
+def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label):
     tmp_path = cmake(
         ["sentry_benchmark"],
         {
@@ -44,4 +33,23 @@ def test_benchmark(target, backend, cmake, httpserver, gbenchmark):
 
         # ignore warmup run
         if i > 0:
-            gbenchmark(benchmark_out)
+            gbenchmark(benchmark_out, label)
+
+
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad"])
+def test_benchmark_init(backend, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        "init", backend, cmake, httpserver, gbenchmark, f"SDK init ({backend})"
+    )
+
+
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad"])
+def test_benchmark_backend(backend, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        "backend",
+        backend,
+        cmake,
+        httpserver,
+        gbenchmark,
+        f"Backend startup ({backend})",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from . import run
 from .cmake import CMake
 
 
+LABEL = "label"
 TIME_UNIT = "time_unit"
 REAL_TIME = "real_time"
 CPU_TIME = "cpu_time"
@@ -69,7 +70,7 @@ def pytest_configure(config):
 
 @pytest.fixture
 def gbenchmark():
-    def _load(json_path, test_name=None):
+    def _load(json_path, label, test_name=None):
         if test_name is None:
             test_name = os.environ.get("PYTEST_CURRENT_TEST").split(" ")[0]
 
@@ -78,6 +79,7 @@ def gbenchmark():
 
         if test_name not in gbenchmarks:
             gbenchmarks[test_name] = {
+                LABEL: label,
                 TIME_UNIT: "",
                 REAL_TIME: [],
                 CPU_TIME: [],
@@ -113,7 +115,7 @@ def _get_benchmark(name, separator):
     ]
 
     return {
-        "name": name,
+        "name": data[LABEL],
         "unit": unit,
         "value": statistics.median(real_time),
         "extra": separator.join(e for e in extra if e),


### PR DESCRIPTION
Pass pretty-formatted labels to make benchmark charts easier to understand:

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/df5fc6e7-f73c-4fbd-b7e8-652b833aea5e) | ![image](https://github.com/user-attachments/assets/af7bcad2-050b-4255-8edf-0282d6ff3dca) |

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->

#skip-changelog