### PR TITLE
feat: add `ounce` support

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -83,9 +83,7 @@ extern "C" {
 /* IBM i PASE is also counted as AIX */
 #    define SENTRY_PLATFORM_AIX
 #    define SENTRY_PLATFORM_UNIX
-#elif defined(__NX__)
-#    define SENTRY_PLATFORM_NX
-#elif defined(__OUNCE__)
+#elif defined(__NINTENDO__)
 #    define SENTRY_PLATFORM_NX
 #else
 #    error unsupported platform


### PR DESCRIPTION
Renaming the deprecated `__NX__` to `__NINTENDO__` for Ounce support.

Related to https://github.com/getsentry/sentry-switch/pull/83

#skip-changelog