### PR TITLE
chore: Change issue template type to label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,9 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: ""
-labels: "Platform: Native"
+labels: "Platform: Native,bug"
 assignees: ""
-type: Bug
 ---
 
 **Description**


### PR DESCRIPTION
We no longer use Issue Type, but Labels instead.
