### PR TITLE
test: rerun flaky `test_shutdown_timeout`

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 black==24.3.0
 pytest==8.1.1
 pytest-httpserver==1.0.10
-pytest-rerunfailures==16.1
+flaky==3.8.1
 msgpack==1.0.8
 pytest-xdist==3.5.0
 clang-format==20.1.5

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -8,6 +8,7 @@ import uuid
 import subprocess
 
 import pytest
+from flaky import flaky
 
 from . import (
     make_dsn,
@@ -555,7 +556,7 @@ def test_breakpad_dump_inflight(cmake, httpserver):
     assert len(httpserver.log) >= 11
 
 
-@pytest.mark.flaky(reruns=3)
+@flaky(max_runs=3)
 def test_shutdown_timeout(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
 


### PR DESCRIPTION
How about automatically re-running the flaky `test_shutdown_timeout` test to mitigate frequent CI failures?

https://github.com/getsentry/sentry-native/blob/c5367b47f4ed1b7be3a6e711d9dcafac14e2edb6/tests/test_integration_http.py#L561-L567