### PR TITLE
ci: drop windows-2019 runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
             SYSTEM_VERSION_COMPAT: 0
             RUN_ANALYZER: asan,llvm-cov
           - name: Windows (old VS, 32-bit)
-            os: windows-2019
+            os: windows-2022
             TEST_X86: 1
           - name: Windows (latest)
             os: windows-latest


### PR DESCRIPTION
We currently use the `windows-2019` runner image for the "old" Windows configuration (which also builds the 32-bit binary). This image is deprecated: https://github.com/actions/runner-images/issues/12045.

All other Windows configurations use `windows-latest`, which currently is `windows-2022` but will be upgraded to `windows-2025`, so let's pin this one on 2022.