### PR TITLE
test: fix SENTRY_TEST(path_directory) to clean up after itself

### DIFF
--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -236,6 +236,7 @@ SENTRY_TEST(path_directory)
     sentry__path_free(path_4);
 #endif
 
+    sentry__path_remove_all(path_1);
     sentry__path_free(path_1);
     sentry__path_free(path_2);
 }


### PR DESCRIPTION
Fixes a small annoyance that running `make test-unit` would clutter the current working directory with a `foo` directory:

```sh
$ ls -d foo
ls: cannot access 'foo': No such file or directory
$ make test-unit
[...]
Test path_directory...                          [ OK ]
[...]
$ ls -d foo
foo
```

#skip-changelog