### PR TITLE
chore: bump codecov-action to 5.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
 
       - name: "Upload to codecov.io"
         if: ${{ contains(env['RUN_ANALYZER'], 'cov') }}
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # pin@v4.5.0
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # pin@v5.4.2
         with:
           directory: coverage
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This change is primarily motivated by the failing codecov invocation in the Linux ARM64 llvm-cov CI config (it works in all other configs, besides `clang-cl`, but this is another issue).

This seemingly was fixed in major 5 of the codecov-action: https://github.com/codecov/codecov-action/issues/1554

codecov works for the first time since you introduced the build config: https://github.com/getsentry/sentry-native/actions/runs/15024781906/job/42222733350?pr=1242#step:23:62

#skip-changelog