### PR TITLE
chore: update Alpine Linux dockerfile to install dotnet 10.0

### DIFF
--- a/.github/docker/alpine/Dockerfile
+++ b/.github/docker/alpine/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add \
     tree \
     wget
 
-RUN curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh | bash -eo pipefail /dev/stdin --channel 8.0 --install-dir /usr/share/dotnet
+RUN curl -sSL --retry 5 https://dot.net/v1/dotnet-install.sh | bash -eo pipefail /dev/stdin --channel 10.0 --install-dir /usr/share/dotnet
 RUN ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
 
 # https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-python.sh


### PR DESCRIPTION
Splitting up https://github.com/getsentry/sentry-native/pull/1457 into two separate PRs (we can keep that one for the CI update + [/test_dotnet.csproj](https://github.com/getsentry/sentry-native/pull/1457/files#diff-8067ddd5a8eeff6af733f5bc8c9e6af9d89b807b0d55939b31e13814a507971a) updates), so we can just update our Alpine docker image with this one.

#skip-changelog