### PR TITLE
docs: improve sentry_attachment_s struct documentation

### DIFF
--- a/src/sentry_attachment.h
+++ b/src/sentry_attachment.h
@@ -17,15 +17,27 @@ typedef enum {
 /**
  * This is a linked list of all the attachments registered via
  * `sentry_options_add_attachment`.
+ *
+ * This struct represents a union of two attachment types:
+ * - File attachments: `path` is set, `buf`/`buf_len` are NULL/0
+ * - Buffer attachments: `buf`/`buf_len` are set, `path` is NULL
+ *
+ * The `filename` field is used for both types to specify the attachment
+ * name in the envelope (defaults to basename of `path` for file attachments).
  */
 struct sentry_attachment_s {
-    sentry_path_t *path;
-    sentry_path_t *filename;
-    char *buf;
-    size_t buf_len;
+    // File attachment data (mutually exclusive with buffer data)
+    sentry_path_t *path;        // Full path to file on disk (NULL for buffer attachments)
+    
+    // Buffer attachment data (mutually exclusive with file data)  
+    char *buf;                  // In-memory buffer content (NULL for file attachments)
+    size_t buf_len;             // Buffer size in bytes (0 for file attachments)
+    
+    // Common fields for both attachment types
+    sentry_path_t *filename;    // Attachment name in envelope (can be set for both types)
     sentry_attachment_type_t type;
     char *content_type;
-    sentry_attachment_t *next;
+    sentry_attachment_t *next;  // Linked list pointer
 };
 
 /**


### PR DESCRIPTION
## Summary
- Clarifies that `sentry_attachment_s` represents a union of two attachment types (file vs buffer)
- Groups struct fields by usage and adds inline comments explaining each field
- Documents the distinction between `path` (filesystem location) and `filename` (envelope attachment name)

## Background
The current struct documentation was confusing because it wasn't clear why both `path` and `filename` fields exist, or that `buf`/`buf_len` and `path` are mutually exclusive. This change makes the union-like nature of the struct explicit.

## Test plan
- [x] Documentation-only change, no functional impact
- [x] Verified struct usage patterns in codebase match documented behavior

#skip-changelog

🤖 Generated with [Claude Code](https://claude.ai/code)