### PR TITLE
fix(test): suppress valgrind for SENTRY_TEST(task_queue) 

### DIFF
--- a/tests/valgrind.txt
+++ b/tests/valgrind.txt
@@ -31,7 +31,9 @@
     pthread stack possibly lost in test_task_queue
     Memcheck:Leak
     fun:calloc
+    ...
     fun:pthread_create*
+    ...
     fun:sentry__bgworker_start
     fun:test_sentry_task_queue
 }


### PR DESCRIPTION
(potential) successor of https://github.com/getsentry/sentry-native/pull/1323 ; we might be too strict on the `valgrind.txt` suppression stacktrace, so adding wildcards (`...`) might fix the flakiness.

fixes https://github.com/getsentry/sentry-native/issues/1322

<details>
<summary>Explanation (from comment on original issue)</summary>

I wonder if the issue is that the stacktrace doesn't look exactly as specified in [valgrind.txt](https://github.com/getsentry/sentry-native/blob/master/tests/valgrind.txt#L30-L37), but there's some frames in-between:

```
{
    pthread stack possibly lost in test_task_queue
    Memcheck:Leak
    fun:calloc
    fun:pthread_create*
    fun:sentry__bgworker_start
    fun:test_sentry_task_queue
}
```
vs
```
calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
calloc (rtld-malloc.h:44)
allocate_dtv (dl-tls.c:370)               <-- additional frames
_dl_allocate_tls (dl-tls.c:629)           <-- additional frames
allocate_stack (allocatestack.c:429)      <-- additional frames
pthread_create@@GLIBC_2.34 (pthread_create.c:655)
sentry__bgworker_start (sentry_sync.c:298)
test_sentry_task_queue (test_sync.c:110)    <-- same start
test_do_run__ (acutest.h:943)
test_run__ (acutest.h:1114)
main (acutest.h:1623)
```

I read online that you can [specify wildcards](https://valgrind.org/docs/manual/manual-core.html#:~:text=A%20location%20line,done%20by%20compilers.) with `...` in the valgrind syntax, so maybe updating to this could fix it:
```
{
    pthread stack possibly lost in test_task_queue
    Memcheck:Leak
    fun:calloc
    ...
    fun:pthread_create*
    fun:sentry__bgworker_start
    fun:test_sentry_task_queue
}
```
</details>

#skip-changelog
