### PR TITLE
fix(logs): move logs flush after `on_crash` call

### DIFF
--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -126,11 +126,6 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
         event, "level", sentry__value_new_level(SENTRY_LEVEL_FATAL));
 
     SENTRY_WITH_OPTIONS (options) {
-        // Flush logs in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
-
         sentry__write_crash_marker(options);
 
         bool should_handle = true;
@@ -155,6 +150,11 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
             sentry_value_t result
                 = options->on_crash_func(uctx, event, options->on_crash_data);
             should_handle = !sentry_value_is_null(result);
+        }
+
+        // Flush logs in a crash-safe manner before crash handling
+        if (options->enable_logs) {
+            sentry__logs_flush_crash_safe();
         }
 
         if (should_handle) {

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -331,10 +331,6 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
     bool should_dump = true;
 
     SENTRY_WITH_OPTIONS (options) {
-        // Flush logs in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
         auto state = static_cast<crashpad_state_t *>(options->backend->data);
         sentry_value_t crash_event
             = sentry__value_new_event_with_id(&state->crash_event_id);
@@ -359,6 +355,12 @@ sentry__crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
             crash_event = options->before_send_func(
                 crash_event, nullptr, options->before_send_data);
         }
+
+        // Flush logs in a crash-safe manner before crash handling
+        if (options->enable_logs) {
+            sentry__logs_flush_crash_safe();
+        }
+
         should_dump = !sentry_value_is_null(crash_event);
 
         if (should_dump) {

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -649,10 +649,6 @@ handle_ucontext(const sentry_ucontext_t *uctx)
         // use a signal-safe allocator before we tear down.
         sentry__page_allocator_enable();
 #endif
-        // Flush logs in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
 
         sentry_value_t event = make_signal_event(sig_slot, uctx, strategy);
         bool should_handle = true;
@@ -662,6 +658,11 @@ handle_ucontext(const sentry_ucontext_t *uctx)
             SENTRY_DEBUG("invoking `on_crash` hook");
             event = options->on_crash_func(uctx, event, options->on_crash_data);
             should_handle = !sentry_value_is_null(event);
+        }
+
+        // Flush logs in a crash-safe manner before crash handling
+        if (options->enable_logs) {
+            sentry__logs_flush_crash_safe();
         }
 
         if (should_handle) {


### PR DESCRIPTION
Fixes #1473 

#skip-changelog