### PR TITLE
craft: only include zip artifacts for github target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,6 +2,7 @@ minVersion: 0.23.1
 changelogPolicy: auto
 targets:
   - name: github
+    includeNames: /^(sentry-native).*\.zip$/
   - name: registry
     sdks:
       github:getsentry/sentry-native:


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry-native/pull/1327.

Since the upload now also includes the binaries for the `craft` symbol-collection target, we must ensure that other craft tasks filter those out (concretely, the GitHub `craft` target failed when uploading the binaries rather than only the release zips).

#skip-changelog