### PR TITLE
fix: remove spurious decref in `sentry_capture_user_feedback()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Remove spurious decref in `sentry_capture_user_feedback()` ([#1510](https://github.com/getsentry/sentry-native/pull/1510))
+
 ## 0.12.6
 
 **Features**:

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -801,7 +801,6 @@ prepare_user_report(sentry_value_t user_report)
 fail:
     SENTRY_WARN("dropping user report");
     sentry_envelope_free(envelope);
-    sentry_value_decref(user_report);
     return NULL;
 }
 


### PR DESCRIPTION
Removes `sentry_value_decref(user_report)` from `prepare_user_report()` fail path. `sentry_capture_user_feedback()` already decrefs unconditionally, so having it in both places caused a use-after-free on failure.

The newer variant `sentry_capture_feedback()` had a similar issue, which was found by @tustanivsky in https://github.com/getsentry/sentry-native/pull/1414#discussion_r2731168736. Notice the difference that `sentry__envelope_add_user_feedback()` takes ownership of the value, but `sentry__envelope_add_user_report()` does not (it only serializes it).