### PR TITLE
chore(internal): update mitmproxy

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ !env['SYSTEM_PYTHON'] && '3.11' || '' }}
+          python-version: ${{ !env['SYSTEM_PYTHON'] && '3.12' || '' }}
           cache: "pip"
 
       - name: Installing Linux Dependencies

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ msgpack==1.0.8
 pytest-xdist==3.5.0
 clang-format==19.1.3
 pywin32==308; sys_platform == "win32"
-mitmproxy==11.0.0
+mitmproxy==12.1.2


### PR DESCRIPTION
Raised by dependabot: https://github.com/getsentry/sentry-native/security/dependabot/3

We only use mitmproxy for testing the Native SDK's proxy feature, so this is not shipped with the SDK itself. Still seems good to update this, as we didn't rely on the specific version.

#skip-changelog