### PR TITLE
feat: add sentry_attachment_set_content_type()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The `sentry_attach_file`, `sentry_scope_attach_file` (and their wide-string variants), and `sentry_remove_attachment` have been added to modify the list of attachments that are sent along with sentry events after a call to `sentry_init`. ([#1266](https://github.com/getsentry/sentry-native/pull/1266))
   - NOTE: When using the `crashpad` backend on macOS, the list of attachments that will be added at the time of a hard crash will be frozen at the time of `sentry_init`, and later modifications will not be reflected.
+- Add `sentry_attachment_set_content_type` to allow specifying the content type of attachments. ([#1276](https://github.com/getsentry/sentry-native/pull/1276))
 
 ## 0.9.0
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1833,6 +1833,9 @@ SENTRY_API sentry_attachment_t *sentry_scope_attach_filew_n(
     sentry_scope_t *scope, const wchar_t *path, size_t path_len);
 #endif
 
+SENTRY_API void sentry_attachment_set_content_type(
+    sentry_attachment_t *attachment, const char *content_type);
+
 /* -- Session APIs -- */
 
 typedef enum {

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1835,6 +1835,9 @@ SENTRY_API sentry_attachment_t *sentry_scope_attach_filew_n(
 
 SENTRY_API void sentry_attachment_set_content_type(
     sentry_attachment_t *attachment, const char *content_type);
+SENTRY_API void sentry_attachment_set_content_type_n(
+    sentry_attachment_t *attachment, const char *content_type,
+    size_t content_type_len);
 
 /* -- Session APIs -- */
 

--- a/src/sentry_attachment.c
+++ b/src/sentry_attachment.c
@@ -1,6 +1,22 @@
 #include "sentry_attachment.h"
 #include "sentry_alloc.h"
 #include "sentry_path.h"
+#include "sentry_string.h"
+
+void
+sentry_attachment_set_content_type(
+    sentry_attachment_t *attachment, const char *content_type)
+{
+    if (!attachment) {
+        return;
+    }
+
+    if (attachment->content_type_owned) {
+        sentry_free((void *)attachment->content_type);
+    }
+    attachment->content_type = sentry__string_clone(content_type);
+    attachment->content_type_owned = true;
+}
 
 static void
 attachment_free(sentry_attachment_t *attachment)
@@ -9,6 +25,9 @@ attachment_free(sentry_attachment_t *attachment)
         return;
     }
     sentry__path_free(attachment->path);
+    if (attachment->content_type_owned) {
+        sentry_free((void *)attachment->content_type);
+    }
     sentry_free(attachment);
 }
 
@@ -41,6 +60,7 @@ sentry__attachments_add(sentry_attachment_t **attachments_ptr,
     attachment->next = NULL;
     attachment->type = attachment_type;
     attachment->content_type = content_type;
+    attachment->content_type_owned = false;
 
     sentry_attachment_t **next_ptr = attachments_ptr;
 

--- a/src/sentry_attachment.c
+++ b/src/sentry_attachment.c
@@ -7,12 +7,21 @@ void
 sentry_attachment_set_content_type(
     sentry_attachment_t *attachment, const char *content_type)
 {
+    sentry_attachment_set_content_type_n(
+        attachment, content_type, sentry__guarded_strlen(content_type));
+}
+
+void
+sentry_attachment_set_content_type_n(sentry_attachment_t *attachment,
+    const char *content_type, size_t content_type_len)
+{
     if (!attachment) {
         return;
     }
 
     sentry_free(attachment->content_type);
-    attachment->content_type = sentry__string_clone(content_type);
+    attachment->content_type
+        = sentry__string_clone_n(content_type, content_type_len);
 }
 
 static void

--- a/src/sentry_attachment.c
+++ b/src/sentry_attachment.c
@@ -11,11 +11,8 @@ sentry_attachment_set_content_type(
         return;
     }
 
-    if (attachment->content_type_owned) {
-        sentry_free((void *)attachment->content_type);
-    }
+    sentry_free(attachment->content_type);
     attachment->content_type = sentry__string_clone(content_type);
-    attachment->content_type_owned = true;
 }
 
 static void
@@ -25,9 +22,7 @@ attachment_free(sentry_attachment_t *attachment)
         return;
     }
     sentry__path_free(attachment->path);
-    if (attachment->content_type_owned) {
-        sentry_free((void *)attachment->content_type);
-    }
+    sentry_free(attachment->content_type);
     sentry_free(attachment);
 }
 
@@ -59,8 +54,7 @@ sentry__attachments_add(sentry_attachment_t **attachments_ptr,
     attachment->path = path;
     attachment->next = NULL;
     attachment->type = attachment_type;
-    attachment->content_type = content_type;
-    attachment->content_type_owned = false;
+    attachment->content_type = sentry__string_clone(content_type);
 
     sentry_attachment_t **next_ptr = attachments_ptr;
 

--- a/src/sentry_attachment.h
+++ b/src/sentry_attachment.h
@@ -22,6 +22,7 @@ struct sentry_attachment_s {
     sentry_path_t *path;
     sentry_attachment_type_t type;
     const char *content_type;
+    bool content_type_owned;
     sentry_attachment_t *next;
 };
 

--- a/src/sentry_attachment.h
+++ b/src/sentry_attachment.h
@@ -21,8 +21,7 @@ typedef enum {
 struct sentry_attachment_s {
     sentry_path_t *path;
     sentry_attachment_type_t type;
-    const char *content_type;
-    bool content_type_owned;
+    char *content_type;
     sentry_attachment_t *next;
 };
 

--- a/tests/unit/tests.inc
+++ b/tests/unit/tests.inc
@@ -1,6 +1,7 @@
 XX(assert_sdk_name)
 XX(assert_sdk_user_agent)
 XX(assert_sdk_version)
+XX(attachment_content_type)
 XX(attachments_add_dedupe)
 XX(attachments_add_remove)
 XX(attachments_extend)


### PR DESCRIPTION
A small follow-up to #1266 to support specifying the content type for attachments, as needed for [sentry-unreal](https://github.com/getsentry/sentry-unreal/blob/main/plugin-dev/Source/Sentry/Public/SentryAttachment.h).

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
