### PR TITLE
feat: `crashpad_wait_for_upload` Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Provide `before_send_transaction` callback. ([#1236](https://github.com/getsentry/sentry-native/pull/1236))
 - Add support for capturing events with local scopes. ([#1248](https://github.com/getsentry/sentry-native/pull/1248))
+- Add Windows support for the `crashpad_wait_for_upload` flag. ([#1255](https://github.com/getsentry/sentry-native/pull/1255), [crashpad#126](https://github.com/getsentry/crashpad/pull/126))
 
 **Fixes**:
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1374,7 +1374,8 @@ SENTRY_API void sentry_options_set_system_crash_reporter_enabled(
  * Enables a wait for the crash report upload to be finished before shutting
  * down. This is disabled by default.
  *
- * This setting only has an effect when using the `crashpad` backend on Linux.
+ * This setting only has an effect when using the `crashpad` backend on Linux
+ * and Windows.
  */
 SENTRY_API void sentry_options_set_crashpad_wait_for_upload(
     sentry_options_t *opts, int wait_for_upload);


### PR DESCRIPTION
Required `crashpad `changes: https://github.com/getsentry/crashpad/pull/126

- [x] Update [user docs](https://docs.sentry.io/platforms/native/configuration/options/#crashpad-wait-for-upload): https://github.com/getsentry/sentry-docs/pull/13863
- [x] Update [backend tradeoff](https://docs.sentry.io/platforms/native/advanced-usage/backend-tradeoffs/): https://github.com/getsentry/sentry-docs/pull/13865
- [x] Update [container env](https://docs.sentry.io/platforms/native/advanced-usage/container-environments/#waiting-for-crashpad-to-finish): https://github.com/getsentry/sentry-docs/pull/13864
- [x] Provide instructions for reproduction
- [ ] ~~Maybe integrate in CI~~

----
### Steps to reproduce:

* Set up Docker for Windows so you can run Windows containers (follow [these steps](https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=dockerce#install-the-container-runtime))
* Verify that everything worked by [running a test container](https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/run-your-first-container#run-a-windows-container). If you use the `nanoserver`, as suggested, you will be able to reuse it below.
* Build the Native SDK on the host system as a static build with static runtime libraries. This is extremely helpful when deploying to a minimal image, such as `nanoserver`, given the relatively complex SDK and runtime dependency chain.
   ```
   cmake -B build -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DSENTRY_BUILD_SHARED_LIBS=OFF -DSENTRY_BUILD_RUNTIMESTATIC=ON
  cmake --build .\build\ --config=RelWithDebInfo
  ```
* ensure that the `crashpad_handler` (and maybe the WER module) are colocated with the `sentry_example.exe`
  ```
  cp .\build\crashpad_build\handler\RelWithDebInfo\crashpad_handler.exe .\build\RelWithDebInfo\.
  cp .\build\crashpad_build\handler\RelWithDebInfo\crashpad_wer.dll .\build\RelWithDebInfo\.
  ```
* Run the `sentry_example.exe` with logging inside a `nanoserver` container only to verify the setup:
  ```
  docker run --rm -it -e SENTRY_DSN="YOUR_TEST_DSN" -v C:\host\path\to\your\build:C:\native_build mcr.microsoft.com/windows/nanoserver:ltsc2022 C:\native_build\RelWithDebInfo\sentry_example.exe log
  ```
* Run the `sentry_example.exe` inside a `nanoserver` container to crash (this will typically fail to report):
  ```
  docker run --rm -it -e SENTRY_DSN="YOUR_TEST_DSN" -v C:\host\path\to\your\build:C:\native_build mcr.microsoft.com/windows/nanoserver:ltsc2022 C:\native_build\RelWithDebInfo\sentry_example.exe log crash
  ```
* Run the `sentry_example.exe` inside a `nanoserver` container to crash, but with `wait-for-upload` enabled (this should always report):
  ```
  docker run --rm -it -e SENTRY_DSN="YOUR_TEST_DSN" -v C:\host\path\to\your\build:C:\native_build mcr.microsoft.com/windows/nanoserver:ltsc2022 C:\native_build\RelWithDebInfo\sentry_example.exe log crash crashpad-wait-for-upload
  ```