### PR TITLE
fix(ci): Fix missing debug symbols for craft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,5 +356,6 @@ jobs:
           name: ${{ github.sha }}
           if-no-files-found: error
           path: |
-            ndk/lib/build/distributions/*.zip
             sentry-native.zip
+            ndk/lib/build/distributions/*.zip
+            ndk/lib/build/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/*


### PR DESCRIPTION
The `libsentry.so` and `libsentry-android.so` files where not uploaded to the git release sha, causing craft to be unable to find and upload those symbols to our symbol server.

#skip-changelog

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
