### PR TITLE
test: add SENTRY_TEST_PATH_PREFIX to crash_marker test database path

### DIFF
--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -155,7 +155,8 @@ SENTRY_TEST(discarding_before_send)
 SENTRY_TEST(crash_marker)
 {
     // We don't use sentry_init() in this test so we must create a database dir
-    sentry_path_t *database_path = sentry__path_from_str(".sentry-native");
+    sentry_path_t *database_path
+        = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".sentry-native");
     TEST_ASSERT(!!database_path);
     TEST_ASSERT(!sentry__path_create_dir_all(database_path));
 


### PR DESCRIPTION
## Summary

Fixes the crash_marker test to properly use `SENTRY_TEST_PATH_PREFIX` when creating the database directory, ensuring consistency with other tests in the suite. This PR fixes a regression introduced by #1404 

## Changes

- Updated database path creation in `crash_marker` test to include `SENTRY_TEST_PATH_PREFIX` prefix in tests/unit/test_basic.c:158-159

## Background

The crash_marker test was creating a database directory without using the test path prefix that other tests use. This could cause the test to write to an unexpected location on some platforms or testing environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)