### PR TITLE
test: migrate from deprecated `sentry_new_function_transport`

### DIFF
--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -11,12 +11,13 @@ typedef struct {
 } sentry_attachments_testdata_t;
 
 static void
-send_envelope_test_attachments(const sentry_envelope_t *envelope, void *_data)
+send_envelope_test_attachments(sentry_envelope_t *envelope, void *_data)
 {
     sentry_attachments_testdata_t *data = _data;
     data->called += 1;
     sentry__envelope_serialize_into_stringbuilder(
         envelope, &data->serialized_envelope);
+    sentry_envelope_free(envelope);
 }
 
 SENTRY_TEST(lazy_attachments)
@@ -28,9 +29,10 @@ SENTRY_TEST(lazy_attachments)
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_auto_session_tracking(options, false);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(options,
-        sentry_new_function_transport(
-            send_envelope_test_attachments, &testdata)));
+    sentry_transport_t *transport
+        = sentry_transport_new(send_envelope_test_attachments);
+    sentry_transport_set_state(transport, &testdata);
+    sentry_options_set_transport(options, transport);
     char rel[] = { 't', 'e', 's', 't' };
     sentry_options_set_release_n(options, rel, sizeof(rel));
 

--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -4,7 +4,7 @@
 #include "sentry_testsupport.h"
 
 static void
-send_envelope_test_basic(const sentry_envelope_t *envelope, void *data)
+send_envelope_test_basic(sentry_envelope_t *envelope, void *data)
 {
     uint64_t *called = data;
     *called += 1;
@@ -26,6 +26,7 @@ send_envelope_test_basic(const sentry_envelope_t *envelope, void *data)
             sentry_value_get_by_key(event, "transaction"));
         TEST_CHECK_STRING_EQUAL(trans, "demo-trans");
     }
+    sentry_envelope_free(envelope);
 }
 
 SENTRY_TEST(basic_function_transport)
@@ -33,8 +34,10 @@ SENTRY_TEST(basic_function_transport)
     uint64_t called = 0;
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(options,
-        sentry_new_function_transport(send_envelope_test_basic, &called)));
+    sentry_transport_t *transport
+        = sentry_transport_new(send_envelope_test_basic);
+    sentry_transport_set_state(transport, &called);
+    sentry_options_set_transport(options, transport);
     sentry_options_set_release(options, "prod");
     sentry_options_set_require_user_consent(options, true);
     sentry_init(options);
@@ -63,10 +66,11 @@ SENTRY_TEST(basic_function_transport)
 }
 
 static void
-counting_transport_func(const sentry_envelope_t *UNUSED(envelope), void *data)
+counting_transport_func(sentry_envelope_t *envelope, void *data)
 {
     uint64_t *called = data;
     *called += 1;
+    sentry_envelope_free(envelope);
 }
 
 static sentry_value_t
@@ -85,9 +89,10 @@ SENTRY_TEST(sampling_before_send)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(options,
-        sentry_new_function_transport(
-            counting_transport_func, &called_transport)));
+    sentry_transport_t *transport
+        = sentry_transport_new(counting_transport_func);
+    sentry_transport_set_state(transport, &called_transport);
+    sentry_options_set_transport(options, transport);
     sentry_options_set_before_send(options, before_send, &called_beforesend);
     sentry_options_set_sample_rate(options, 0.75);
     sentry_init(options);
@@ -127,9 +132,10 @@ SENTRY_TEST(discarding_before_send)
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     // Disable sessions or this test would fail if env:SENTRY_RELEASE is set.
     sentry_options_set_auto_session_tracking(options, 0);
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(options,
-        sentry_new_function_transport(
-            counting_transport_func, &called_transport)););
+    sentry_transport_t *transport
+        = sentry_transport_new(counting_transport_func);
+    sentry_transport_set_state(transport, &called_transport);
+    sentry_options_set_transport(options, transport);
     sentry_options_set_before_send(
         options, discarding_before_send, &called_beforesend);
     sentry_init(options);

--- a/tests/unit/test_concurrency.c
+++ b/tests/unit/test_concurrency.c
@@ -4,7 +4,7 @@
 #include <sentry_sync.h>
 
 static void
-send_envelope_test_concurrent(const sentry_envelope_t *envelope, void *data)
+send_envelope_test_concurrent(sentry_envelope_t *envelope, void *data)
 {
     sentry__atomic_fetch_and_add((long *)data, 1);
 
@@ -15,6 +15,7 @@ send_envelope_test_concurrent(const sentry_envelope_t *envelope, void *data)
         TEST_CHECK_STRING_EQUAL(
             event_id, "4c035723-8638-4c3a-923f-2ab9d08b4018");
     }
+    sentry_envelope_free(envelope);
 }
 
 static void
@@ -22,8 +23,10 @@ init_framework(long *called)
 {
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(options,
-        sentry_new_function_transport(send_envelope_test_concurrent, called)));
+    sentry_transport_t *transport
+        = sentry_transport_new(send_envelope_test_concurrent);
+    sentry_transport_set_state(transport, called);
+    sentry_options_set_transport(options, transport);
     sentry_options_set_release(options, "prod");
     sentry_options_set_require_user_consent(options, false);
     sentry_options_set_auto_session_tracking(options, true);

--- a/tests/unit/test_failures.c
+++ b/tests/unit/test_failures.c
@@ -10,15 +10,14 @@ transport_startup_fail(
 }
 
 static void
-noop_send(const sentry_envelope_t *UNUSED(envelope), void *UNUSED(data))
+noop_send(sentry_envelope_t *envelope, void *UNUSED(data))
 {
+    sentry_envelope_free(envelope);
 }
 
 SENTRY_TEST(init_failure)
 {
-    sentry_transport_t *transport = NULL;
-    SENTRY_TEST_DEPRECATED(
-        transport = sentry_new_function_transport(noop_send, NULL));
+    sentry_transport_t *transport = sentry_transport_new(noop_send);
     TEST_ASSERT(!!transport);
     sentry_transport_set_startup_func(transport, transport_startup_fail);
 

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -4,7 +4,7 @@
 #include "sentry_value.h"
 
 static void
-send_envelope(const sentry_envelope_t *envelope, void *data)
+send_envelope(sentry_envelope_t *envelope, void *data)
 {
     uint64_t *called = data;
     *called += 1;
@@ -50,6 +50,7 @@ send_envelope(const sentry_envelope_t *envelope, void *data)
         "test");
 
     sentry_value_decref(session);
+    sentry_envelope_free(envelope);
 }
 
 SENTRY_TEST(session_basics)
@@ -57,8 +58,9 @@ SENTRY_TEST(session_basics)
     uint64_t called = 0;
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(
-        options, sentry_new_function_transport(send_envelope, &called)));
+    sentry_transport_t *transport = sentry_transport_new(send_envelope);
+    sentry_transport_set_state(transport, &called);
+    sentry_options_set_transport(options, transport);
     sentry_options_set_release(options, "my_release");
 
     // the default environment is always `production` if not overwritten by the
@@ -101,7 +103,7 @@ typedef struct {
 } session_assertion_t;
 
 static void
-send_sampled_envelope(const sentry_envelope_t *envelope, void *data)
+send_sampled_envelope(sentry_envelope_t *envelope, void *data)
 {
     session_assertion_t *assertion = data;
 
@@ -133,6 +135,7 @@ send_sampled_envelope(const sentry_envelope_t *envelope, void *data)
 
         sentry_value_decref(session);
     }
+    sentry_envelope_free(envelope);
 }
 
 SENTRY_TEST(count_sampled_events)
@@ -141,8 +144,9 @@ SENTRY_TEST(count_sampled_events)
 
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    SENTRY_TEST_DEPRECATED(sentry_options_set_transport(options,
-        sentry_new_function_transport(send_sampled_envelope, &assertion)));
+    sentry_transport_t *transport = sentry_transport_new(send_sampled_envelope);
+    sentry_transport_set_state(transport, &assertion);
+    sentry_options_set_transport(options, transport);
     sentry_options_set_release(options, "my_release");
     sentry_options_set_sample_rate(options, 0.5);
     sentry_init(options);


### PR DESCRIPTION
Use the `sentry_transport_new` replacement in tests to avoid calling deprecated APIs and having to suppress deprecation warnings.

#skip-changelog