### PR TITLE
fix(ndk): correct interpolation of new `project.layout.buildDirectory` property

### DIFF
--- a/ndk/build.gradle.kts
+++ b/ndk/build.gradle.kts
@@ -105,12 +105,12 @@ subprojects {
         tasks.named("distZip").configure {
             this.dependsOn("publishToMavenLocal")
             this.doLast {
-                val distributionFilePath =
-                    "${this.project.layout.buildDirectory}${sep}distributions${sep}${this.project.name}-${this.project.version}.zip"
-
-                val file = File(distributionFilePath)
-                if (!file.exists()) throw IllegalStateException("Distribution file: $distributionFilePath does not exist")
-                if (file.length() == 0L) throw IllegalStateException("Distribution file: $distributionFilePath is empty")
+                val distZip =
+                    this.project.layout.buildDirectory.dir("distributions").map {
+                        it.file("${this.project.name}-${this.project.version}.zip")
+                    }.get().asFile
+                if (!distZip.exists()) throw IllegalStateException("Distribution file: ${distZip.absolutePath} does not exist")
+                if (distZip.length() == 0L) throw IllegalStateException("Distribution file: ${distZip.absolutePath} is empty")
             }
         }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry-native/pull/1256, where I replaced the deprecated `project.buildDir` with its lazy variant  `project.layout.buildDirectory`. It forgot to change the interpolation when constructing the distribution-zip path, since the new property is an entirely different type (duh).

This currently breaks the release archive job on `master` which isn't executed during the PR CI runs.