### PR TITLE
feat: Add pkg-config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**:
 
+- Add pkg-config support ([#1411](https://github.com/getsentry/sentry-native/pull/1411))
 - Add support for outgoing W3C traceparent header propagation with the `propagate_traceparent` option. ([#1394](https://github.com/getsentry/sentry-native/pull/1394))
 
 **Fixes**:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
 endif()
 
 option(SENTRY_ENABLE_INSTALL "Enable sentry installation" "${SENTRY_MAIN_PROJECT}")
+option(SENTRY_INSTALL_PKGCONFIG "Generate and install pkg-config file" ON)
 
 if(MSVC AND CMAKE_GENERATOR_TOOLSET MATCHES "_xp$")
 	message(WARNING "Crashpad is not supported for MSVC with XP toolset. Default backend was switched to 'breakpad'")
@@ -818,4 +819,30 @@ if(SENTRY_BUILD_SHARED_LIBS)
 	target_link_libraries(sentry PRIVATE
 	    "$<$<PLATFORM_ID:Android>:-Wl,-z,max-page-size=16384>"
 	)
+endif()
+
+# Generate and install pkg-config file
+if(SENTRY_INSTALL_PKGCONFIG)
+  set(PREFIX "${CMAKE_INSTALL_PREFIX}")
+  set(PKGCONFIG_VERSION "${SENTRY_VERSION_FULL}")
+  # Use absolute paths for libdir and includedir to support non-standard layouts (e.g., lib64)
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PKGCONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+  else()
+    set(PKGCONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PKGCONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  else()
+    set(PKGCONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/sentry.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/sentry.pc"
+    @ONLY
+  )
+  sentry_install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/sentry.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )
 endif()

--- a/sentry.pc.in
+++ b/sentry.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=@PKGCONFIG_LIBDIR@
+includedir=@PKGCONFIG_INCLUDEDIR@
+
+Name: sentry
+Description: Sentry SDK for C, C++ and native applications
+Version: @PKGCONFIG_VERSION@
+URL: https://sentry.io/
+Libs: -L${libdir} -lsentry
+Cflags: -I${includedir}


### PR DESCRIPTION
## Summary
- Added support for generating and installing a `.pc` file for pkg-config
- Controlled by the `SENTRY_INSTALL_PKGCONFIG` CMake option
- Uses the existing `sentry.pc.in` template to generate the pkg-config file
- Installs the generated file to the standard pkg-config directory (`${CMAKE_INSTALL_LIBDIR}/pkgconfig`)

## Benefits
This allows downstream projects to easily discover and link against sentry-native using pkg-config:

```bash
pkg-config --cflags --libs sentry
```

## Test plan
- [x] Build with `SENTRY_INSTALL_PKGCONFIG` enabled
- [x] Verify `sentry.pc` file is generated in build directory
- [x] Verify `sentry.pc` file is installed to correct location
- [x] Test that pkg-config can find and use the installed file
