### PR TITLE
chore: make update-test-discovery sort locale-independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: test
 
 update-test-discovery:
-	@perl -ne 'print if s/SENTRY_TEST\(([^)]+)\).*/XX(\1)/' tests/unit/*.c | sort | grep -v define | uniq > tests/unit/tests.inc
+	@perl -ne 'print if s/SENTRY_TEST\(([^)]+)\).*/XX(\1)/' tests/unit/*.c | LC_ALL=C sort | grep -v define | uniq > tests/unit/tests.inc
 .PHONY: update-test-discovery
 
 build/Makefile: CMakeLists.txt


### PR DESCRIPTION
Sort `tests/unit/tests.inc` in the same order regardless of the system locale to avoid undesired changes after running `make test` and others.

```diff
$ LC_ALL=C make update-test-discovery
$ git diff
$ LC_ALL=en_US.utf8 make update-test-discovery
$ git diff
diff --git a/tests/unit/tests.inc b/tests/unit/tests.inc
index 3b1c3dc..49fe498 100644
--- a/tests/unit/tests.inc
+++ b/tests/unit/tests.inc
@@ -28,8 +28,8 @@ XX(child_spans_ts)
 XX(concurrent_init)
 XX(concurrent_uninit)
 XX(count_sampled_events)
-XX(crash_marker)
 XX(crashed_last_run)
+XX(crash_marker)
 XX(custom_logger)
 XX(discarding_before_send)
 XX(distributed_headers)
@@ -43,8 +43,8 @@ XX(dsn_auth_header_null_dsn)
 XX(dsn_parsing_complete)
 XX(dsn_parsing_invalid)
 XX(dsn_store_url_custom_agent)
-XX(dsn_store_url_with_path)
 XX(dsn_store_url_without_path)
+XX(dsn_store_url_with_path)
 XX(dsn_with_ending_forward_slash_will_be_cleaned)
 XX(dsn_with_non_http_scheme_is_invalid)
 XX(dsn_without_project_id_is_invalid)
@@ -76,8 +76,8 @@ XX(page_allocator)
 XX(path_basics)
 XX(path_current_exe)
 XX(path_directory)
-XX(path_from_str_n_wo_null_termination)
 XX(path_from_str_null)
+XX(path_from_str_n_wo_null_termination)
 XX(path_joining_unix)
 XX(path_joining_windows)
 XX(path_relative_filename)
@@ -97,9 +97,9 @@ XX(set_trace_id_with_txn)
 XX(slice)
 XX(span_data)
 XX(span_data_n)
+XX(spans_on_scope)
 XX(span_tagging)
 XX(span_tagging_n)
-XX(spans_on_scope)
 XX(stack_guarantee)
 XX(stack_guarantee_auto_init)
 XX(symbolized)
```

#skip-changelog