### PR TITLE
chore: make `SENTRY_VERSION` global for pytest to simplify bump-version script

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -15,7 +15,5 @@ NEW_VERSION="$2"
 echo "Bumping version: ${NEW_VERSION}"
 
 perl -pi -e "s/^(#\s*)define SENTRY_SDK_VERSION.*/\$1define SENTRY_SDK_VERSION \"${NEW_VERSION}\"/" include/sentry.h
-perl -pi -e "s/\"version\": \"[^\"]+\"/\"version\": \"${NEW_VERSION}\"/" tests/assertions.py
-perl -pi -e "s/sentry.native\/[^\"]+\"/sentry.native\/${NEW_VERSION}\"/" tests/test_integration_http.py
 perl -pi -e "s/^versionName\=.*/versionName\=${NEW_VERSION}/" ndk/gradle.properties
-perl -pi -e "s/^sentry_version \=.*/sentry_version \= \"${NEW_VERSION}\"/" tests/win_utils.py
+perl -pi -e "s/^SENTRY_VERSION \=.*/SENTRY_VERSION \= \"${NEW_VERSION}\"/" tests/__init__.py

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,8 @@ sourcedir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 # https://docs.pytest.org/en/latest/assert.html#assert-details
 pytest.register_assert_rewrite("tests.assertions")
-from tests.assertions import assert_no_proxy_request
+
+SENTRY_VERSION = "0.11.3"
 
 
 def make_dsn(httpserver, auth="uiaeosnrtdy", id=123456, proxy_host=False):

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import msgpack
 
+from . import SENTRY_VERSION
 from .conditions import is_android
 
 VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)[-.]?(.*)")
@@ -107,9 +108,9 @@ def assert_event_meta(
     }
     expected_sdk = {
         "name": "sentry.native",
-        "version": "0.11.3",
+        "version": SENTRY_VERSION,
         "packages": [
-            {"name": "github:getsentry/sentry-native", "version": "0.11.3"},
+            {"name": "github:getsentry/sentry-native", "version": SENTRY_VERSION},
         ],
     }
     if is_android:

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from tests import assert_no_proxy_request
+from tests.assertions import assert_no_proxy_request
 
 
 def setup_proxy_env_vars(port):

--- a/tests/test_embedded_info.py
+++ b/tests/test_embedded_info.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import pytest
-from . import run
+from . import run, SENTRY_VERSION
 from .conditions import has_http
 
 
@@ -155,7 +155,7 @@ def test_sdk_version_override(cmake):
             "SENTRY_EMBED_INFO": "ON",
             "SENTRY_BUILD_PLATFORM": "version-test",
             "SENTRY_BUILD_VARIANT": "override",
-            "SENTRY_SDK_VERSION": "0.11.3+20251016-test-build",
+            "SENTRY_SDK_VERSION": f"{SENTRY_VERSION}+20251016-test-build",
         },
     )
 
@@ -180,7 +180,7 @@ def test_sdk_version_override(cmake):
 
         # Verify that version and build ID are correctly separated
         assert (
-            "SENTRY_VERSION:0.11.3;" in output
+            f"SENTRY_VERSION:{SENTRY_VERSION};" in output
         ), "Version should be base version without build metadata"
         assert (
             "BUILD:20251016-test-build;" in output
@@ -201,7 +201,7 @@ def test_sdk_version_override_with_explicit_build_id(cmake):
             "SENTRY_EMBED_INFO": "ON",
             "SENTRY_BUILD_PLATFORM": "version-test",
             "SENTRY_BUILD_VARIANT": "explicit-build",
-            "SENTRY_SDK_VERSION": "0.11.3+20251016-ignored",
+            "SENTRY_SDK_VERSION": f"{SENTRY_VERSION}+20251016-ignored",
             "SENTRY_BUILD_ID": "explicit-build-id",
         },
     )
@@ -226,7 +226,9 @@ def test_sdk_version_override_with_explicit_build_id(cmake):
         output = result.stdout
 
         # Verify that explicit build ID takes precedence
-        assert "SENTRY_VERSION:0.11.3;" in output, "Version should be base version"
+        assert (
+            f"SENTRY_VERSION:{SENTRY_VERSION};" in output
+        ), "Version should be base version"
         assert (
             "BUILD:explicit-build-id;" in output
         ), "Explicit build ID should take precedence"

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -16,6 +16,7 @@ from . import (
     split_log_request_cond,
     is_feedback_envelope,
     is_logs_envelope,
+    SENTRY_VERSION,
 )
 from .proxy import (
     setup_proxy_env_vars,
@@ -48,7 +49,7 @@ pytestmark = pytest.mark.skipif(not has_http, reason="tests need http")
 
 # fmt: off
 auth_header = (
-    "Sentry sentry_key=uiaeosnrtdy, sentry_version=7, sentry_client=sentry.native/0.11.3"
+    f"Sentry sentry_key=uiaeosnrtdy, sentry_version=7, sentry_client=sentry.native/{SENTRY_VERSION}"
 )
 # fmt: on
 

--- a/tests/win_utils.py
+++ b/tests/win_utils.py
@@ -1,7 +1,7 @@
 import pathlib
 import win32api
 
-sentry_version = "0.11.3"
+from tests import SENTRY_VERSION
 
 
 def check_binary_version(binary_path: pathlib.Path):
@@ -13,7 +13,7 @@ def check_binary_version(binary_path: pathlib.Path):
     ls = info["FileVersionLS"]
     file_version = (ms >> 16, ms & 0xFFFF, ls >> 16, ls & 0xFFFF)
     file_version = f"{file_version[0]}.{file_version[1]}.{file_version[2]}"
-    if sentry_version != file_version:
+    if SENTRY_VERSION != file_version:
         raise RuntimeError(
-            f"Binary {binary_path.parts[-1]} has a different version ({file_version}) than expected ({sentry_version})."
+            f"Binary {binary_path.parts[-1]} has a different version ({file_version}) than expected ({SENTRY_VERSION})."
         )


### PR DESCRIPTION
#skip-changelog