### PR TITLE
fix: update array attribute types to general 'array' string

### DIFF
--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -511,9 +511,9 @@ sentry_value_new_user(const char *id, const char *username, const char *email,
 
 /**
  * Converts a sentry_value_t attribute to its type string representation.
- * For lists, checks the first element to determine the array type.
+ * For lists, checks the first element to determine if it is a scalar array.
  * Returns NULL for unsupported types (NULL, OBJECT).
- * https://develop.sentry.dev/sdk/telemetry/spans/span-protocol/#attribute-object-properties
+ * https://develop.sentry.dev/sdk/telemetry/attributes/
  */
 static const char *
 attribute_value_type_to_str(sentry_value_t value)
@@ -537,15 +537,12 @@ attribute_value_type_to_str(sentry_value_t value)
         // Determine type based on first element
         switch (sentry_value_get_type(first_item)) {
         case SENTRY_VALUE_TYPE_BOOL:
-            return "boolean[]";
         case SENTRY_VALUE_TYPE_INT32:
         case SENTRY_VALUE_TYPE_INT64:
-        case SENTRY_VALUE_TYPE_UINT64:
-            return "integer[]";
         case SENTRY_VALUE_TYPE_DOUBLE:
-            return "double[]";
         case SENTRY_VALUE_TYPE_STRING:
-            return "string[]";
+            return "array";
+        case SENTRY_VALUE_TYPE_UINT64: // TODO update when we support this
         case SENTRY_VALUE_TYPE_NULL:
         case SENTRY_VALUE_TYPE_OBJECT:
         case SENTRY_VALUE_TYPE_LIST:

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -547,7 +547,7 @@ SENTRY_TEST(value_attribute)
         sentry_value_get_type(string_list_attr) == SENTRY_VALUE_TYPE_OBJECT);
     TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
                                 string_list_attr, "type")),
-        "string[]");
+        "array");
     sentry_value_t string_list_value
         = sentry_value_get_by_key(string_list_attr, "value");
     TEST_CHECK(
@@ -565,7 +565,7 @@ SENTRY_TEST(value_attribute)
         sentry_value_get_type(integer_list_attr) == SENTRY_VALUE_TYPE_OBJECT);
     TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
                                 integer_list_attr, "type")),
-        "integer[]");
+        "array");
     sentry_value_decref(integer_list_attr);
 
     sentry_value_t double_list = sentry_value_new_list();
@@ -577,7 +577,7 @@ SENTRY_TEST(value_attribute)
         sentry_value_get_type(double_list_attr) == SENTRY_VALUE_TYPE_OBJECT);
     TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
                                 double_list_attr, "type")),
-        "double[]");
+        "array");
     sentry_value_decref(double_list_attr);
 
     sentry_value_t boolean_list = sentry_value_new_list();
@@ -589,7 +589,7 @@ SENTRY_TEST(value_attribute)
         sentry_value_get_type(boolean_list_attr) == SENTRY_VALUE_TYPE_OBJECT);
     TEST_CHECK_STRING_EQUAL(sentry_value_as_string(sentry_value_get_by_key(
                                 boolean_list_attr, "type")),
-        "boolean[]");
+        "array");
     sentry_value_decref(boolean_list_attr);
 
     // Test empty list (should return null since first element is null)


### PR DESCRIPTION
Based on the Relay changes in https://github.com/getsentry/relay/pull/5394 , we don't need to parse & forward the exact type (this gets checked during processing). 

These `array` type attributes cannot be visualized yet, but they are parsed & stored.

#skip-changelog