### PR TITLE
tests: remove flaky logger test from transport suite

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -14,7 +14,7 @@ def test_unit(cmake, unittest):
 
 @pytest.mark.skipif(not has_http, reason="tests need http transport")
 def test_unit_transport(cmake, unittest):
-    if unittest in ["custom_logger"]:
+    if unittest in ["custom_logger", "logger_enable_disable_functionality"]:
         pytest.skip("excluded from transport test-suite")
 
     cwd = cmake(["sentry_test_unit"], {"SENTRY_BACKEND": "none"})

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -11,6 +11,8 @@ typedef struct {
 // Note: All logger unit-tests must only run from the transportless unit-test
 // suite, since the transport can concurrently log while we do our
 // single-threaded test assertions here, leading to flaky test runs.
+// To blacklist a test, add to the respective list of `test_unit_transport`
+// in the `tests/test_unit.py` unit-test runner.
 
 static void
 test_logger(

--- a/tests/unit/test_logger.c
+++ b/tests/unit/test_logger.c
@@ -8,6 +8,10 @@ typedef struct {
     bool assert_now;
 } logger_test_t;
 
+// Note: All logger unit-tests must only run from the transportless unit-test
+// suite, since the transport can concurrently log while we do our
+// single-threaded test assertions here, leading to flaky test runs.
+
 static void
 test_logger(
     sentry_level_t level, const char *message, va_list args, void *_data)


### PR DESCRIPTION
Logger unit tests are always written from a single-threaded perspective. As such, they should be running inside the transport-based test suite since the transport could be concurrently logging and thus would lead to flaky test assertions.

#skip-changelog