### PR TITLE
chore: ignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ obj/
 .cache
 
 sentry-native.sln
+
+# Local Claude Code settings that should not be committed
+.claude/settings.local.json


### PR DESCRIPTION
Ignore .claude/settings.local.json as these are local settings not intended for version control.

#skip-changelog