### PR TITLE
test: assert crashpad attachment upload

### DIFF
--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -303,6 +303,7 @@ class CrashpadAttachments:
     breadcrumb1: list
     breadcrumb2: list
     view_hierarchy: dict
+    cmake_cache: int
 
 
 def _unpack_breadcrumbs(payload):
@@ -316,6 +317,7 @@ def _load_crashpad_attachments(msg):
     breadcrumb1 = []
     breadcrumb2 = []
     view_hierarchy = {}
+    cmake_cache = -1
     for part in msg.walk():
         if part.get_filename() is not None:
             assert part.get("Content-Type") is None
@@ -329,8 +331,12 @@ def _load_crashpad_attachments(msg):
                 breadcrumb2 = _unpack_breadcrumbs(part.get_payload(decode=True))
             case "view-hierarchy.json":
                 view_hierarchy = json.loads(part.get_payload(decode=True))
+            case "CMakeCache.txt":
+                cmake_cache = len(part.get_payload(decode=True))
 
-    return CrashpadAttachments(event, breadcrumb1, breadcrumb2, view_hierarchy)
+    return CrashpadAttachments(
+        event, breadcrumb1, breadcrumb2, view_hierarchy, cmake_cache
+    )
 
 
 def is_valid_timestamp(timestamp):
@@ -358,13 +364,17 @@ def assert_overflowing_breadcrumb(attachments):
         assert_breadcrumb_inner(attachments.breadcrumb1)
 
 
-def assert_crashpad_upload(req, expect_view_hierarchy=False):
+def assert_crashpad_upload(req, expect_attachment=False, expect_view_hierarchy=False):
     multipart = gzip.decompress(req.get_data())
     msg = email.message_from_bytes(bytes(str(req.headers), encoding="utf8") + multipart)
     attachments = _load_crashpad_attachments(msg)
 
     assert_overflowing_breadcrumb(attachments)
     assert_event_meta(attachments.event, integration="crashpad")
+    if expect_attachment:
+        assert attachments.cmake_cache > 0
+    else:
+        assert attachments.cmake_cache == -1
     if expect_view_hierarchy:
         assert_attachment_content_view_hierarchy(attachments.view_hierarchy)
     assert any(

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -277,7 +277,9 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
     envelope = Envelope.deserialize(session)
 
     assert_session(envelope, {"status": "crashed", "errors": 1})
-    assert_crashpad_upload(multipart, expect_view_hierarchy=True)
+    assert_crashpad_upload(
+        multipart, expect_attachment=True, expect_view_hierarchy=True
+    )
 
     # Windows throttles WER crash reporting frequency, so let's wait a bit
     time.sleep(2)
@@ -357,7 +359,9 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
 
     envelope = Envelope.deserialize(session.get_data())
     assert_session(envelope, {"status": "crashed", "errors": 1})
-    assert_crashpad_upload(multipart, expect_view_hierarchy=True)
+    assert_crashpad_upload(
+        multipart, expect_attachment=True, expect_view_hierarchy=True
+    )
 
 
 @pytest.mark.parametrize(
@@ -423,7 +427,9 @@ def test_crashpad_dumping_stack_overflow(cmake, httpserver, build_args):
 
     envelope = Envelope.deserialize(session.get_data())
     assert_session(envelope, {"status": "crashed", "errors": 1})
-    assert_crashpad_upload(multipart, expect_view_hierarchy=True)
+    assert_crashpad_upload(
+        multipart, expect_attachment=True, expect_view_hierarchy=True
+    )
 
 
 def is_session_envelope(data):


### PR DESCRIPTION
Some test functions in `test_integration_crashpad.py` pass the "attachment" argument to make `sentry_example` attach `CMakeCache.txt`, but there was no assertion that it was uploaded.