### PR TITLE
ci: pin kcov to v43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git
           cd kcov
+          git checkout a6ff5ac44524d1bc9c298ca14c10edd41ded1cea # check whether a particular change introduced error logs
           mkdir build
           cd build
           cmake ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git
           cd kcov
-          git checkout a6ff5ac44524d1bc9c298ca14c10edd41ded1cea # check whether a particular change introduced error logs
+          git checkout v43 # pin to a version without the current coveralls git integration
           mkdir build
           cd build
           cmake ..


### PR DESCRIPTION
The behavior described in #1263 leads back to a [recent version of `kcov`](https://github.com/SimonKagstrom/kcov/commit/0ecc2dc754765f77c72e2637a244c579d3c63cf2) integrating a `git` metadata collection for the `coveralls` writer.

Our test execution happens in temporary directories rather than a `git` repository, so that all invocations will fail. Additionally, we don't use `coveralls` as a coverage service, but `kcov` doesn't allow selecting its writers (they are all registered on startup). 

Since it is generally a good idea to pin CI dependencies, I think this is a sane fix to flooding the `kcov` jobs with irrelevant `git` errors.

An upstream solution to the problem would be to silence `stderr` on the `git` invocations.

#skip-changelog
