### PR TITLE
fix(logs): Fix test failures when session tracking is enabled

### DIFF
--- a/src/sentry_logs.c
+++ b/src/sentry_logs.c
@@ -733,6 +733,9 @@ sentry_log_fatal(const char *message, ...)
 void
 sentry__logs_startup(void)
 {
+    // Reset batching_stop flag in case logs system was previously shutdown
+    sentry__atomic_store(&g_logs_state.batching_stop, 0);
+
     sentry__cond_init(&g_logs_state.request_flush);
 
     sentry__thread_init(&g_logs_state.batching_thread);

--- a/tests/unit/test_logs.c
+++ b/tests/unit/test_logs.c
@@ -15,15 +15,19 @@ static void
 validate_logs_envelope(sentry_envelope_t *envelope, void *data)
 {
     uint64_t *called = data;
-    *called += 1;
 
     // Verify we have at least one envelope item
     TEST_CHECK(sentry__envelope_get_item_count(envelope) > 0);
 
-    // Get the first item and check it's a logs item
+    // Get the first item and check its type
     const sentry_envelope_item_t *item = sentry__envelope_get_item(envelope, 0);
     sentry_value_t type_header = sentry__envelope_item_get_header(item, "type");
-    TEST_CHECK_STRING_EQUAL(sentry_value_as_string(type_header), "log");
+    const char *type = sentry_value_as_string(type_header);
+
+    // Only validate and count log envelopes, skip others (e.g., session)
+    if (strcmp(type, "log") == 0) {
+        *called += 1;
+    }
 
     sentry_envelope_free(envelope);
 }
@@ -98,6 +102,8 @@ SENTRY_TEST(formatted_log_messages)
     sentry_options_set_transport(options, transport);
 
     sentry_init(options);
+    // Allow log timer_task to start
+    sleep_ms(20);
 
     // Test format specifiers
     sentry_log_info("String: %s, Integer: %d, Float: %.2f", "test", 42, 3.14);


### PR DESCRIPTION
## Summary

Fixes 3 test failures in `test_logs.c` that occur when auto-session tracking is enabled (the default configuration):
- `basic_logging_functionality`
- `formatted_log_messages`
- `logs_disabled_by_default`

These failures were discovered during console SDK testing (Nintendo Switch, PlayStation, Xbox) where session tracking is enabled by default and tests run sequentially in a single process.

## Root Causes & Fixes

### 1. Session envelope filtering in `validate_logs_envelope` callback
**Problem**: The callback was counting **all** envelopes (including session envelopes sent by `sentry_close()`), but only validating log envelopes, causing assertion failures.

**Fix**: Modified the callback to filter by envelope type - only count and validate log envelopes, skip others (like sessions).

```c
// Before: counted all envelopes unconditionally
*called += 1;
TEST_CHECK_STRING_EQUAL(sentry_value_as_string(type_header), "log");

// After: filter and count only log envelopes
const char *type = sentry_value_as_string(type_header);
if (strcmp(type, "log") == 0) {
    *called += 1;
}
```

### 2. Missing initialization delay in `formatted_log_messages` test
**Problem**: Test didn't wait for the log batching thread to start before logging messages.

**Fix**: Added `sleep_ms(20)` after `sentry_init()` to allow the batching thread to initialize, matching the pattern used in `basic_logging_functionality`.

### 3. Logs system state not reset between test runs
**Problem**: The `batching_stop` atomic flag was set to 1 during shutdown but never reset to 0 during startup, causing "preventing double shutdown" errors and preventing log flushes in subsequent test runs.

**Fix**: Added atomic store to reset `batching_stop` to 0 in `sentry__logs_startup()`:

```c
void
sentry__logs_startup(void)
{
    // Reset batching_stop flag in case logs system was previously shutdown
    sentry__atomic_store(&g_logs_state.batching_stop, 0);
    // ... rest of startup
}
```

## Test Plan

- All 217 sentry-native unit tests now pass in console SDK environments
- Verified with Nintendo Switch SDK where tests run sequentially with session tracking enabled
- No regressions expected in standard environments

## Notes

These fixes ensure the logs tests work correctly in environments where:
- Auto-session tracking is enabled (the default: `options->auto_session_tracking = true`)
- Tests run sequentially in a single process (reusing global state)
- Multiple `sentry_init()`/`sentry_close()` cycles occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)