### PR TITLE
feat: allow PS SDK to implement custom transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 	set(LINUX TRUE)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "AIX" OR CMAKE_SYSTEM_NAME STREQUAL "OS400")
 	set(AIX TRUE)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Prospero")
+	set(PROSPERO TRUE)
 endif()
 
 #setup sentry library type
@@ -117,34 +119,39 @@ endif()
 
 if(WIN32)
 	set(SENTRY_DEFAULT_TRANSPORT "winhttp")
+	set(_SUPPORTED_TRANSPORTS "none, winhttp")
+elseif(PROSPERO)
+	set(SENTRY_DEFAULT_TRANSPORT "pshttp")
+	set(_SUPPORTED_TRANSPORTS "none, pshttp")
 elseif((APPLE AND NOT IOS) OR LINUX OR AIX OR NX)
 	set(SENTRY_DEFAULT_TRANSPORT "curl")
+	set(_SUPPORTED_TRANSPORTS "none, curl")
 else()
 	set(SENTRY_DEFAULT_TRANSPORT "none")
+	set(_SUPPORTED_TRANSPORTS "none, curl, or winhttp on Windows")
 endif()
 
-if(NOT DEFINED SENTRY_TRANSPORT)
-	set(SENTRY_TRANSPORT ${SENTRY_DEFAULT_TRANSPORT} CACHE STRING
-		"The HTTP transport that sentry uses to submit events to the sentry server, can be either 'none', 'curl' or 'winhttp' on Windows.")
-endif()
+set(SENTRY_TRANSPORT ${SENTRY_DEFAULT_TRANSPORT} CACHE STRING
+	"The HTTP transport that sentry uses to submit events to the sentry server, can be one of: ${_SUPPORTED_TRANSPORTS}.")
 
 if(SENTRY_TRANSPORT STREQUAL "winhttp")
 	set(SENTRY_TRANSPORT_WINHTTP TRUE)
+	if(NOT WIN32)
+		message(FATAL_ERROR "The winhttp transport is only supported on Windows.")
+	endif()
 elseif(SENTRY_TRANSPORT STREQUAL "curl")
 	set(SENTRY_TRANSPORT_CURL TRUE)
 elseif(SENTRY_TRANSPORT STREQUAL "none")
 	set(SENTRY_TRANSPORT_NONE TRUE)
-elseif(SENTRY_TRANSPORT STREQUAL "custom")
-	message(DEBUG
-		"SENTRY_TRANSPORT set to 'custom' - a custom transport source must be added to the compilation unit by the downstream SDK.")
+elseif(SENTRY_TRANSPORT STREQUAL "pshttp")
+	# Not implemented here, but in the downstream SDK
+	if(NOT PROSPERO)
+		message(FATAL_ERROR "The pshttp transport is only supported on PlayStation.")
+	endif()
 else()
-	message(FATAL_ERROR "SENTRY_TRANSPORT must be one of 'none', 'curl' or 'winhttp'.
-		Downstream SDKs may choose to provide their own by specifying 'custom'.")
+	message(FATAL_ERROR "SENTRY_TRANSPORT must be one of: ${_SUPPORTED_TRANSPORTS}")
 endif()
 
-if(SENTRY_TRANSPORT_WINHTTP AND NOT WIN32)
-	message(FATAL_ERROR "The winhttp transport is only supported on Windows.")
-endif()
 
 if(SENTRY_BUILD_TESTS OR SENTRY_BUILD_EXAMPLES)
 	enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,10 @@ else()
 	set(SENTRY_DEFAULT_TRANSPORT "none")
 endif()
 
-set(SENTRY_TRANSPORT ${SENTRY_DEFAULT_TRANSPORT} CACHE STRING
-	"The HTTP transport that sentry uses to submit events to the sentry server, can be either 'none', 'curl' or 'winhttp' on windows.")
+if(NOT DEFINED SENTRY_TRANSPORT)
+	set(SENTRY_TRANSPORT ${SENTRY_DEFAULT_TRANSPORT} CACHE STRING
+		"The HTTP transport that sentry uses to submit events to the sentry server, can be either 'none', 'curl' or 'winhttp' on Windows.")
+endif()
 
 if(SENTRY_TRANSPORT STREQUAL "winhttp")
 	set(SENTRY_TRANSPORT_WINHTTP TRUE)
@@ -132,8 +134,12 @@ elseif(SENTRY_TRANSPORT STREQUAL "curl")
 	set(SENTRY_TRANSPORT_CURL TRUE)
 elseif(SENTRY_TRANSPORT STREQUAL "none")
 	set(SENTRY_TRANSPORT_NONE TRUE)
+elseif(SENTRY_TRANSPORT STREQUAL "custom")
+	message(DEBUG
+		"SENTRY_TRANSPORT set to 'custom' - a custom transport source must be added to the compilation unit by the downstream SDK.")
 else()
-	message(FATAL_ERROR "SENTRY_TRANSPORT must be one of 'none', 'curl' or 'winhttp'")
+	message(FATAL_ERROR "SENTRY_TRANSPORT must be one of 'none', 'curl' or 'winhttp'.
+		Downstream SDKs may choose to provide their own by specifying 'custom'.")
 endif()
 
 if(SENTRY_TRANSPORT_WINHTTP AND NOT WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if(WIN32)
 		path/sentry_path_windows.c
 		symbolizer/sentry_symbolizer_windows.c
 	)
-elseif(NX OR CMAKE_SYSTEM_NAME STREQUAL "Prospero")
+elseif(NX OR PROSPERO)
 	sentry_target_sources_cwd(sentry
 		sentry_unix_spinlock.h
 		path/sentry_path_unix.c


### PR DESCRIPTION
Similar to a custom backend that's already supported, this adds support for downstream SDKs (e.g. PlayStation) to implement custom transport with proprietary APIs of the target platform.

#skip-changelog - this is intended for internal use
