### PR TITLE
ci(publishing): Use shim ossrh-staging-api server to publish to the new central repo 

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -20,8 +20,8 @@ targets:
     includeNames: /^(sentry-native-ndk-).*\.zip$/
     mavenCliPath: scripts/mvnw
     mavenSettingsPath: scripts/settings.xml
-    mavenRepoId: ossrh
-    mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2/
+    mavenRepoId: ossrh-staging-api
+    mavenRepoUrl: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
     android:
       distDirRegex: /^(sentry-native-ndk).*$/
       fileReplaceeRegex: /\d+\.\d+\.\d+(-\w+(\.\d+)?)?(-SNAPSHOT)?/

--- a/scripts/settings.xml
+++ b/scripts/settings.xml
@@ -4,7 +4,7 @@
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>ossrh-staging-api</id>
       <username>${env.OSSRH_USERNAME}</username>
       <password>${env.OSSRH_PASSWORD}</password>
     </server>


### PR DESCRIPTION
_#skip-changelog_

Since Nexus’ OSSRH repository was [shut down](https://central.sonatype.org/news/20250326_ossrh_sunset/) on 30.6.2025 we were forced to migrate to the new Central Repository. Same as https://github.com/getsentry/sentry-java/pull/4530. 