### PR TITLE
chore: PS downstream SDK support

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -49,6 +49,8 @@ extern "C" {
 #    define SENTRY_PLATFORM_ANDROID
 #    define SENTRY_PLATFORM_LINUX
 #    define SENTRY_PLATFORM_UNIX
+#elif defined(__PROSPERO__)
+#    define SENTRY_PLATFORM_PROSPERO
 #elif defined(__linux) || defined(__linux__)
 #    define SENTRY_PLATFORM_LINUX
 #    define SENTRY_PLATFORM_UNIX
@@ -93,6 +95,8 @@ extern "C" {
 /* context type dependencies */
 #ifdef _WIN32
 #    include <windows.h>
+#elif defined(SENTRY_PLATFORM_PROSPERO)
+#    include <sys/signal.h>
 #else
 #    include <signal.h>
 #endif
@@ -499,6 +503,8 @@ SENTRY_EXPERIMENTAL_API void sentry_event_value_add_stacktrace(
 typedef struct sentry_ucontext_s {
 #ifdef _WIN32
     EXCEPTION_POINTERS exception_ptrs;
+#elif defined(SENTRY_PLATFORM_PROSPERO)
+    int data;
 #else
     int signum;
     siginfo_t *siginfo;

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -51,6 +51,7 @@ extern "C" {
 #    define SENTRY_PLATFORM_UNIX
 #elif defined(__PROSPERO__)
 #    define SENTRY_PLATFORM_PROSPERO
+#    define SENTRY_PLATFORM_UNIX
 #elif defined(__linux) || defined(__linux__)
 #    define SENTRY_PLATFORM_LINUX
 #    define SENTRY_PLATFORM_UNIX

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -50,7 +50,7 @@ extern "C" {
 #    define SENTRY_PLATFORM_LINUX
 #    define SENTRY_PLATFORM_UNIX
 #elif defined(__PROSPERO__)
-#    define SENTRY_PLATFORM_PROSPERO
+#    define SENTRY_PLATFORM_PS
 #    define SENTRY_PLATFORM_UNIX
 #elif defined(__linux) || defined(__linux__)
 #    define SENTRY_PLATFORM_LINUX
@@ -96,7 +96,7 @@ extern "C" {
 /* context type dependencies */
 #ifdef _WIN32
 #    include <windows.h>
-#elif defined(SENTRY_PLATFORM_PROSPERO)
+#elif defined(SENTRY_PLATFORM_PS)
 #    include <sys/signal.h>
 #else
 #    include <signal.h>
@@ -504,7 +504,7 @@ SENTRY_EXPERIMENTAL_API void sentry_event_value_add_stacktrace(
 typedef struct sentry_ucontext_s {
 #ifdef _WIN32
     EXCEPTION_POINTERS exception_ptrs;
-#elif defined(SENTRY_PLATFORM_PROSPERO)
+#elif defined(SENTRY_PLATFORM_PS)
     int data;
 #else
     int signum;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if(WIN32)
 		path/sentry_path_windows.c
 		symbolizer/sentry_symbolizer_windows.c
 	)
-elseif(NX)
+elseif(NX OR CMAKE_SYSTEM_NAME STREQUAL "Prospero")
 	sentry_target_sources_cwd(sentry
 		sentry_unix_spinlock.h
 		path/sentry_path_unix.c

--- a/src/path/sentry_path.c
+++ b/src/path/sentry_path.c
@@ -16,11 +16,13 @@ sentry__path_remove_all(const sentry_path_t *path)
 {
     if (sentry__path_is_dir(path)) {
         sentry_pathiter_t *piter = sentry__path_iter_directory(path);
-        const sentry_path_t *p;
-        while ((p = sentry__pathiter_next(piter)) != NULL) {
-            sentry__path_remove_all(p);
+        if (piter) {
+            const sentry_path_t *p;
+            while ((p = sentry__pathiter_next(piter)) != NULL) {
+                sentry__path_remove_all(p);
+            }
+            sentry__pathiter_free(piter);
         }
-        sentry__pathiter_free(piter);
     }
     return sentry__path_remove(path);
 }

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -4,7 +4,7 @@
 #include "sentry_string.h"
 #include "sentry_utils.h"
 
-#ifdef SENTRY_PLATFORM_PROSPERO
+#ifdef SENTRY_PLATFORM_PS
 #    include <sys/dirent.h>
 #else
 #    include <dirent.h>
@@ -34,7 +34,7 @@ static const size_t MAX_READ_TO_BUFFER = 134217728;
 struct sentry_pathiter_s {
     const sentry_path_t *parent;
     sentry_path_t *current;
-#ifndef SENTRY_PLATFORM_PROSPERO
+#ifndef SENTRY_PLATFORM_PS
     DIR *dir_handle;
 #endif
 };
@@ -112,7 +112,7 @@ sentry__filelock_unlock(sentry_filelock_t *lock)
 }
 
 // Defined in a downstream SDK.
-#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PS)
 sentry_path_t *
 sentry__path_absolute(const sentry_path_t *path)
 {
@@ -169,7 +169,7 @@ sentry__path_current_exe(void)
 }
 
 // Defined in a downstream SDK.
-#if !defined(SENTRY_PLATFORM_PROSPERO)
+#if !defined(SENTRY_PLATFORM_PS)
 sentry_path_t *
 sentry__path_dir(const sentry_path_t *path)
 {
@@ -373,7 +373,7 @@ done:
 }
 
 // Defined in a downstream SDK.
-#if !defined(SENTRY_PLATFORM_PROSPERO)
+#if !defined(SENTRY_PLATFORM_PS)
 sentry_pathiter_t *
 sentry__path_iter_directory(const sentry_path_t *path)
 {

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -4,10 +4,15 @@
 #include "sentry_string.h"
 #include "sentry_utils.h"
 
-#include <dirent.h>
+#ifdef SENTRY_PLATFORM_PROSPERO
+#    include <sys/dirent.h>
+#else
+#    include <dirent.h>
+#    include <libgen.h>
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
-#include <libgen.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,7 +34,9 @@ static const size_t MAX_READ_TO_BUFFER = 134217728;
 struct sentry_pathiter_s {
     const sentry_path_t *parent;
     sentry_path_t *current;
+#ifndef SENTRY_PLATFORM_PROSPERO
     DIR *dir_handle;
+#endif
 };
 
 static size_t
@@ -104,7 +111,8 @@ sentry__filelock_unlock(sentry_filelock_t *lock)
     lock->is_locked = false;
 }
 
-#ifndef SENTRY_PLATFORM_NX // defined in a downstream SDK.
+// Defined in a downstream SDK.
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
 sentry_path_t *
 sentry__path_absolute(const sentry_path_t *path)
 {
@@ -160,6 +168,8 @@ sentry__path_current_exe(void)
     return NULL;
 }
 
+// Defined in a downstream SDK.
+#if !defined(SENTRY_PLATFORM_PROSPERO)
 sentry_path_t *
 sentry__path_dir(const sentry_path_t *path)
 {
@@ -177,6 +187,7 @@ sentry__path_dir(const sentry_path_t *path)
     }
     return sentry__path_from_str_owned(newpathbuf);
 }
+#endif
 
 sentry_path_t *
 sentry__path_from_str_n(const char *s, size_t s_len)
@@ -361,6 +372,8 @@ done:
     return rv;
 }
 
+// Defined in a downstream SDK.
+#if !defined(SENTRY_PLATFORM_PROSPERO)
 sentry_pathiter_t *
 sentry__path_iter_directory(const sentry_path_t *path)
 {
@@ -413,6 +426,7 @@ sentry__pathiter_free(sentry_pathiter_t *piter)
     sentry__path_free(piter->current);
     sentry_free(piter);
 }
+#endif
 
 int
 sentry__path_touch(const sentry_path_t *path)

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -31,13 +31,13 @@
 // only read this many bytes to memory ever
 static const size_t MAX_READ_TO_BUFFER = 134217728;
 
+#ifndef SENTRY_PLATFORM_PS
 struct sentry_pathiter_s {
     const sentry_path_t *parent;
     sentry_path_t *current;
-#ifndef SENTRY_PLATFORM_PS
     DIR *dir_handle;
-#endif
 };
+#endif
 
 static size_t
 write_loop(int fd, const char *buf, size_t buf_len)

--- a/src/sentry_alloc.c
+++ b/src/sentry_alloc.c
@@ -5,7 +5,7 @@
 
 /* on unix platforms we add support for a simplistic page allocator that can
    be enabled to make code async safe */
-#if defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PROSPERO)
+#if defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PS)
 #    include "sentry_unix_pageallocator.h"
 #    define WITH_PAGE_ALLOCATOR
 #endif

--- a/src/sentry_alloc.c
+++ b/src/sentry_alloc.c
@@ -5,7 +5,7 @@
 
 /* on unix platforms we add support for a simplistic page allocator that can
    be enabled to make code async safe */
-#ifdef SENTRY_PLATFORM_UNIX
+#if defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PROSPERO)
 #    include "sentry_unix_pageallocator.h"
 #    define WITH_PAGE_ALLOCATOR
 #endif

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -92,7 +92,7 @@ sentry__should_skip_upload(void)
     return skip;
 }
 
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
 int
 sentry__native_init(sentry_options_t *options)
 #else

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -129,7 +129,7 @@ bool sentry__should_send_transaction(
     sentry_value_t tx_ctx, sentry_sampling_context_t *sampling_ctx);
 #endif
 
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
 int sentry__native_init(sentry_options_t *options);
 #endif
 

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -187,7 +187,7 @@ sentry__process_old_runs(const sentry_options_t *options, uint64_t last_crash)
         }
         sentry_pathiter_t *run_iter = sentry__path_iter_directory(run_dir);
         const sentry_path_t *file;
-        while ((file = sentry__pathiter_next(run_iter)) != NULL) {
+        while (run_iter && (file = sentry__pathiter_next(run_iter)) != NULL) {
             if (sentry__path_filename_matches(file, "session.json")) {
                 if (!session_envelope) {
                     session_envelope = sentry__envelope_new();

--- a/src/sentry_json.c
+++ b/src/sentry_json.c
@@ -134,11 +134,11 @@ sentry__jsonwriter_new_sb(sentry_stringbuilder_t *sb)
     bool owns_sb = false;
     if (!sb) {
         sb = SENTRY_MAKE(sentry_stringbuilder_t);
+        if (!sb) {
+            return NULL;
+        }
         owns_sb = true;
         sentry__stringbuilder_init(sb);
-    }
-    if (!sb) {
-        return NULL;
     }
     sentry_jsonwriter_t *rv = SENTRY_MAKE(sentry_jsonwriter_t);
     if (!rv) {

--- a/src/sentry_logger.c
+++ b/src/sentry_logger.c
@@ -56,11 +56,11 @@ sentry__logger_defaultlogger(
     size_t len = strlen(prefix) + strlen(priority)
         + sentry__guarded_strlen(message) + 2;
     char *format = sentry_malloc(len);
-    snprintf(format, len, "%s%s%s\n", prefix, priority, message);
-
-    vfprintf(stderr, format, args);
-
-    sentry_free(format);
+    if (format) {
+        snprintf(format, len, "%s%s%s\n", prefix, priority, message);
+        vfprintf(stderr, format, args);
+        sentry_free(format);
+    }
 }
 
 #endif

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -396,7 +396,7 @@ fail:
     sentry_value_decref(os);
     return sentry_value_new_null();
 }
-#elif defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PROSPERO)
+#elif defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PS)
 
 #    include <fcntl.h>
 #    include <sys/utsname.h>
@@ -592,7 +592,7 @@ fail:
     return sentry_value_new_null();
 }
 
-#elif defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
+#elif defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
 
 // sentry__get_os_context() is defined in a downstream SDK.
 

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -592,7 +592,7 @@ fail:
     return sentry_value_new_null();
 }
 
-#elif defined(SENTRY_PLATFORM_NX)
+#elif defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
 
 // sentry__get_os_context() is defined in a downstream SDK.
 

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -396,7 +396,7 @@ fail:
     sentry_value_decref(os);
     return sentry_value_new_null();
 }
-#elif defined(SENTRY_PLATFORM_UNIX)
+#elif defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PROSPERO)
 
 #    include <fcntl.h>
 #    include <sys/utsname.h>

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -137,7 +137,7 @@ sentry__scope_flush_unlock(void)
     }
 }
 
-#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PS)
 static void
 sentry__foreach_stacktrace(
     sentry_value_t event, void (*func)(sentry_value_t stacktrace))
@@ -360,7 +360,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
         sentry_value_decref(l);
     }
 
-#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PS)
     if (mode & SENTRY_SCOPE_MODULES) {
         sentry_value_t modules = sentry_get_modules_list();
         if (!sentry_value_is_null(modules)) {

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -137,7 +137,7 @@ sentry__scope_flush_unlock(void)
     }
 }
 
-#ifndef SENTRY_PLATFORM_NX
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
 static void
 sentry__foreach_stacktrace(
     sentry_value_t event, void (*func)(sentry_value_t stacktrace))
@@ -360,7 +360,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
         sentry_value_decref(l);
     }
 
-#ifndef SENTRY_PLATFORM_NX
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
     if (mode & SENTRY_SCOPE_MODULES) {
         sentry_value_t modules = sentry_get_modules_list();
         if (!sentry_value_is_null(modules)) {

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -389,7 +389,7 @@ sentry__usec_time_to_iso8601(uint64_t time)
     size_t buf_len = sizeof(buf);
     time_t secs = time / 1000000;
     struct tm *tm;
-#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_PROSPERO)
+#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_PS)
     tm = gmtime(&secs);
 #else
     struct tm tm_buf;
@@ -462,7 +462,7 @@ sentry__iso8601_to_usec(const char *iso)
     tm.tm_sec = s;
 #ifdef SENTRY_PLATFORM_WINDOWS
     time_t time = _mkgmtime(&tm);
-#elif defined(SENTRY_PLATFORM_PROSPERO)
+#elif defined(SENTRY_PLATFORM_PS)
     time_t time = mktime(&tm); // TODO is this correct?
 #elif defined(SENTRY_PLATFORM_AIX)
     /*
@@ -509,7 +509,7 @@ sentry__iso8601_to_usec(const char *iso)
 // to ensure the C locale is also used there.
 #if !defined(SENTRY_PLATFORM_ANDROID) && !defined(SENTRY_PLATFORM_IOS)         \
     && !defined(SENTRY_PLATFORM_AIX) && !defined(SENTRY_PLATFORM_NX)           \
-    && !defined(SENTRY_PLATFORM_PROSPERO)
+    && !defined(SENTRY_PLATFORM_PS)
 #    define HAS_C_LOCALE
 #endif
 

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -424,6 +424,7 @@ sentry__usec_time_to_iso8601(uint64_t time)
     return sentry__string_clone(buf);
 }
 
+#ifndef SENTRY_PLATFORM_PS
 uint64_t
 sentry__iso8601_to_usec(const char *iso)
 {
@@ -460,11 +461,9 @@ sentry__iso8601_to_usec(const char *iso)
     tm.tm_hour = h;
     tm.tm_min = m;
     tm.tm_sec = s;
-#ifdef SENTRY_PLATFORM_WINDOWS
+#    ifdef SENTRY_PLATFORM_WINDOWS
     time_t time = _mkgmtime(&tm);
-#elif defined(SENTRY_PLATFORM_PS)
-    time_t time = mktime(&tm); // TODO is this correct?
-#elif defined(SENTRY_PLATFORM_AIX)
+#    elif defined(SENTRY_PLATFORM_AIX)
     /*
      * timegm is a GNU extension that AIX doesn't support. We'll have to fake
      * it by setting TZ instead w/ mktime, then unsets it. Changes global env.
@@ -487,15 +486,16 @@ sentry__iso8601_to_usec(const char *iso)
         unsetenv("TZ");
     }
     tzset();
-#else
+#    else
     time_t time = timegm(&tm);
-#endif
+#    endif
     if (time == -1) {
         return 0;
     }
 
     return (uint64_t)time * 1000000 + (uint64_t)usec;
 }
+#endif
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    define sentry__locale_t _locale_t

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -389,7 +389,7 @@ sentry__usec_time_to_iso8601(uint64_t time)
     size_t buf_len = sizeof(buf);
     time_t secs = time / 1000000;
     struct tm *tm;
-#ifdef SENTRY_PLATFORM_WINDOWS
+#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_PROSPERO)
     tm = gmtime(&secs);
 #else
     struct tm tm_buf;
@@ -462,6 +462,8 @@ sentry__iso8601_to_usec(const char *iso)
     tm.tm_sec = s;
 #ifdef SENTRY_PLATFORM_WINDOWS
     time_t time = _mkgmtime(&tm);
+#elif defined(SENTRY_PLATFORM_PROSPERO)
+    time_t time = mktime(&tm); // TODO is this correct?
 #elif defined(SENTRY_PLATFORM_AIX)
     /*
      * timegm is a GNU extension that AIX doesn't support. We'll have to fake
@@ -506,7 +508,8 @@ sentry__iso8601_to_usec(const char *iso)
 // if Android ever adds locale support in NDK we will have to revisit this code
 // to ensure the C locale is also used there.
 #if !defined(SENTRY_PLATFORM_ANDROID) && !defined(SENTRY_PLATFORM_IOS)         \
-    && !defined(SENTRY_PLATFORM_AIX) && !defined(SENTRY_PLATFORM_NX)
+    && !defined(SENTRY_PLATFORM_AIX) && !defined(SENTRY_PLATFORM_NX)           \
+    && !defined(SENTRY_PLATFORM_PROSPERO)
 #    define HAS_C_LOCALE
 #endif
 

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -15,7 +15,7 @@
 #    include <time.h>
 #endif
 
-#ifdef SENTRY_PLATFORM_PROSPERO
+#ifdef SENTRY_PLATFORM_PS
 #    undef MIN
 #    undef MAX
 #    define getenv(_) NULL

--- a/src/sentry_utils.h
+++ b/src/sentry_utils.h
@@ -15,6 +15,12 @@
 #    include <time.h>
 #endif
 
+#ifdef SENTRY_PLATFORM_PROSPERO
+#    undef MIN
+#    undef MAX
+#    define getenv(_) NULL
+#endif
+
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 

--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -224,7 +224,8 @@ SENTRY_TEST(crashed_last_run)
 SENTRY_TEST(capture_minidump_basic)
 {
     // skipping on platforms that don't have access to fixtures on the local FS
-#if defined(SENTRY_PLATFORM_ANDROID) || defined(SENTRY_PLATFORM_NX)
+#if defined(SENTRY_PLATFORM_ANDROID) || defined(SENTRY_PLATFORM_NX)            \
+    || defined(SENTRY_PLATFORM_PS)
     SKIP_TEST();
 #else
     SENTRY_TEST_OPTIONS_NEW(options);

--- a/tests/unit/test_fuzzfailures.c
+++ b/tests/unit/test_fuzzfailures.c
@@ -42,7 +42,8 @@ parse_json_roundtrip(const sentry_path_t *path)
 SENTRY_TEST(fuzz_json)
 {
     // skipping on platforms that don't have access to fixtures on the local FS
-#if defined(SENTRY_PLATFORM_ANDROID) || defined(SENTRY_PLATFORM_NX)
+#if defined(SENTRY_PLATFORM_ANDROID) || defined(SENTRY_PLATFORM_NX)            \
+    || defined(SENTRY_PLATFORM_PS)
     SKIP_TEST();
 #else
     sentry_path_t *path = sentry__path_from_str(__FILE__);

--- a/tests/unit/test_fuzzfailures.c
+++ b/tests/unit/test_fuzzfailures.c
@@ -54,6 +54,7 @@ SENTRY_TEST(fuzz_json)
     size_t items = 0;
     const sentry_path_t *p;
     sentry_pathiter_t *piter = sentry__path_iter_directory(path);
+    TEST_ASSERT(piter != NULL);
     while ((p = sentry__pathiter_next(piter)) != NULL) {
         parse_json_roundtrip(p);
         items += 1;

--- a/tests/unit/test_modulefinder.c
+++ b/tests/unit/test_modulefinder.c
@@ -7,7 +7,7 @@
 
 SENTRY_TEST(module_finder)
 {
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
     return SKIP_TEST();
 #endif
     // make sure that we are able to do multiple cleanup cycles

--- a/tests/unit/test_mpack.c
+++ b/tests/unit/test_mpack.c
@@ -46,7 +46,7 @@ SENTRY_TEST(mpack_newlines)
 
     size_t size_rt;
     char *buf_rt = sentry__path_read_to_buffer(file, &size_rt);
-
+    TEST_ASSERT(buf_rt != NULL);
     TEST_CHECK_INT_EQUAL(size, size_rt);
     TEST_CHECK(!memcmp(buf, buf_rt, size));
 

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -145,6 +145,7 @@ SENTRY_TEST(path_basics)
     TEST_CHECK(!!path);
 
     sentry_pathiter_t *piter = sentry__path_iter_directory(path);
+    TEST_ASSERT(piter != NULL);
     while ((p = sentry__pathiter_next(piter)) != NULL) {
         bool is_file = sentry__path_is_file(p);
         bool is_dir = sentry__path_is_dir(p);

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -160,7 +160,7 @@ SENTRY_TEST(path_basics)
 SENTRY_TEST(path_current_exe)
 {
     sentry_path_t *path = sentry__path_current_exe();
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
     // Not available on NX
     TEST_CHECK(!path);
 #else

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -160,7 +160,7 @@ SENTRY_TEST(path_basics)
 SENTRY_TEST(path_current_exe)
 {
     sentry_path_t *path = sentry__path_current_exe();
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
     // Not available on NX
     TEST_CHECK(!path);
 #else

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -162,7 +162,7 @@ SENTRY_TEST(path_current_exe)
 {
     sentry_path_t *path = sentry__path_current_exe();
 #if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
-    // Not available on NX
+    // Not available on NX or PS
     TEST_CHECK(!path);
 #else
     TEST_CHECK(!!path);

--- a/tests/unit/test_symbolizer.c
+++ b/tests/unit/test_symbolizer.c
@@ -30,7 +30,7 @@ asserter(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(symbolizer)
 {
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
     return SKIP_TEST();
 #endif
     int called = 0;

--- a/tests/unit/test_symbolizer.c
+++ b/tests/unit/test_symbolizer.c
@@ -30,7 +30,7 @@ asserter(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(symbolizer)
 {
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
     return SKIP_TEST();
 #endif
     int called = 0;

--- a/tests/unit/test_unwinder.c
+++ b/tests/unit/test_unwinder.c
@@ -38,7 +38,7 @@ find_frame(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(unwinder)
 {
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
     return SKIP_TEST();
 #endif
     void *backtrace1[MAX_FRAMES] = { 0 };

--- a/tests/unit/test_unwinder.c
+++ b/tests/unit/test_unwinder.c
@@ -38,7 +38,7 @@ find_frame(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(unwinder)
 {
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
     return SKIP_TEST();
 #endif
     void *backtrace1[MAX_FRAMES] = { 0 };

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -249,7 +249,7 @@ SENTRY_TEST(os)
     TEST_CHECK(!sentry_value_is_null(os));
     TEST_CHECK(sentry_value_get_type(sentry_value_get_by_key(os, "name"))
         == SENTRY_VALUE_TYPE_STRING);
-#ifndef SENTRY_PLATFORM_NX
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
     TEST_CHECK(sentry_value_get_type(sentry_value_get_by_key(os, "version"))
         == SENTRY_VALUE_TYPE_STRING);
 #endif

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -249,7 +249,7 @@ SENTRY_TEST(os)
     TEST_CHECK(!sentry_value_is_null(os));
     TEST_CHECK(sentry_value_get_type(sentry_value_get_by_key(os, "name"))
         == SENTRY_VALUE_TYPE_STRING);
-#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PROSPERO)
+#if !defined(SENTRY_PLATFORM_NX) && !defined(SENTRY_PLATFORM_PS)
     TEST_CHECK(sentry_value_get_type(sentry_value_get_by_key(os, "version"))
         == SENTRY_VALUE_TYPE_STRING);
 #endif

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -211,7 +211,7 @@ SENTRY_TEST(dsn_store_url_custom_agent)
 
 SENTRY_TEST(page_allocator)
 {
-#ifndef SENTRY_PLATFORM_UNIX
+#if !defined(SENTRY_PLATFORM_UNIX) || defined(SENTRY_PLATFORM_PS)
     SKIP_TEST();
 #else
     const size_t size = 4096;

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -641,7 +641,7 @@ SENTRY_TEST(value_get_by_null_key)
 
 SENTRY_TEST(value_set_stacktrace)
 {
-#ifdef SENTRY_PLATFORM_NX
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
     return SKIP_TEST();
 #endif
     sentry_value_t exc

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -641,7 +641,7 @@ SENTRY_TEST(value_get_by_null_key)
 
 SENTRY_TEST(value_set_stacktrace)
 {
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PROSPERO)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
     return SKIP_TEST();
 #endif
     sentry_value_t exc

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -247,16 +247,14 @@
 #include <string.h>
 #include <setjmp.h>
 
-#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
+#if (defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)) && !defined(__PROSPERO__)
     #define ACUTEST_UNIX__      1
     #include <errno.h>
+    #include <libgen.h>
     #include <unistd.h>
     #include <sys/types.h>
-#if !defined (__PROSPERO__)
-    #include <libgen.h>
     #include <sys/wait.h>
     #include <signal.h>
-#endif
     #include <time.h>
 
     #if defined CLOCK_PROCESS_CPUTIME_ID  &&  defined CLOCK_MONOTONIC

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -915,6 +915,7 @@ test_do_run__(const struct test__* test, int index)
 
 #ifdef __cplusplus
 #ifdef __has_feature
+// Support for `-fno-exceptions` 
 #if __has_feature(cxx_exceptions)
     #define ACUTEST_HAS_EXCEPTIONS
 #endif

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -250,11 +250,13 @@
 #if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
     #define ACUTEST_UNIX__      1
     #include <errno.h>
-    #include <libgen.h>
     #include <unistd.h>
     #include <sys/types.h>
+#if !defined (__PROSPERO__)
+    #include <libgen.h>
     #include <sys/wait.h>
     #include <signal.h>
+#endif
     #include <time.h>
 
     #if defined CLOCK_PROCESS_CPUTIME_ID  &&  defined CLOCK_MONOTONIC

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -913,10 +913,19 @@ test_do_run__(const struct test__* test, int index)
 
     test_begin_test_line__(test);
 
-#if defined(__cplusplus) && __has_feature(cxx_exceptions)
-    try {
+#ifdef __cplusplus
+#ifdef __has_feature
+#if __has_feature(cxx_exceptions)
+    #define ACUTEST_HAS_EXCEPTIONS
+#endif
+#else
+    #define ACUTEST_HAS_EXCEPTIONS
+#endif
 #endif
 
+#ifdef ACUTEST_HAS_EXCEPTIONS
+    try {
+#endif
         /* This is good to do for case the test unit e.g. crashes. */
         fflush(stdout);
         fflush(stderr);
@@ -967,7 +976,7 @@ aborted:
         test_current_unit__ = NULL;
         return (test_current_failures__ == 0) ? 0 : -1;
 
-#if defined(__cplusplus) && __has_feature(cxx_exceptions)
+#ifdef ACUTEST_HAS_EXCEPTIONS
     } catch(std::exception& e) {
         const char* what = e.what();
         test_check__(0, NULL, 0, "Threw std::exception");

--- a/vendor/acutest.h
+++ b/vendor/acutest.h
@@ -913,7 +913,7 @@ test_do_run__(const struct test__* test, int index)
 
     test_begin_test_line__(test);
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && __has_feature(cxx_exceptions)
     try {
 #endif
 
@@ -967,7 +967,7 @@ aborted:
         test_current_unit__ = NULL;
         return (test_current_failures__ == 0) ? 0 : -1;
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && __has_feature(cxx_exceptions)
     } catch(std::exception& e) {
         const char* what = e.what();
         test_check__(0, NULL, 0, "Threw std::exception");
@@ -1524,7 +1524,12 @@ test_is_tracer_present__(void)
 #endif
 
 int
-main(int argc, char** argv)
+#ifndef TEST_MAIN_NAME
+main
+#else
+TEST_MAIN_NAME
+#endif
+(int argc, char** argv)
 {
     int i;
     test_argv0__ = argv[0];


### PR DESCRIPTION
Enables a private sentry-playstation SDK to build for PlayStation. I'll follow up with test updates in another PR once I get them to run on PS (or update this one if it's still not reviewed)

#skip-changelog because it's only used internally.