### PR TITLE
test: mark `test_breakpad_dump_inflight` as flaky with timeout

### DIFF
--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -568,6 +568,7 @@ def test_breakpad_reinstall(cmake, httpserver):
 
 
 @pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@flaky(max_runs=3)
 def test_breakpad_dump_inflight(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "breakpad"})
 
@@ -583,6 +584,7 @@ def test_breakpad_dump_inflight(cmake, httpserver):
         ["log", "capture-multiple", "crash"],
         expect_failure=True,
         env=env,
+        timeout=300,
     )
 
     run(tmp_path, "sentry_example", ["log", "no-setup"], env=env)


### PR DESCRIPTION
Add a 5-minute timeout, which should be generous enough even for busy CI environments, and retry up to 3 times to prevent the test from hanging indefinitely, or 6 hours in CI.

Close: #1501

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
