### PR TITLE
test: ASAN_OPTIONS=detect_odr_violation=2

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -140,7 +140,9 @@ def run(cwd, exe, args, expect_failure=False, env=None, **kwargs):
         "./{}".format(exe) if sys.platform != "win32" else "{}\\{}.exe".format(cwd, exe)
     ]
     if "asan" in os.environ.get("RUN_ANALYZER", ""):
-        env["ASAN_OPTIONS"] = "detect_leaks=1:detect_invalid_join=0"
+        env["ASAN_OPTIONS"] = (
+            "detect_leaks=1:detect_invalid_join=0:detect_odr_violation=2"
+        )
         env["LSAN_OPTIONS"] = "suppressions={}".format(
             os.path.join(sourcedir, "tests", "leaks.txt")
         )


### PR DESCRIPTION
A quick test to see if any of the CI ASAN builds can detect ODR violation for mpack.