### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,11 +31,11 @@ build
 # .NET
 bin/
 obj/
+sentry-native.sln
+*.csproj.user
 
 # clangd
 .cache
-
-sentry-native.sln
 
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json


### PR DESCRIPTION
VS Code C#/DevKit/Uno extensions notice the .NET project in `tests/fixtures/dotnet_signal` and like to leave behind annoying `.csproj.user` files.

```sh
$ git status
On branch master
Your branch is up to date with 'upstream/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        tests/fixtures/dotnet_signal/test_dotnet.csproj.user

nothing added to commit but untracked files present (use "git add" to track)
```