### PR TITLE
fix: interop with managed .NET runtimes

### DIFF
--- a/tests/fixtures/dotnet_signal/Program.cs
+++ b/tests/fixtures/dotnet_signal/Program.cs
@@ -51,13 +51,16 @@ class Program
             {
                 Console.WriteLine("dereference a NULL object from managed code");
                 var s = default(string);
-                var c = s.Length;
+                var c = s!.Length;
             }
-            catch (NullReferenceException exception)
+            catch (NullReferenceException)
             {
-                Console.WriteLine("dereference another NULL object from managed code");
-                var s = default(string);
-                var c = s.Length;
+                if (args is ["managed-exception"])
+                {
+                    Console.WriteLine("dereference another NULL object from managed code");
+                    var s = default(string);
+                    var c = s!.Length;
+                }
             }
         }
     }

--- a/tests/fixtures/dotnet_signal/test_dotnet.csproj
+++ b/tests/fixtures/dotnet_signal/test_dotnet.csproj
@@ -4,5 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <Configuration>Release</Configuration>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Detect the situation when Mono/CLR converts a signal to a managed exception and transfers execution to the managed exception handler. In this case, Sentry Native should abort crash handling because the exception was already caught and handled in managed code.

See:
- #3954