### PR TITLE
Add platform guard to fix Xbox build issues

### DIFF
--- a/src/screenshot/sentry_screenshot_windows.c
+++ b/src/screenshot/sentry_screenshot_windows.c
@@ -110,6 +110,10 @@ save_bitmap(HBITMAP bitmap, const wchar_t *path)
 static void
 calculate_region(DWORD pid, HRGN region)
 {
+#ifdef _GAMING_XBOX_SCARLETT
+    (DWORD)pid;
+    (HRGN)region;
+#else
     HMODULE dwmapi = load_library(L"dwmapi.dll");
     if (!dwmapi) {
         return;
@@ -141,11 +145,16 @@ calculate_region(DWORD pid, HRGN region)
         }
         hwnd = GetWindow(hwnd, GW_HWNDPREV);
     }
+#endif // _GAMING_XBOX_SCARLETT
 }
 
 bool
 sentry__screenshot_capture(const sentry_path_t *path)
 {
+#ifdef _GAMING_XBOX_SCARLETT
+    (sentry_path_t*)path;
+    return false;
+#else
     HRGN region = CreateRectRgn(0, 0, 0, 0);
     calculate_region(GetCurrentProcessId(), region);
 
@@ -180,4 +189,5 @@ sentry__screenshot_capture(const sentry_path_t *path)
     ReleaseDC(NULL, src);
     DeleteObject(region);
     return rv;
+#endif // _GAMING_XBOX_SCARLETT
 }

--- a/src/screenshot/sentry_screenshot_windows.c
+++ b/src/screenshot/sentry_screenshot_windows.c
@@ -111,8 +111,8 @@ static void
 calculate_region(DWORD pid, HRGN region)
 {
 #ifdef _GAMING_XBOX_SCARLETT
-    (DWORD)pid;
-    (HRGN)region;
+    (DWORD) pid;
+    (HRGN) region;
 #else
     HMODULE dwmapi = load_library(L"dwmapi.dll");
     if (!dwmapi) {

--- a/src/screenshot/sentry_screenshot_windows.c
+++ b/src/screenshot/sentry_screenshot_windows.c
@@ -152,7 +152,7 @@ bool
 sentry__screenshot_capture(const sentry_path_t *path)
 {
 #ifdef _GAMING_XBOX_SCARLETT
-    (sentry_path_t*)path;
+    (sentry_path_t *)path;
     return false;
 #else
     HRGN region = CreateRectRgn(0, 0, 0, 0);


### PR DESCRIPTION
This PR fixes minor errors when building `sentry-native` for Xbox (see [xbox_build.md](https://github.com/getsentry/sentry-native/blob/f365474360fbe0036910ecd9d2589993544c2507/toolchains/xbox/xbox_build.md) for more details) by excluding Windows-specific code using `_GAMING_XBOX_SCARLETT` platform guard.

#skip-changelog