### PR TITLE
ref(logs): extract reusable batcher for metrics

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,8 @@ sentry_target_sources_cwd(sentry
 	sentry_attachment.h
 	sentry_backend.c
 	sentry_backend.h
+	sentry_batcher.c
+	sentry_batcher.h
 	sentry_boot.h
 	sentry_core.c
 	sentry_core.h

--- a/src/sentry_batcher.c
+++ b/src/sentry_batcher.c
@@ -1,0 +1,395 @@
+#include "sentry_batcher.h"
+#include "sentry_core.h"
+#include "sentry_cpu_relax.h"
+#include "sentry_options.h"
+
+#ifdef SENTRY_UNITTEST
+#    ifdef SENTRY_PLATFORM_WINDOWS
+#        include <windows.h>
+#        define sleep_ms(MILLISECONDS) Sleep(MILLISECONDS)
+#    else
+#        include <unistd.h>
+#        define sleep_ms(MILLISECONDS) usleep(MILLISECONDS * 1000)
+#    endif
+#endif
+
+// Use a sleep spinner around a monotonic timer so we don't syscall sleep from
+// a signal handler. While this is strictly needed only there, there is no
+// reason not to use the same implementation across platforms.
+static void
+crash_safe_sleep_ms(uint64_t delay_ms)
+{
+    const uint64_t start = sentry__monotonic_time();
+    const uint64_t end = start + delay_ms;
+    while (sentry__monotonic_time() < end) {
+        for (int i = 0; i < 64; i++) {
+            sentry__cpu_relax();
+        }
+    }
+}
+
+// checks whether the currently active buffer should be flushed.
+// otherwise we could miss the trigger of adding the last log if we're actively
+// flushing the other buffer already.
+// we can safely check the state of the active buffer, as the only thread that
+// can change which buffer is active is the one calling this check function
+// inside sentry__batcher_flush() below
+static bool
+check_for_flush_condition(sentry_batcher_t *batcher)
+{
+    // In sentry__batcher_flush, after finishing a flush:
+    long current_active = sentry__atomic_fetch(&batcher->active_idx);
+    sentry_batcher_buffer_t *current_buf = &batcher->buffers[current_active];
+
+    // Check if current active buffer is also full
+    // We could even lower the threshold for high-contention scenarios
+    return sentry__atomic_fetch(&current_buf->index)
+        >= SENTRY_BATCHER_QUEUE_LENGTH;
+}
+
+void
+sentry__batcher_flush(sentry_batcher_t *batcher, bool crash_safe)
+{
+    if (crash_safe) {
+        // In crash-safe mode, spin lock with timeout and backoff
+        int attempts = 0;
+        while (!sentry__atomic_compare_swap(&batcher->flushing, 0, 1)) {
+            const int max_attempts = 200;
+            if (++attempts > max_attempts) {
+                SENTRY_WARN(
+                    "sentry__batcher_flush: timeout waiting for flushing "
+                    "lock in crash-safe mode");
+                return;
+            }
+
+            // backoff max-wait with max_attempts = 200 based sleep slots:
+            // 9ms + 450ms + 1010ms = 1500ish ms
+            const uint32_t sleep_time = (attempts < 10) ? 1
+                : (attempts < 100)                      ? 5
+                                                        : 10;
+            crash_safe_sleep_ms(sleep_time);
+        }
+    } else {
+        // Normal mode: try once and return if already flushing
+        const long already_flushing
+            = sentry__atomic_store(&batcher->flushing, 1);
+        if (already_flushing) {
+            return;
+        }
+    }
+    do {
+        // prep both buffers
+        long old_buf_idx = sentry__atomic_fetch(&batcher->active_idx);
+        long new_buf_idx = 1 - old_buf_idx;
+        sentry_batcher_buffer_t *old_buf = &batcher->buffers[old_buf_idx];
+        sentry_batcher_buffer_t *new_buf = &batcher->buffers[new_buf_idx];
+
+        // reset new buffer...
+        sentry__atomic_store(&new_buf->index, 0);
+        sentry__atomic_store(&new_buf->adding, 0);
+        sentry__atomic_store(&new_buf->sealed, 0);
+
+        // ...and make it active (after this we're good to go producer side)
+        sentry__atomic_store(&batcher->active_idx, new_buf_idx);
+
+        // seal old buffer
+        sentry__atomic_store(&old_buf->sealed, 1);
+
+        // Wait for all in-flight producers of the old buffer
+        while (sentry__atomic_fetch(&old_buf->adding) > 0) {
+            sentry__cpu_relax();
+        }
+
+        long n = sentry__atomic_store(&old_buf->index, 0);
+        if (n > SENTRY_BATCHER_QUEUE_LENGTH) {
+            n = SENTRY_BATCHER_QUEUE_LENGTH;
+        }
+
+        if (n > 0) {
+            // now we can do the actual batching of the old buffer
+
+            sentry_value_t logs = sentry_value_new_object();
+            sentry_value_t log_items = sentry_value_new_list();
+            int i;
+            for (i = 0; i < n; i++) {
+                sentry_value_append(log_items, old_buf->items[i]);
+            }
+            sentry_value_set_by_key(logs, "items", log_items);
+
+            sentry_envelope_t *envelope = sentry__envelope_new();
+            batcher->batch_func(envelope, logs);
+
+            SENTRY_WITH_OPTIONS (options) {
+                if (crash_safe) {
+                    // Write directly to disk to avoid transport queuing during
+                    // crash
+                    sentry__run_write_envelope(options->run, envelope);
+                    sentry_envelope_free(envelope);
+                } else {
+                    // Normal operation: use transport for HTTP transmission
+                    sentry__capture_envelope(options->transport, envelope);
+                }
+            }
+            sentry_value_decref(logs);
+        }
+    } while (check_for_flush_condition(batcher));
+
+    sentry__atomic_store(&batcher->flushing, 0);
+}
+
+#define ENQUEUE_MAX_RETRIES 2
+
+bool
+sentry__batcher_enqueue(sentry_batcher_t *batcher, sentry_value_t item)
+{
+    for (int attempt = 0; attempt <= ENQUEUE_MAX_RETRIES; attempt++) {
+        // retrieve the active buffer
+        const long active_idx = sentry__atomic_fetch(&batcher->active_idx);
+        sentry_batcher_buffer_t *active = &batcher->buffers[active_idx];
+
+        // if the buffer is already sealed we retry or drop and exit early.
+        if (sentry__atomic_fetch(&active->sealed) != 0) {
+            if (attempt == ENQUEUE_MAX_RETRIES) {
+                return false;
+            }
+            continue;
+        }
+
+        // `adding` is our boundary for this buffer since it keeps the flusher
+        // blocked. We have to recheck that the flusher hasn't already switched
+        // the active buffer or sealed the one this thread is on. If either is
+        // true we have to unblock the flusher and retry or drop the item.
+        sentry__atomic_fetch_and_add(&active->adding, 1);
+        const long active_idx_check
+            = sentry__atomic_fetch(&batcher->active_idx);
+        const long sealed_check = sentry__atomic_fetch(&active->sealed);
+        if (active_idx != active_idx_check) {
+            sentry__atomic_fetch_and_add(&active->adding, -1);
+            if (attempt == ENQUEUE_MAX_RETRIES) {
+                return false;
+            }
+            continue;
+        }
+        if (sealed_check) {
+            sentry__atomic_fetch_and_add(&active->adding, -1);
+            if (attempt == ENQUEUE_MAX_RETRIES) {
+                return false;
+            }
+            continue;
+        }
+
+        // Now we can finally request a slot and check if the item fits in this
+        // buffer.
+        const long item_idx = sentry__atomic_fetch_and_add(&active->index, 1);
+        if (item_idx < SENTRY_BATCHER_QUEUE_LENGTH) {
+            // got a slot, write item to the buffer and unblock flusher
+            active->items[item_idx] = item;
+            sentry__atomic_fetch_and_add(&active->adding, -1);
+
+            // Check if active buffer is now full and trigger flush. We could
+            // introduce additional watermarks here to trigger the flush earlier
+            // under high contention.
+            // TODO replace with a level-triggered flag
+            if (item_idx == SENTRY_BATCHER_QUEUE_LENGTH - 1) {
+                sentry__cond_wake(&batcher->request_flush);
+            }
+            return true;
+        }
+        // ping the batching thread to flush, since we could miss a cond_wake
+        // on adding the last item
+        sentry__cond_wake(&batcher->request_flush);
+        // Buffer is already full, roll back our increments and retry or drop.
+        sentry__atomic_fetch_and_add(&active->adding, -1);
+        if (attempt == ENQUEUE_MAX_RETRIES) {
+            // TODO report this (e.g. client reports)
+            return false;
+        }
+    }
+    return false;
+}
+
+SENTRY_THREAD_FN
+batcher_thread_func(void *data)
+{
+    sentry_batcher_t *batcher = data;
+    SENTRY_DEBUG("Starting batching thread");
+    sentry_mutex_t task_lock;
+    sentry__mutex_init(&task_lock);
+    sentry__mutex_lock(&task_lock);
+
+    // Transition from STARTING to RUNNING using compare-and-swap
+    // CAS ensures atomic state verification: only succeeds if state is STARTING
+    // If CAS fails, shutdown already set state to STOPPED, so exit immediately
+    // Uses sequential consistency to ensure all thread initialization is
+    // visible
+    if (!sentry__atomic_compare_swap(&batcher->thread_state,
+            (long)SENTRY_BATCHER_THREAD_STARTING,
+            (long)SENTRY_BATCHER_THREAD_RUNNING)) {
+        SENTRY_DEBUG(
+            "batcher thread detected shutdown during startup, exiting");
+        sentry__mutex_unlock(&task_lock);
+        sentry__mutex_free(&task_lock);
+        return 0;
+    }
+
+    // Main loop: run while state is RUNNING
+    while (sentry__atomic_fetch(&batcher->thread_state)
+        == SENTRY_BATCHER_THREAD_RUNNING) {
+        // Sleep for 5 seconds or until request_flush hits
+        const int triggered_by = sentry__cond_wait_timeout(
+            &batcher->request_flush, &task_lock, 5000);
+
+        // Check if we should still be running
+        if (sentry__atomic_fetch(&batcher->thread_state)
+            != SENTRY_BATCHER_THREAD_RUNNING) {
+            break;
+        }
+
+        switch (triggered_by) {
+        case 0:
+#ifdef SENTRY_PLATFORM_WINDOWS
+            if (GetLastError() == ERROR_TIMEOUT) {
+                SENTRY_TRACE("Batcher flushed by timeout");
+                break;
+            }
+#endif
+            SENTRY_TRACE("Batcher flushed by filled buffer");
+            break;
+#ifdef SENTRY_PLATFORM_UNIX
+        case ETIMEDOUT:
+            SENTRY_TRACE("Batcher flushed by timeout");
+            break;
+#endif
+#ifdef SENTRY_PLATFORM_WINDOWS
+        case 1:
+            SENTRY_TRACE("Batcher flushed by filled buffer");
+            break;
+#endif
+        default:
+            SENTRY_WARN("Batcher flush trigger returned unexpected value");
+            continue;
+        }
+
+        // Try to flush
+        sentry__batcher_flush(batcher, false);
+    }
+
+    sentry__mutex_unlock(&task_lock);
+    sentry__mutex_free(&task_lock);
+    SENTRY_DEBUG("batching thread exiting");
+    return 0;
+}
+
+void
+sentry__batcher_startup(
+    sentry_batcher_t *batcher, sentry_batch_func_t batch_func)
+{
+    batcher->batch_func = batch_func;
+
+    // Mark thread as starting before actually spawning so thread can transition
+    // to RUNNING. This prevents shutdown from thinking the thread was never
+    // started if it races with the thread's initialization.
+    sentry__atomic_store(
+        &batcher->thread_state, (long)SENTRY_BATCHER_THREAD_STARTING);
+
+    sentry__cond_init(&batcher->request_flush);
+
+    sentry__thread_init(&batcher->batching_thread);
+    int spawn_result = sentry__thread_spawn(
+        &batcher->batching_thread, batcher_thread_func, batcher);
+
+    if (spawn_result == 1) {
+        SENTRY_ERROR("Failed to start batching thread");
+        // Failed to spawn, reset to STOPPED
+        // Note: condition variable doesn't need explicit cleanup for static
+        // storage (pthread_cond_t on POSIX and CONDITION_VARIABLE on Windows)
+        sentry__atomic_store(
+            &batcher->thread_state, (long)SENTRY_BATCHER_THREAD_STOPPED);
+    }
+}
+
+void
+sentry__batcher_shutdown(sentry_batcher_t *batcher, uint64_t timeout)
+{
+    (void)timeout;
+
+    // Atomically transition to STOPPED and get the previous state
+    // This handles the race where thread might be in STARTING state:
+    // - If thread's CAS hasn't run yet: CAS will fail, thread exits cleanly
+    // - If thread already transitioned to RUNNING: normal shutdown path
+    const long old_state = sentry__atomic_store(
+        &batcher->thread_state, (long)SENTRY_BATCHER_THREAD_STOPPED);
+
+    // If thread was never started, nothing to do
+    if (old_state == SENTRY_BATCHER_THREAD_STOPPED) {
+        SENTRY_DEBUG("batcher thread was not started, skipping shutdown");
+        return;
+    }
+
+    // Thread was started (either STARTING or RUNNING), signal it to stop
+    sentry__cond_wake(&batcher->request_flush);
+
+    // Always join the thread to avoid leaks
+    sentry__thread_join(batcher->batching_thread);
+
+    // Perform final flush to ensure any remaining items are sent
+    sentry__batcher_flush(batcher, false);
+
+    sentry__thread_free(&batcher->batching_thread);
+}
+
+void
+sentry__batcher_flush_crash_safe(sentry_batcher_t *batcher)
+{
+    // Check if batcher is initialized
+    const long state = sentry__atomic_fetch(&batcher->thread_state);
+    if (state == SENTRY_BATCHER_THREAD_STOPPED) {
+        return;
+    }
+
+    // Signal the thread to stop but don't wait, since the crash-safe flush
+    // will spin-lock on flushing anyway.
+    sentry__atomic_store(
+        &batcher->thread_state, (long)SENTRY_BATCHER_THREAD_STOPPED);
+
+    // Perform crash-safe flush directly to disk to avoid transport queuing
+    // This is safe because we're in a crash scenario and the main thread
+    // is likely dead or dying anyway
+    sentry__batcher_flush(batcher, true);
+}
+
+void
+sentry__batcher_force_flush(sentry_batcher_t *batcher)
+{
+    while (sentry__atomic_fetch(&batcher->flushing)) {
+        sentry__cpu_relax();
+    }
+    sentry__batcher_flush(batcher, false);
+}
+
+#ifdef SENTRY_UNITTEST
+/**
+ * Wait for the batching thread to be ready.
+ * This is a test-only helper to avoid race conditions in tests.
+ */
+void
+sentry__batcher_wait_for_thread_startup(sentry_batcher_t *batcher)
+{
+    const int max_wait_ms = 1000;
+    const int check_interval_ms = 10;
+    const int max_attempts = max_wait_ms / check_interval_ms;
+
+    for (int i = 0; i < max_attempts; i++) {
+        const long state = sentry__atomic_fetch(&batcher->thread_state);
+        if (state == SENTRY_BATCHER_THREAD_RUNNING) {
+            SENTRY_DEBUGF(
+                "batcher thread ready after %d ms", i * check_interval_ms);
+            return;
+        }
+        sleep_ms(check_interval_ms);
+    }
+
+    SENTRY_WARNF(
+        "batcher thread failed to start within %d ms timeout", max_wait_ms);
+}
+#endif

--- a/src/sentry_batcher.h
+++ b/src/sentry_batcher.h
@@ -1,0 +1,58 @@
+#ifndef SENTRY_BATCHER_H_INCLUDED
+#define SENTRY_BATCHER_H_INCLUDED
+
+#include "sentry_boot.h"
+#include "sentry_envelope.h"
+#include "sentry_sync.h"
+
+#ifdef SENTRY_UNITTEST
+#    define SENTRY_BATCHER_QUEUE_LENGTH 5
+#else
+#    define SENTRY_BATCHER_QUEUE_LENGTH 100
+#endif
+
+/**
+ * Thread lifecycle states for the batching thread.
+ */
+typedef enum {
+    /** Thread is not running (initial state or after shutdown) */
+    SENTRY_BATCHER_THREAD_STOPPED = 0,
+    /** Thread is starting up but not yet ready */
+    SENTRY_BATCHER_THREAD_STARTING = 1,
+    /** Thread is running and processing items */
+    SENTRY_BATCHER_THREAD_RUNNING = 2,
+} sentry_batcher_thread_state_t;
+
+typedef struct {
+    sentry_value_t items[SENTRY_BATCHER_QUEUE_LENGTH];
+    long index; // (atomic) index for producer threads to get a unique slot
+    long adding; // (atomic) count of in-flight writers on this buffer
+    long sealed; // (atomic) 0=writeable, 1=sealed (meaning we drop)
+} sentry_batcher_buffer_t;
+
+typedef sentry_envelope_item_t *(*sentry_batch_func_t)(
+    sentry_envelope_t *envelope, sentry_value_t items);
+
+typedef struct {
+    sentry_batcher_buffer_t buffers[2]; // double buffer
+    long active_idx; // (atomic) index to the active buffer
+    long flushing; // (atomic) reentrancy guard to the flusher
+    long thread_state; // (atomic) sentry_batcher_thread_state_t
+    sentry_cond_t request_flush; // condition variable to schedule a flush
+    sentry_threadid_t batching_thread; // the batching thread
+    sentry_batch_func_t batch_func; // function to add items to envelope
+} sentry_batcher_t;
+
+void sentry__batcher_flush(sentry_batcher_t *batcher, bool crash_safe);
+bool sentry__batcher_enqueue(sentry_batcher_t *batcher, sentry_value_t item);
+void sentry__batcher_startup(
+    sentry_batcher_t *batcher, sentry_batch_func_t batch_func);
+void sentry__batcher_shutdown(sentry_batcher_t *batcher, uint64_t timeout);
+void sentry__batcher_flush_crash_safe(sentry_batcher_t *batcher);
+void sentry__batcher_force_flush(sentry_batcher_t *batcher);
+
+#ifdef SENTRY_UNITTEST
+void sentry__batcher_wait_for_thread_startup(sentry_batcher_t *batcher);
+#endif
+
+#endif

--- a/src/sentry_logs.c
+++ b/src/sentry_logs.c
@@ -1,55 +1,14 @@
 #include "sentry_logs.h"
+#include "sentry_batcher.h"
 #include "sentry_core.h"
-#include "sentry_cpu_relax.h"
 #include "sentry_envelope.h"
 #include "sentry_options.h"
 #include "sentry_os.h"
 #include "sentry_scope.h"
-#include "sentry_sync.h"
 #include <stdarg.h>
 #include <string.h>
 
-#ifdef SENTRY_UNITTEST
-#    define QUEUE_LENGTH 5
-#else
-#    define QUEUE_LENGTH 100
-#endif
-#define FLUSH_TIMER 5
-
-#ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
-#    define sleep_ms(MILLISECONDS) Sleep(MILLISECONDS)
-#else
-#    include <unistd.h>
-#    define sleep_ms(MILLISECONDS) usleep(MILLISECONDS * 1000)
-#endif
-/**
- * Thread lifecycle states for the logs batching thread.
- */
-typedef enum {
-    /** Thread is not running (initial state or after shutdown) */
-    SENTRY_LOGS_THREAD_STOPPED = 0,
-    /** Thread is starting up but not yet ready */
-    SENTRY_LOGS_THREAD_STARTING = 1,
-    /** Thread is running and processing logs */
-    SENTRY_LOGS_THREAD_RUNNING = 2,
-} sentry_logs_thread_state_t;
-
-typedef struct {
-    sentry_value_t logs[QUEUE_LENGTH];
-    long index; // (atomic) index for producer threads to get a unique slot
-    long adding; // (atomic) count of in-flight writers on this buffer
-    long sealed; // (atomic) 0=writeable, 1=sealed (meaning we drop)
-} log_buffer_t;
-
-static struct {
-    log_buffer_t buffers[2]; // double buffer
-    long active_idx; // (atomic) index to the active buffer
-    long flushing; // (atomic) reentrancy guard to the flusher
-    long thread_state; // (atomic) sentry_logs_thread_state_t
-    sentry_cond_t request_flush; // condition variable to schedule a flush
-    sentry_threadid_t batching_thread; // the batching thread
-} g_logs_state = {
+static sentry_batcher_t g_batcher = {
     {
         {
             .index = 0,
@@ -64,272 +23,9 @@ static struct {
     },
     .active_idx = 0,
     .flushing = 0,
-    .thread_state = SENTRY_LOGS_THREAD_STOPPED,
+    .thread_state = SENTRY_BATCHER_THREAD_STOPPED,
+    .batch_func = sentry__envelope_add_logs,
 };
-
-// checks whether the currently active buffer should be flushed.
-// otherwise we could miss the trigger of adding the last log if we're actively
-// flushing the other buffer already.
-// we can safely check the state of the active buffer, as the only thread that
-// can change which buffer is active is the one calling this check function
-// inside flush_logs_queue() below
-static bool
-check_for_flush_condition(void)
-{
-    // In flush_logs_queue, after finishing a flush:
-    long current_active = sentry__atomic_fetch(&g_logs_state.active_idx);
-    log_buffer_t *current_buf = &g_logs_state.buffers[current_active];
-
-    // Check if current active buffer is also full
-    // We could even lower the threshold for high-contention scenarios
-    return sentry__atomic_fetch(&current_buf->index) >= QUEUE_LENGTH;
-}
-
-// Use a sleep spinner around a monotonic timer so we don't syscall sleep from
-// a signal handler. While this is strictly needed only there, there is no
-// reason not to use the same implementation across platforms.
-static void
-crash_safe_sleep_ms(uint64_t delay_ms)
-{
-    const uint64_t start = sentry__monotonic_time();
-    const uint64_t end = start + delay_ms;
-    while (sentry__monotonic_time() < end) {
-        for (int i = 0; i < 64; i++) {
-            sentry__cpu_relax();
-        }
-    }
-}
-
-static void
-flush_logs_queue(bool crash_safe)
-{
-    if (crash_safe) {
-        // In crash-safe mode, spin lock with timeout and backoff
-        int attempts = 0;
-        while (!sentry__atomic_compare_swap(&g_logs_state.flushing, 0, 1)) {
-            const int max_attempts = 200;
-            if (++attempts > max_attempts) {
-                SENTRY_WARN("flush_logs_queue: timeout waiting for flushing "
-                            "lock in crash-safe mode");
-                return;
-            }
-
-            // backoff max-wait with max_attempts = 200 based sleep slots:
-            // 9ms + 450ms + 1010ms = 1500ish ms
-            const uint32_t sleep_time = (attempts < 10) ? 1
-                : (attempts < 100)                      ? 5
-                                                        : 10;
-            crash_safe_sleep_ms(sleep_time);
-        }
-    } else {
-        // Normal mode: try once and return if already flushing
-        const long already_flushing
-            = sentry__atomic_store(&g_logs_state.flushing, 1);
-        if (already_flushing) {
-            return;
-        }
-    }
-    do {
-        // prep both buffers
-        long old_buf_idx = sentry__atomic_fetch(&g_logs_state.active_idx);
-        long new_buf_idx = 1 - old_buf_idx;
-        log_buffer_t *old_buf = &g_logs_state.buffers[old_buf_idx];
-        log_buffer_t *new_buf = &g_logs_state.buffers[new_buf_idx];
-
-        // reset new buffer...
-        sentry__atomic_store(&new_buf->index, 0);
-        sentry__atomic_store(&new_buf->adding, 0);
-        sentry__atomic_store(&new_buf->sealed, 0);
-
-        // ...and make it active (after this we're good to go producer side)
-        sentry__atomic_store(&g_logs_state.active_idx, new_buf_idx);
-
-        // seal old buffer
-        sentry__atomic_store(&old_buf->sealed, 1);
-
-        // Wait for all in-flight producers of the old buffer
-        while (sentry__atomic_fetch(&old_buf->adding) > 0) {
-            sentry__cpu_relax();
-        }
-
-        long n = sentry__atomic_store(&old_buf->index, 0);
-        if (n > QUEUE_LENGTH) {
-            n = QUEUE_LENGTH;
-        }
-
-        if (n > 0) {
-            // now we can do the actual batching of the old buffer
-
-            sentry_value_t logs = sentry_value_new_object();
-            sentry_value_t log_items = sentry_value_new_list();
-            int i;
-            for (i = 0; i < n; i++) {
-                sentry_value_append(log_items, old_buf->logs[i]);
-            }
-            sentry_value_set_by_key(logs, "items", log_items);
-
-            sentry_envelope_t *envelope = sentry__envelope_new();
-            sentry__envelope_add_logs(envelope, logs);
-
-            SENTRY_WITH_OPTIONS (options) {
-                if (crash_safe) {
-                    // Write directly to disk to avoid transport queuing during
-                    // crash
-                    sentry__run_write_envelope(options->run, envelope);
-                    sentry_envelope_free(envelope);
-                } else {
-                    // Normal operation: use transport for HTTP transmission
-                    sentry__capture_envelope(options->transport, envelope);
-                }
-            }
-            sentry_value_decref(logs);
-        }
-    } while (check_for_flush_condition());
-
-    sentry__atomic_store(&g_logs_state.flushing, 0);
-}
-
-#define ENQUEUE_MAX_RETRIES 2
-
-static bool
-enqueue_log(sentry_value_t log)
-{
-    for (int attempt = 0; attempt <= ENQUEUE_MAX_RETRIES; attempt++) {
-        // retrieve the active buffer
-        const long active_idx = sentry__atomic_fetch(&g_logs_state.active_idx);
-        log_buffer_t *active = &g_logs_state.buffers[active_idx];
-
-        // if the buffer is already sealed we retry or drop and exit early.
-        if (sentry__atomic_fetch(&active->sealed) != 0) {
-            if (attempt == ENQUEUE_MAX_RETRIES) {
-                return false;
-            }
-            continue;
-        }
-
-        // `adding` is our boundary for this buffer since it keeps the flusher
-        // blocked. We have to recheck that the flusher hasn't already switched
-        // the active buffer or sealed the one this thread is on. If either is
-        // true we have to unblock the flusher and retry or drop the log.
-        sentry__atomic_fetch_and_add(&active->adding, 1);
-        const long active_idx_check
-            = sentry__atomic_fetch(&g_logs_state.active_idx);
-        const long sealed_check = sentry__atomic_fetch(&active->sealed);
-        if (active_idx != active_idx_check) {
-            sentry__atomic_fetch_and_add(&active->adding, -1);
-            if (attempt == ENQUEUE_MAX_RETRIES) {
-                return false;
-            }
-            continue;
-        }
-        if (sealed_check) {
-            sentry__atomic_fetch_and_add(&active->adding, -1);
-            if (attempt == ENQUEUE_MAX_RETRIES) {
-                return false;
-            }
-            continue;
-        }
-
-        // Now we can finally request a slot and check if the log fits in this
-        // buffer.
-        const long log_idx = sentry__atomic_fetch_and_add(&active->index, 1);
-        if (log_idx < QUEUE_LENGTH) {
-            // got a slot, write log to the buffer and unblock flusher
-            active->logs[log_idx] = log;
-            sentry__atomic_fetch_and_add(&active->adding, -1);
-
-            // Check if active buffer is now full and trigger flush. We could
-            // introduce additional watermarks here to trigger the flush earlier
-            // under high contention.
-            // TODO replace with a level-triggered flag
-            if (log_idx == QUEUE_LENGTH - 1) {
-                sentry__cond_wake(&g_logs_state.request_flush);
-            }
-            return true;
-        }
-        // ping the batching thread to flush, since we could miss a cond_wake
-        // on adding the last item
-        sentry__cond_wake(&g_logs_state.request_flush);
-        // Buffer is already full, roll back our increments and retry or drop.
-        sentry__atomic_fetch_and_add(&active->adding, -1);
-        if (attempt == ENQUEUE_MAX_RETRIES) {
-            // TODO report this (e.g. client reports)
-            return false;
-        }
-    }
-    return false;
-}
-
-SENTRY_THREAD_FN
-batching_thread_func(void *data)
-{
-    (void)data;
-    SENTRY_DEBUG("Starting batching thread");
-    sentry_mutex_t task_lock;
-    sentry__mutex_init(&task_lock);
-    sentry__mutex_lock(&task_lock);
-
-    // Transition from STARTING to RUNNING using compare-and-swap
-    // CAS ensures atomic state verification: only succeeds if state is STARTING
-    // If CAS fails, shutdown already set state to STOPPED, so exit immediately
-    // Uses sequential consistency to ensure all thread initialization is
-    // visible
-    if (!sentry__atomic_compare_swap(&g_logs_state.thread_state,
-            (long)SENTRY_LOGS_THREAD_STARTING,
-            (long)SENTRY_LOGS_THREAD_RUNNING)) {
-        SENTRY_DEBUG("logs thread detected shutdown during startup, exiting");
-        sentry__mutex_unlock(&task_lock);
-        sentry__mutex_free(&task_lock);
-        return 0;
-    }
-
-    // Main loop: run while state is RUNNING
-    while (sentry__atomic_fetch(&g_logs_state.thread_state)
-        == SENTRY_LOGS_THREAD_RUNNING) {
-        // Sleep for 5 seconds or until request_flush hits
-        const int triggered_by = sentry__cond_wait_timeout(
-            &g_logs_state.request_flush, &task_lock, 5000);
-
-        // Check if we should still be running
-        if (sentry__atomic_fetch(&g_logs_state.thread_state)
-            != SENTRY_LOGS_THREAD_RUNNING) {
-            break;
-        }
-
-        switch (triggered_by) {
-        case 0:
-#ifdef SENTRY_PLATFORM_WINDOWS
-            if (GetLastError() == ERROR_TIMEOUT) {
-                SENTRY_TRACE("Logs flushed by timeout");
-                break;
-            }
-#endif
-            SENTRY_TRACE("Logs flushed by filled buffer");
-            break;
-#ifdef SENTRY_PLATFORM_UNIX
-        case ETIMEDOUT:
-            SENTRY_TRACE("Logs flushed by timeout");
-            break;
-#endif
-#ifdef SENTRY_PLATFORM_WINDOWS
-        case 1:
-            SENTRY_TRACE("Logs flushed by filled buffer");
-            break;
-#endif
-        default:
-            SENTRY_WARN("Logs flush trigger returned unexpected value");
-            continue;
-        }
-
-        // Try to flush logs
-        flush_logs_queue(false);
-    }
-
-    sentry__mutex_unlock(&task_lock);
-    sentry__mutex_free(&task_lock);
-    SENTRY_DEBUG("batching thread exiting");
-    return 0;
-}
 
 static const char *
 level_as_string(sentry_level_t level)
@@ -813,7 +509,7 @@ sentry__logs_log(sentry_level_t level, const char *message, va_list args)
         if (discarded) {
             return SENTRY_LOG_RETURN_DISCARD;
         }
-        if (!enqueue_log(log)) {
+        if (!sentry__batcher_enqueue(&g_batcher, log)) {
             sentry_value_decref(log);
             return SENTRY_LOG_RETURN_FAILED;
         }
@@ -891,58 +587,14 @@ sentry_log_fatal(const char *message, ...)
 void
 sentry__logs_startup(void)
 {
-    // Mark thread as starting before actually spawning so thread can transition
-    // to RUNNING. This prevents shutdown from thinking the thread was never
-    // started if it races with the thread's initialization.
-    sentry__atomic_store(
-        &g_logs_state.thread_state, (long)SENTRY_LOGS_THREAD_STARTING);
-
-    sentry__cond_init(&g_logs_state.request_flush);
-
-    sentry__thread_init(&g_logs_state.batching_thread);
-    int spawn_result = sentry__thread_spawn(
-        &g_logs_state.batching_thread, batching_thread_func, NULL);
-
-    if (spawn_result == 1) {
-        SENTRY_ERROR("Failed to start batching thread");
-        // Failed to spawn, reset to STOPPED
-        // Note: condition variable doesn't need explicit cleanup for static
-        // storage (pthread_cond_t on POSIX and CONDITION_VARIABLE on Windows)
-        sentry__atomic_store(
-            &g_logs_state.thread_state, (long)SENTRY_LOGS_THREAD_STOPPED);
-    }
+    sentry__batcher_startup(&g_batcher, sentry__envelope_add_logs);
 }
 
 void
 sentry__logs_shutdown(uint64_t timeout)
 {
-    (void)timeout;
     SENTRY_DEBUG("shutting down logs system");
-
-    // Atomically transition to STOPPED and get the previous state
-    // This handles the race where thread might be in STARTING state:
-    // - If thread's CAS hasn't run yet: CAS will fail, thread exits cleanly
-    // - If thread already transitioned to RUNNING: normal shutdown path
-    const long old_state = sentry__atomic_store(
-        &g_logs_state.thread_state, (long)SENTRY_LOGS_THREAD_STOPPED);
-
-    // If thread was never started, nothing to do
-    if (old_state == SENTRY_LOGS_THREAD_STOPPED) {
-        SENTRY_DEBUG("logs thread was not started, skipping shutdown");
-        return;
-    }
-
-    // Thread was started (either STARTING or RUNNING), signal it to stop
-    sentry__cond_wake(&g_logs_state.request_flush);
-
-    // Always join the thread to avoid leaks
-    sentry__thread_join(g_logs_state.batching_thread);
-
-    // Perform final flush to ensure any remaining logs are sent
-    flush_logs_queue(false);
-
-    sentry__thread_free(&g_logs_state.batching_thread);
-
+    sentry__batcher_shutdown(&g_batcher, timeout);
     SENTRY_DEBUG("logs system shutdown complete");
 }
 
@@ -950,33 +602,14 @@ void
 sentry__logs_flush_crash_safe(void)
 {
     SENTRY_DEBUG("crash-safe logs flush");
-
-    // Check if logs system is initialized
-    const long state = sentry__atomic_fetch(&g_logs_state.thread_state);
-    if (state == SENTRY_LOGS_THREAD_STOPPED) {
-        return;
-    }
-
-    // Signal the thread to stop but don't wait, since the crash-safe flush
-    // will spin-lock on flushing anyway.
-    sentry__atomic_store(
-        &g_logs_state.thread_state, (long)SENTRY_LOGS_THREAD_STOPPED);
-
-    // Perform crash-safe flush directly to disk to avoid transport queuing
-    // This is safe because we're in a crash scenario and the main thread
-    // is likely dead or dying anyway
-    flush_logs_queue(true);
-
+    sentry__batcher_flush_crash_safe(&g_batcher);
     SENTRY_DEBUG("crash-safe logs flush complete");
 }
 
 void
 sentry__logs_force_flush(void)
 {
-    while (sentry__atomic_fetch(&g_logs_state.flushing)) {
-        sentry__cpu_relax();
-    }
-    flush_logs_queue(false);
+    sentry__batcher_force_flush(&g_batcher);
 }
 
 #ifdef SENTRY_UNITTEST
@@ -987,21 +620,6 @@ sentry__logs_force_flush(void)
 void
 sentry__logs_wait_for_thread_startup(void)
 {
-    const int max_wait_ms = 1000;
-    const int check_interval_ms = 10;
-    const int max_attempts = max_wait_ms / check_interval_ms;
-
-    for (int i = 0; i < max_attempts; i++) {
-        const long state = sentry__atomic_fetch(&g_logs_state.thread_state);
-        if (state == SENTRY_LOGS_THREAD_RUNNING) {
-            SENTRY_DEBUGF(
-                "logs thread ready after %d ms", i * check_interval_ms);
-            return;
-        }
-        sleep_ms(check_interval_ms);
-    }
-
-    SENTRY_WARNF(
-        "logs thread failed to start within %d ms timeout", max_wait_ms);
+    sentry__batcher_wait_for_thread_startup(&g_batcher);
 }
 #endif


### PR DESCRIPTION
## Summary
- Extracts the batching infrastructure from `sentry_logs.c` into a reusable `sentry_batcher` module
- Prepares for metrics support by making the batcher telemetry-type agnostic

### Changes

**New files:**
- `src/sentry_batcher.h` - Batcher types and API declarations
- `src/sentry_batcher.c` - Batcher implementation

**Key features of the batcher:**
- Lock-free double-buffer pattern for high-throughput producer threads
- Configurable `batch_func` callback for telemetry-specific envelope creation
- Thread lifecycle management (STOPPED → STARTING → RUNNING)
- Crash-safe flush mode for signal handler contexts
- Test helper `sentry__batcher_wait_for_thread_startup()` for avoiding race conditions

**API:**
```c
void sentry__batcher_startup(sentry_batcher_t *batcher, sentry_batch_func_t batch_func);
bool sentry__batcher_enqueue(sentry_batcher_t *batcher, sentry_value_t item);
void sentry__batcher_shutdown(sentry_batcher_t *batcher, uint64_t timeout);
void sentry__batcher_flush(sentry_batcher_t *batcher, bool crash_safe);
void sentry__batcher_force_flush(sentry_batcher_t *batcher);
void sentry__batcher_flush_crash_safe(sentry_batcher_t *batcher);
```

**Usage example (from sentry_logs.c):**
```c
static sentry_batcher_t g_batcher = { ... };

void sentry__logs_startup(void) {
    sentry__batcher_startup(&g_batcher, sentry__envelope_add_logs);
}
```

## Test plan
- [x] Existing logs tests continue to pass
- [x] Build succeeds on all platforms

Relates to https://github.com/getsentry/sentry-native/issues/1453