### PR TITLE
fix: use custom page allocator on ps5

### DIFF
--- a/src/sentry_alloc.c
+++ b/src/sentry_alloc.c
@@ -5,7 +5,7 @@
 
 /* on unix platforms we add support for a simplistic page allocator that can
    be enabled to make code async safe */
-#if defined(SENTRY_PLATFORM_UNIX) && !defined(SENTRY_PLATFORM_PS)
+#if defined(SENTRY_PLATFORM_UNIX)
 #    include "sentry_unix_pageallocator.h"
 #    define WITH_PAGE_ALLOCATOR
 #endif


### PR DESCRIPTION
This is required in signal handlers due to missing malloc.

#skip-changelog because this is for internal use only