### PR TITLE
fix: limit proguard rules in the NDK package to local namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Unreleased
 
+**Breaking changes**:
+
+- Limiting the proguard rules in the NDK package, moves the burden of the configuration to it users. Please ensure to [configure proguard](http://proguard.sourceforge.net/manual/examples.html#native) so that native methods in your namespace can be symbolicated if the appear in stack traces. ([#1250](https://github.com/getsentry/sentry-native/pull/1250))
+
 **Features**:
 
 - Provide `before_send_transaction` callback. ([#1236](https://github.com/getsentry/sentry-native/pull/1236))
+
+**Fixes**:
+
+- Reduce the scope of the proguard rules in the NDK package to local namespaces. ([#1250](https://github.com/getsentry/sentry-native/pull/1250))
 
 **Docs**:
 

--- a/ndk/lib/proguard-rules.pro
+++ b/ndk/lib/proguard-rules.pro
@@ -8,7 +8,7 @@
 -keep class io.sentry.ndk.DebugImage { *; }
 
 # For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
--keepclasseswithmembernames,includedescriptorclasses class * {
+-keepclasseswithmembernames,includedescriptorclasses class io.sentry.ndk.** {
     native <methods>;
 }
 

--- a/ndk/sample/proguard-rules.pro
+++ b/ndk/sample/proguard-rules.pro
@@ -17,7 +17,7 @@
 -keepattributes LineNumberTable,SourceFile
 
 # For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
--keepclasseswithmembernames,includedescriptorclasses class * {
+-keepclasseswithmembernames,includedescriptorclasses class io.sentry.ndk.sample.** {
     native <methods>;
 }
 


### PR DESCRIPTION
Fixes #1249 (but limits scope even more severely than proposed, given the append merge-nature, even for the sample).

@markushi, feel free to integrate and merge whenever it makes sense.