### PR TITLE
feat: Add `before_send_transaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Provide `before_send_transaction` callback. ([#1236](https://github.com/getsentry/sentry-native/pull/1236))
+
 ## 0.8.5
 
 **Breaking changes**:
@@ -9,7 +15,6 @@
 **Features**:
 
 - Add `sentry_value_new_user(id, username, email, ip_address)` function to avoid ambiguous user-context-keys. ([#1228](https://github.com/getsentry/sentry-native/pull/1228))
-- Provide `before_send_transaction` callback. ([#1236](https://github.com/getsentry/sentry-native/pull/1236))
  
 **Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 **Features**:
 
 - Add `sentry_value_new_user(id, username, email, ip_address)` function to avoid ambiguous user-context-keys. ([#1228](https://github.com/getsentry/sentry-native/pull/1228))
-
+- Provide `before_send_transaction` callback. ([#1236](https://github.com/getsentry/sentry-native/pull/1236))
+ 
 **Fixes**:
 
 - Remove compile-time check for the `libcurl` feature `AsynchDNS`. ([#1206](https://github.com/getsentry/sentry-native/pull/1206))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,8 @@ The example currently supports the following commands:
 - `capture-transaction`: Captures a transaction.
   - `update-tx-from-header`: Updates the transaction with trace header `"2674eb52d5874b13b560236d6c79ce8a-a0f9fdf04f1a63df"` (`trace_id`-`parent_span_id`).
   - `scope-transaction-event`: Scopes the created transaction and captures an additional event.
+- `before-transaction`: Installs a `before_transaction()` callback that updates the transaction title.
+- `discarding-before-transaction`: Installs a `before_transaction()` callback that discards the transaction.
 - `traces-sampler`: Installs a traces sampler callback function when used alongside `capture-transaction`.
 - `attach-view-hierarchy`: Adds a `view-hierarchy.json` attachment file, giving it the proper `attachment_type` and `content_type`. 
  This file can be found in `./tests/fixtures/view-hierachy.json`.

--- a/examples/example.c
+++ b/examples/example.c
@@ -104,6 +104,21 @@ on_crash_callback(
     return event;
 }
 
+static sentry_value_t
+before_transaction_callback(sentry_value_t tx)
+{
+    printf("before_transaction_callback\n");
+    return tx;
+}
+
+static sentry_value_t
+discarding_before_transaction_callback(sentry_value_t tx)
+{
+    printf("discarding_before_transaction_callback\n");
+    sentry_value_decref(tx);
+    return sentry_value_new_null();
+}
+
 static void
 print_envelope(sentry_envelope_t *envelope, void *unused_state)
 {
@@ -258,6 +273,16 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "discarding-on-crash")) {
         sentry_options_set_on_crash(
             options, discarding_on_crash_callback, NULL);
+    }
+
+    if (has_arg(argc, argv, "before-transaction")) {
+        sentry_options_set_before_transaction(
+            options, before_transaction_callback);
+    }
+
+    if (has_arg(argc, argv, "discarding-before-transaction")) {
+        sentry_options_set_before_transaction(
+            options, discarding_before_transaction_callback);
     }
 
     if (has_arg(argc, argv, "traces-sampler")) {

--- a/examples/example.c
+++ b/examples/example.c
@@ -57,10 +57,10 @@ traces_sampler_callback(const sentry_transaction_context_t *transaction_ctx,
 }
 
 static sentry_value_t
-before_send_callback(sentry_value_t event, void *hint, void *closure)
+before_send_callback(sentry_value_t event, void *hint, void *user_data)
 {
     (void)hint;
-    (void)closure;
+    (void)user_data;
 
     // make our mark on the event
     sentry_value_set_by_key(
@@ -71,10 +71,11 @@ before_send_callback(sentry_value_t event, void *hint, void *closure)
 }
 
 static sentry_value_t
-discarding_before_send_callback(sentry_value_t event, void *hint, void *closure)
+discarding_before_send_callback(
+    sentry_value_t event, void *hint, void *user_data)
 {
     (void)hint;
-    (void)closure;
+    (void)user_data;
 
     // discard event and signal backend to stop further processing
     sentry_value_decref(event);
@@ -83,10 +84,10 @@ discarding_before_send_callback(sentry_value_t event, void *hint, void *closure)
 
 static sentry_value_t
 discarding_on_crash_callback(
-    const sentry_ucontext_t *uctx, sentry_value_t event, void *closure)
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *user_data)
 {
     (void)uctx;
-    (void)closure;
+    (void)user_data;
 
     // discard event and signal backend to stop further processing
     sentry_value_decref(event);
@@ -95,19 +96,19 @@ discarding_on_crash_callback(
 
 static sentry_value_t
 on_crash_callback(
-    const sentry_ucontext_t *uctx, sentry_value_t event, void *closure)
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *user_data)
 {
     (void)uctx;
-    (void)closure;
+    (void)user_data;
 
     // tell the backend to retain the event
     return event;
 }
 
 static sentry_value_t
-before_transaction_callback(sentry_value_t tx, void *closure)
+before_transaction_callback(sentry_value_t tx, void *user_data)
 {
-    (void)closure;
+    (void)user_data;
 
     sentry_value_set_by_key(
         tx, "transaction", sentry_value_new_string("little.coffeepot"));
@@ -115,9 +116,9 @@ before_transaction_callback(sentry_value_t tx, void *closure)
 }
 
 static sentry_value_t
-discarding_before_transaction_callback(sentry_value_t tx, void *closure)
+discarding_before_transaction_callback(sentry_value_t tx, void *user_data)
 {
-    (void)closure;
+    (void)user_data;
     // throw out any transaction while a tag is active
     if (!sentry_value_is_null(sentry_value_get_by_key(tx, "tags"))) {
         sentry_value_decref(tx);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -862,7 +862,7 @@ SENTRY_API void sentry_options_set_send_default_pii(
  * sent.
  */
 typedef sentry_value_t (*sentry_event_function_t)(
-    sentry_value_t event, void *hint, void *closure);
+    sentry_value_t event, void *hint, void *user_data);
 
 /**
  * Sets the `before_send` callback.
@@ -870,7 +870,7 @@ typedef sentry_value_t (*sentry_event_function_t)(
  * See the `sentry_event_function_t` typedef above for more information.
  */
 SENTRY_API void sentry_options_set_before_send(
-    sentry_options_t *opts, sentry_event_function_t func, void *closure);
+    sentry_options_t *opts, sentry_event_function_t func, void *user_data);
 
 /**
  * Type of the `on_crash` callback.
@@ -923,7 +923,7 @@ SENTRY_API void sentry_options_set_before_send(
  * sent.
  */
 typedef sentry_value_t (*sentry_crash_function_t)(
-    const sentry_ucontext_t *uctx, sentry_value_t event, void *closure);
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *user_data);
 
 /**
  * Sets the `on_crash` callback.
@@ -1763,7 +1763,7 @@ typedef struct sentry_transaction_s sentry_transaction_t;
  * return a `sentry_value_new_null()` instead.
  */
 typedef sentry_value_t (*sentry_transaction_function_t)(
-    sentry_value_t transaction, void *data);
+    sentry_value_t transaction, void *user_data);
 
 /**
  * Sets the `before_transaction` callback.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -870,7 +870,7 @@ typedef sentry_value_t (*sentry_event_function_t)(
  * See the `sentry_event_function_t` typedef above for more information.
  */
 SENTRY_API void sentry_options_set_before_send(
-    sentry_options_t *opts, sentry_event_function_t func, void *data);
+    sentry_options_t *opts, sentry_event_function_t func, void *closure);
 
 /**
  * Type of the `on_crash` callback.
@@ -1761,19 +1761,15 @@ typedef struct sentry_transaction_s sentry_transaction_t;
  * that same transaction. In case the transaction should be discarded, the
  * callback needs to call `sentry_value_decref` on the provided transaction, and
  * return a `sentry_value_new_null()` instead.
- * TODO ensure this docstring is correct & complete
- * TODO do we want a (void* hint) parameter too (see sentry_event_function_t)?
- *  this is always passed as NULL to the on_crash/on_send callbacks :thinking:
- *  TODO before_send_data (like for on_crash/on_send)?
  */
 typedef sentry_value_t (*sentry_transaction_function_t)(
-    sentry_value_t transaction);
+    sentry_value_t transaction, void *data);
 
 /**
  * Sets the `before_transaction` callback.
  */
 SENTRY_EXPERIMENTAL_API void sentry_options_set_before_transaction(
-    sentry_options_t *opts, sentry_transaction_function_t func);
+    sentry_options_t *opts, sentry_transaction_function_t func, void *data);
 
 /**
  * A sentry Span.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1755,6 +1755,27 @@ struct sentry_transaction_s;
 typedef struct sentry_transaction_s sentry_transaction_t;
 
 /**
+ * Type of the `before_transaction` callback.
+ *
+ * The callback takes ownership of the `transaction`, and should usually return
+ * that same transaction. In case the transaction should be discarded, the
+ * callback needs to call `sentry_value_decref` on the provided transaction, and
+ * return a `sentry_value_new_null()` instead.
+ * TODO ensure this docstring is correct & complete
+ * TODO do we want a (void* hint) parameter too (see sentry_event_function_t)?
+ *  this is always passed as NULL to the on_crash/on_send callbacks :thinking:
+ *  TODO before_send_data (like for on_crash/on_send)?
+ */
+typedef sentry_value_t (*sentry_transaction_function_t)(
+    sentry_value_t transaction);
+
+/**
+ * Sets the `before_transaction` callback.
+ */
+SENTRY_EXPERIMENTAL_API void sentry_options_set_before_transaction(
+    sentry_options_t *opts, sentry_transaction_function_t func);
+
+/**
  * A sentry Span.
  *
  * See https://develop.sentry.dev/sdk/event-payloads/span/

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -634,10 +634,9 @@ sentry__prepare_transaction(const sentry_options_t *options,
     }
 
     if (options->before_transaction_func) {
-        // TODO why no invoke_before_send in func arguments (vs prepare_event)
-        //      (also why is it always `true` for prepare_event)
         SENTRY_DEBUG("invoking `before_transaction` hook");
-        transaction = options->before_transaction_func(transaction);
+        transaction = options->before_transaction_func(
+            transaction, options->before_transaction_data);
         if (sentry_value_is_null(transaction)) {
             SENTRY_DEBUG(
                 "transaction was discarded by the `before_transaction` hook");

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -633,6 +633,18 @@ sentry__prepare_transaction(const sentry_options_t *options,
         sentry__scope_apply_to_event(scope, options, transaction, mode);
     }
 
+    if (options->before_transaction_func) {
+        // TODO why no invoke_before_send in func arguments (vs prepare_event)
+        //      (also why is it always `true` for prepare_event)
+        SENTRY_DEBUG("invoking `before_transaction` hook");
+        transaction = options->before_transaction_func(transaction);
+        if (sentry_value_is_null(transaction)) {
+            SENTRY_DEBUG(
+                "transaction was discarded by the `before_transaction` hook");
+            return NULL;
+        }
+    }
+
     sentry__ensure_event_id(transaction, event_id);
     envelope = sentry__envelope_new();
     if (!envelope || !sentry__envelope_add_transaction(envelope, transaction)) {

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -158,6 +158,13 @@ sentry_options_set_on_crash(
 }
 
 void
+sentry_options_set_before_transaction(
+    sentry_options_t *opts, sentry_transaction_function_t func)
+{
+    opts->before_transaction_func = func;
+}
+
+void
 sentry_options_set_dsn_n(
     sentry_options_t *opts, const char *raw_dsn, size_t raw_dsn_len)
 {

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -159,9 +159,10 @@ sentry_options_set_on_crash(
 
 void
 sentry_options_set_before_transaction(
-    sentry_options_t *opts, sentry_transaction_function_t func)
+    sentry_options_t *opts, sentry_transaction_function_t func, void *data)
 {
     opts->before_transaction_func = func;
+    opts->before_transaction_data = data;
 }
 
 void

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -143,26 +143,26 @@ sentry_options_set_send_default_pii(sentry_options_t *opts, int value)
 
 void
 sentry_options_set_before_send(
-    sentry_options_t *opts, sentry_event_function_t func, void *data)
+    sentry_options_t *opts, sentry_event_function_t func, void *user_data)
 {
     opts->before_send_func = func;
-    opts->before_send_data = data;
+    opts->before_send_data = user_data;
 }
 
 void
 sentry_options_set_on_crash(
-    sentry_options_t *opts, sentry_crash_function_t func, void *data)
+    sentry_options_t *opts, sentry_crash_function_t func, void *user_data)
 {
     opts->on_crash_func = func;
-    opts->on_crash_data = data;
+    opts->on_crash_data = user_data;
 }
 
 void
 sentry_options_set_before_transaction(
-    sentry_options_t *opts, sentry_transaction_function_t func, void *data)
+    sentry_options_t *opts, sentry_transaction_function_t func, void *user_data)
 {
     opts->before_transaction_func = func;
-    opts->before_transaction_data = data;
+    opts->before_transaction_data = user_data;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -68,6 +68,7 @@ struct sentry_options_s {
     void *before_send_data;
     sentry_crash_function_t on_crash_func;
     void *on_crash_data;
+    sentry_transaction_function_t before_transaction_func;
 
     /* Experimentally exposed */
     double traces_sample_rate;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -69,6 +69,7 @@ struct sentry_options_s {
     sentry_crash_function_t on_crash_func;
     void *on_crash_data;
     sentry_transaction_function_t before_transaction_func;
+    void *before_transaction_data;
 
     /* Experimentally exposed */
     double traces_sample_rate;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-native/issues/1214 (and related to https://github.com/getsentry/sentry-native/issues/864#issuecomment-1649461251)

ToDo
- [x] add option
- [x] call inside transaction event preparation
- [x] add to example
- [x] answer todo questions in-code
- [x] add tests
- [x] changelog
- [x] docs https://github.com/getsentry/sentry-docs/pull/13715

## questions (resolved)
- Why do we have invoke_before_send passed into prepare_event ([see code](https://github.com/getsentry/sentry-native/blob/e511a8ed0be28e4fd9826854032df370ac0acd77/src/sentry_core.c#L554-L555)), and why is it true for sentry_core occurrences ([1](https://github.com/getsentry/sentry-native/blob/e511a8ed0be28e4fd9826854032df370ac0acd77/src/sentry_core.c#L466), [2](https://github.com/getsentry/sentry-native/blob/e511a8ed0be28e4fd9826854032df370ac0acd77/src/sentry_core.cL1407-L1408)), but passed as !options->on_crash_func for [breakpad](https://github.com/getsentry/sentry-native/blob/e511a8ed0be28e4fd9826854032df370ac0acd77/src/backends/sentry_backend_breakpad.cpp#L145-L146)?

  > For crashes, we only `before_send` if there is no `on_crash` hook.
- Where do we callback? Before or after applying scope?
  
  > As late as possible, to give the user maximal context.
- (void* hint) parameter (which is unused for the other callbacks, but exists afaict), [see here](https://github.com/getsentry/sentry-native/pull/1236/files#diff-9c77242571e813d699b88663fdc7d7ad7bb5b481a3c1af8d34e1a9e242cbf076R1765-R1766)
  
  > Not relevant for `before_send_transaction`.
- Do we want to add `before_transaction_data` to modify transactions before sending? [see here](https://github.com/getsentry/sentry-native/pull/1236/files#diff-9c77242571e813d699b88663fdc7d7ad7bb5b481a3c1af8d34e1a9e242cbf076R1767)
  
  > Yes.
