### PR TITLE
ci: update kcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,10 @@ jobs:
           sudo apt install cmake clang-19 llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
           # Install kcov from source
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
-          git clone https://github.com/jpnurmi/kcov.git
+          git clone https://github.com/SimonKagstrom/kcov.git
           cd kcov
-          git checkout v43-opt # pin to a version without the current coveralls git integration
+          # pin to a known good version with the coveralls git integration and performance bottlenecks fixed
+          git checkout 8afe9f29c58ef575877664c7ba209328233b70cc
           mkdir build
           cd build
           cmake ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,9 @@ jobs:
           sudo apt install cmake clang-19 llvm g++-12 valgrind zlib1g-dev libcurl4-openssl-dev
           # Install kcov from source
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-12-dev libdw-dev libiberty-dev
-          git clone https://github.com/SimonKagstrom/kcov.git
+          git clone https://github.com/jpnurmi/kcov.git
           cd kcov
-          git checkout v43 # pin to a version without the current coveralls git integration
+          git checkout v43-opt # pin to a version without the current coveralls git integration
           mkdir build
           cd build
           cmake ..


### PR DESCRIPTION
Bump kcov to an un unreleased revision that contains both:
- https://github.com/SimonKagstrom/kcov/pull/482
- https://github.com/SimonKagstrom/kcov/pull/483

Linux (clang 19 + kcov):
| Before | After |
|---|---|
| [47m 18s](https://github.com/getsentry/sentry-native/actions/runs/15874686952/job/44759360055#logs) | [8m 12s](https://github.com/getsentry/sentry-native/actions/runs/15971824656/job/45044951744#logs) |

<details><summary>old details</summary>

When running the very first sentry-native unit test `assert_sdk_name`:
```sh
perf record -g -- kcov --include-path=/path/to/sentry-native/src /tmp/pytest-of-jpnurmi/pytest-20/cmake0/coverage ./sentry_test_unit --no-summary assert_sdk_name
```
It takes roughly 5.5 seconds, and 92% of the time is spent in [`get_real_path()`](https://github.com/SimonKagstrom/kcov/blob/ee728054aaf8942393b60973c166741761324126/src/utils.cc#L576-L596).

![image](https://github.com/user-attachments/assets/be3c13fb-a7ae-4f84-a17f-86f690287569)

For that single test case alone, kcov does 1792620 repetitive failed and uncached lookups. Only 2214 of the lookups are unique. I'm not sure if it's safe to cache the failed lookups, but the purpose of this experiment is to see what kind of impact it would have on the sentry-native CI if the bottleneck was fixed in kcov in one way or another...
</details>