### PR TITLE
ci: allow workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths-ignore:
       - "*.md"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Allows triggering the CI for highly experimental/WIP branches without having to open a PR.