### PR TITLE
ci: specify `SDKROOT` on all macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Set macOS SDKROOT
         if: ${{ runner.os == 'macOS' }}
-        run: echo "SDKROOT=macosx" >> "$GITHUB_ENV"
+        run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
 
       - name: Remove Strawberry Perl from PATH
         if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
_CMake_ 4 defaults to an empty `CMAKE_OSX_SYSROOT`: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html

This will lead to inconsistent include order since _CMake_ auto-detects the sysroot way later in the build.

Because the _GHA_ runner image for `macos-15` with version `20250908.1827` [no longer pins to _CMake_ `3.31.6`](https://github.com/actions/runner-images/compare/macos-15/20250830.1803...macos-15/20250908.1827#diff-4fc7cdbdbaa22d0e19c5af07bf52d1931f8bf79ea99d0a424945a8820dd537a3) we have to ensure that all _macOS_ _CMake_ builds can construct a valid `CMAKE_OSX_SYSROOT` from a specified `SDKROOT` env variable. 