### PR TITLE
chore: fix failing `array` type attribute test

### DIFF
--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -1798,4 +1798,4 @@ def test_logs_global_and_local_attributes_merge(cmake, httpserver):
 
     assert "global.attribute.array" in attributes_0
     assert attributes_0["global.attribute.array"]["value"] == ["item1", "item2"]
-    assert attributes_0["global.attribute.array"]["type"] == "string[]"
+    assert attributes_0["global.attribute.array"]["type"] == "array"


### PR DESCRIPTION
- global/local attribute test was not updated to `array` type yet

Follow-up of combining https://github.com/getsentry/sentry-native/pull/1479 and https://github.com/getsentry/sentry-native/pull/1486

#skip-changelog