### PR TITLE
feat: Add comprehensive semver support for SENTRY_SDK_VERSION parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 #read sentry-native version
 file(READ "include/sentry.h" _SENTRY_HEADER_CONTENT)
-string(REGEX MATCH "#define SENTRY_SDK_VERSION \"([0-9\.]+)\"" _SENTRY_VERSION_MATCH "${_SENTRY_HEADER_CONTENT}")
+string(REGEX MATCH "#define SENTRY_SDK_VERSION \"([0-9\.]+)([+\-][^\"]+)*\"" _SENTRY_VERSION_MATCH "${_SENTRY_HEADER_CONTENT}")
 set(SENTRY_VERSION "${CMAKE_MATCH_1}")
 unset(_SENTRY_HEADER_CONTENT)
 unset(_SENTRY_VERSION_MATCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,16 +9,30 @@ else()
 	cmake_policy(SET CMP0077 NEW)
 endif()
 
-#read sentry-native version
-file(READ "include/sentry.h" _SENTRY_HEADER_CONTENT)
-string(REGEX MATCH "#define SENTRY_SDK_VERSION \"([0-9\.]+)([+\-][^\"]+)*\"" _SENTRY_VERSION_MATCH "${_SENTRY_HEADER_CONTENT}")
-set(SENTRY_VERSION "${CMAKE_MATCH_1}")
-unset(_SENTRY_HEADER_CONTENT)
-unset(_SENTRY_VERSION_MATCH)
+# Extract version string from SENTRY_SDK_VERSION define in sentry.h
+file(READ "include/sentry.h" _VERSION_STR_TMP)
+# Supports full semver format including prerelease and build metadata
+string(REGEX MATCH "#define SENTRY_SDK_VERSION \"([^\"]+)\"" _VERSION_STR_TMP "${_VERSION_STR_TMP}")
+set(SENTRY_VERSION_FULL "${CMAKE_MATCH_1}")
+# Extract just the major.minor.patch part from the full version
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _VERSION_STR_TMP "${SENTRY_VERSION_FULL}")
+set(SENTRY_VERSION_MAJOR "${CMAKE_MATCH_1}")
+set(SENTRY_VERSION_MINOR "${CMAKE_MATCH_2}")
+set(SENTRY_VERSION_PATCH "${CMAKE_MATCH_3}")
+set(SENTRY_VERSION_BASE "${SENTRY_VERSION_MAJOR}.${SENTRY_VERSION_MINOR}.${SENTRY_VERSION_PATCH}")
+unset(_VERSION_STR_TMP)
+
+message(STATUS "Sentry SDK version (full): ${SENTRY_VERSION_FULL}")
+message(STATUS "Sentry SDK version (base): ${SENTRY_VERSION_BASE}")
+message(STATUS "Sentry SDK version major='${SENTRY_VERSION_MAJOR}' minor='${SENTRY_VERSION_MINOR}' patch='${SENTRY_VERSION_PATCH}'")
+
+if(NOT SENTRY_VERSION_FULL OR NOT SENTRY_VERSION_BASE OR SENTRY_VERSION_MAJOR STREQUAL "" OR SENTRY_VERSION_MINOR STREQUAL "" OR SENTRY_VERSION_PATCH STREQUAL "")
+    message(FATAL_ERROR "Parsed Sentry SDK version '${SENTRY_VERSION_FULL}' does not match expected semver format")
+endif()
 
 project(Sentry-Native
 	LANGUAGES C CXX ASM
-	VERSION ${SENTRY_VERSION}
+	VERSION ${SENTRY_VERSION_BASE}
 )
 
 set(SENTRY_MAIN_PROJECT OFF)
@@ -710,7 +724,7 @@ configure_package_config_file(sentry-config.cmake.in sentry-config.cmake
 # We would have liked to use `SameMinorVersion`, but that is only supported on
 # CMake >= 3.11.
 write_basic_package_version_file(sentry-config-version.cmake
-	VERSION ${SENTRY_VERSION}
+	VERSION ${SENTRY_VERSION_BASE}
 	COMPATIBILITY SameMajorVersion)
 
 sentry_install(TARGETS sentry EXPORT sentry

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -4,12 +4,6 @@ function(sentry_add_version_resource TGT FILE_DESCRIPTION)
 	set(RESOURCE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${TGT}.rc")
 	set(RESOURCE_PATH_TMP "${RESOURCE_PATH}.in")
 
-	# Extract major, minor and patch version from SENTRY_VERSION
-	string(REPLACE "." ";" _SENTRY_VERSION_LIST "${SENTRY_VERSION}")
-	list(GET _SENTRY_VERSION_LIST 0 SENTRY_VERSION_MAJOR)
-	list(GET _SENTRY_VERSION_LIST 1 SENTRY_VERSION_MINOR)
-	list(GET _SENTRY_VERSION_LIST 2 SENTRY_VERSION_PATCH)
-
 	# Produce the resource file with configure-time replacements
 	configure_file("${SENTRY_SOURCE_DIR}/sentry.rc.in" "${RESOURCE_PATH_TMP}" @ONLY)
 

--- a/sentry.rc.in
+++ b/sentry.rc.in
@@ -7,12 +7,12 @@ BEGIN
     BLOCK "040904E4"
     BEGIN
         VALUE "FileDescription", "@FILE_DESCRIPTION@"
-        VALUE "FileVersion", "@SENTRY_VERSION@"
+        VALUE "FileVersion", "@SENTRY_VERSION_FULL@"
         VALUE "InternalName", "sentry-native"
         VALUE "LegalCopyright", "https://sentry.io"
         VALUE "OriginalFilename", "$<TARGET_FILE_NAME:@TGT@>"
         VALUE "ProductName", "Sentry Native SDK"
-        VALUE "ProductVersion", "@SENTRY_VERSION@"
+        VALUE "ProductVersion", "@SENTRY_VERSION_FULL@"
     END
 END
 BLOCK "VarFileInfo"


### PR DESCRIPTION
## Summary

Adds comprehensive semantic versioning (semver) support to the SENTRY_SDK_VERSION parsing in CMake, enabling proper handling of prerelease identifiers and build metadata while maintaining backward compatibility.

## Changes Made

### Version Extraction Enhancements
- **Full semver support**: Now correctly parses versions like `1.2.3-alpha.1+build.123`
- **Dual version variables**: 
  - `SENTRY_VERSION_FULL`: Complete version string (e.g., `1.2.3-alpha.1+build.123`)
  - `SENTRY_VERSION_BASE`: Major.minor.patch only (e.g., `1.2.3`)
  - Individual components: `SENTRY_VERSION_MAJOR`, `SENTRY_VERSION_MINOR`, `SENTRY_VERSION_PATCH`
- **Improved logging**: Shows both full and base versions during cmake configuration
- **Robust error handling**: Fixed condition that failed when version components were `0`

### Resource File Improvements  
- **Numeric fields**: Use base version components for Windows-compatible `FILEVERSION`/`PRODUCTVERSION`
- **String fields**: Use full version for `FileVersion`/`ProductVersion` display strings
- **Template updates**: Modified `sentry.rc.in` to use `@SENTRY_VERSION_FULL@` for string fields

### CMake Integration
- **PROJECT call**: Uses `SENTRY_VERSION_BASE` for maximum compatibility
- **write_basic_package_version_file**: Uses base version for proper package manager support
- **sentry_add_version_resource()**: Simplified to focus on resource generation only

## Manual Testing

Thoroughly tested with multiple version formats by modifying `SENTRY_SDK_VERSION` in `sentry.h` and running `cmake ..`:

### Test Results
- **Simple**: `0.10.1` → Base: `0.10.1`, Full: `0.10.1`
- **Prerelease**: `1.2.3-alpha.1` → Base: `1.2.3`, Full: `1.2.3-alpha.1`  
- **Build metadata**: `1.2.3+build.123` → Base: `1.2.3`, Full: `1.2.3+build.123`
- **Full semver**: `1.2.3-beta.2+build.456` → Base: `1.2.3`, Full: `1.2.3-beta.2+build.456`
- **Edge cases**: `0.0.0`, `0.0.1-alpha` → All handled correctly

### CMake Configuration Output Examples
```
-- Sentry SDK version (full): 1.5.2-beta.3+build.789
-- Sentry SDK version (base): 1.5.2
-- Sentry SDK version major='1' minor='5' patch='2'
```

<details>
<summary>Generated sentry.rc with prerelease semver (1.5.2-beta.3+build.789)</summary>

```rc
1 VERSIONINFO
FILEVERSION    1,5,2,0
PRODUCTVERSION 1,5,2,0
BEGIN
BLOCK "StringFileInfo"
BEGIN
    BLOCK "040904E4"
    BEGIN
        VALUE "FileDescription", "Client Library"
        VALUE "FileVersion", "1.5.2-beta.3+build.789"
        VALUE "InternalName", "sentry-native"
        VALUE "LegalCopyright", "https://sentry.io"
        VALUE "OriginalFilename", "sentry.dll"
        VALUE "ProductName", "Sentry Native SDK"
        VALUE "ProductVersion", "1.5.2-beta.3+build.789"
    END
END
BLOCK "VarFileInfo"
BEGIN
    VALUE "Translation", 0x409, 1252
END
END
```

**Key Success Points:**
- Numeric version fields (FILEVERSION/PRODUCTVERSION): Use base version `1,5,2,0` for Windows compatibility
- String version fields (FileVersion/ProductVersion): Use full semver `"1.5.2-beta.3+build.789"` preserving all metadata
</details>

## Compatibility

✅ **Backward compatible**: Existing simple versions like `0.10.1` work unchanged  
✅ **Forward compatible**: Supports full semver like `1.2.3-alpha.1+build.123`  
✅ **Edge cases handled**: Including `0.0.0` and other zero-component versions  
✅ **Windows resource files**: Proper numeric and string version separation

## Benefits

- **Console SDKs** can embed custom versioning schemes
- **Windows resource files** get proper numeric and string versions
- **Package managers** work with standard base versions  
- **CMake PROJECT** uses compatible version format
- **Full semver compliance** per https://semver.org/ specification

This enables console SDKs to use versions like `0.10.1+console.20250918` while maintaining full CMake and Windows resource compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)

#skip-changelog