### PR TITLE
chore: remove `twxs.cmake` from the recommended VSCode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "ms-vscode.cpptools",
-    "ms-vscode.cmake-tools",
-    "twxs.cmake"
+    "ms-vscode.cmake-tools"
   ]
 }


### PR DESCRIPTION
see: https://github.com/twxs/vs.language.cmake/issues/119

CMake Tools also recommends uninstalling `twxs.cmake` when installing it. This is an unnecessary dev-setup prologue.

#skip-changelog