### PR TITLE
Add FreeBSD platform detection to sentry.h

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -52,6 +52,9 @@ extern "C" {
 #elif defined(__linux) || defined(__linux__)
 #    define SENTRY_PLATFORM_LINUX
 #    define SENTRY_PLATFORM_UNIX
+#elif defined(__FreeBSD__)
+#    define SENTRY_PLATFORM_FREEBSD
+#    define SENTRY_PLATFORM_UNIX
 #elif defined(_AIX)
 /* IBM i PASE is also counted as AIX */
 #    define SENTRY_PLATFORM_AIX


### PR DESCRIPTION
Extend platform detection logic to recognize FreeBSD as a supported platform.

Define SENTRY_PLATFORM_FREEBSD and SENTRY_PLATFORM_UNIX macros when compiling on FreeBSD. It's sufficient for the overall build to work without any additional modifications to the cpp files as FreeBSD is compatible with the existing Unix platform code.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
