### PR TITLE
chore: fix bump-version.sh matching spaces in sentry.h

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,7 +14,7 @@ NEW_VERSION="$2"
 
 echo "Bumping version: ${NEW_VERSION}"
 
-perl -pi -e "s/^#    define SENTRY_SDK_VERSION.*/#    define SENTRY_SDK_VERSION \"${NEW_VERSION}\"/" include/sentry.h
+perl -pi -e "s/^(#\s*)define SENTRY_SDK_VERSION.*/\$1define SENTRY_SDK_VERSION \"${NEW_VERSION}\"/" include/sentry.h
 perl -pi -e "s/\"version\": \"[^\"]+\"/\"version\": \"${NEW_VERSION}\"/" tests/assertions.py
 perl -pi -e "s/sentry.native\/[^\"]+\"/sentry.native\/${NEW_VERSION}\"/" tests/test_integration_http.py
 perl -pi -e "s/^versionName\=.*/versionName\=${NEW_VERSION}/" ndk/gradle.properties


### PR DESCRIPTION
Fixing the release workflow as became apparent in https://github.com/getsentry/publish/issues/6522#issuecomment-3456923230

Spaces were introduced in https://github.com/getsentry/sentry-native/pull/1417/files#diff-9c77242571e813d699b88663fdc7d7ad7bb5b481a3c1af8d34e1a9e242cbf076R82

#skip-changelog