### PR TITLE
test: skip basic_transport_thread_name test on NX platform

### DIFF
--- a/tests/unit/test_basic.c
+++ b/tests/unit/test_basic.c
@@ -305,6 +305,11 @@ SENTRY_TEST(capture_minidump_invalid_path)
 
 SENTRY_TEST(basic_transport_thread_name)
 {
+#if defined(SENTRY_PLATFORM_NX)
+    // NX transport won't start without custom network_connect_func.
+    SKIP_TEST();
+#endif
+
     const char *expected_thread_name = "sentry::worker_thread";
 
     SENTRY_TEST_OPTIONS_NEW(options);


### PR DESCRIPTION
## Summary

Skips the `basic_transport_thread_name` test on NX (Nintendo Switch) platform to prevent false test failures.

## Changes

- Added `SENTRY_PLATFORM_NX` check to skip the test in tests/unit/test_basic.c:309-311

## Background

The `basic_transport_thread_name` test cannot run on NX because the transport won't start without a custom `network_connect_func`. Rather than failing the test, we now skip it on this platform where it's not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)