### PR TITLE
test: consolidate sleep macros

### DIFF
--- a/tests/unit/sentry_testsupport.h
+++ b/tests/unit/sentry_testsupport.h
@@ -104,4 +104,14 @@
         SENTRY_RESTORE_DEPRECATED                                              \
     } while (0)
 
+#ifdef SENTRY_PLATFORM_WINDOWS
+#    include <windows.h>
+#    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
+#    define sleep_ms(MILLISECONDS) Sleep(MILLISECONDS)
+#else
+#    include <unistd.h>
+#    define sleep_s(SECONDS) sleep(SECONDS)
+#    define sleep_ms(MILLISECONDS) usleep((MILLISECONDS) * 1000)
+#endif
+
 #endif // SENTRY_TEST_SUPPORT_H_INCLUDED

--- a/tests/unit/test_logs.c
+++ b/tests/unit/test_logs.c
@@ -4,14 +4,6 @@
 #include "sentry_envelope.h"
 #include <string.h>
 
-#ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
-#    define sleep_ms(MILLISECONDS) Sleep(MILLISECONDS)
-#else
-#    include <unistd.h>
-#    define sleep_ms(MILLISECONDS) usleep(MILLISECONDS * 1000)
-#endif
-
 typedef struct {
     uint64_t called_count;
     bool has_validation_error;

--- a/tests/unit/test_metrics.c
+++ b/tests/unit/test_metrics.c
@@ -4,14 +4,6 @@
 #include "sentry_envelope.h"
 #include <string.h>
 
-#ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
-#    define sleep_ms(MILLISECONDS) Sleep(MILLISECONDS)
-#else
-#    include <unistd.h>
-#    define sleep_ms(MILLISECONDS) usleep(MILLISECONDS * 1000)
-#endif
-
 typedef struct {
     uint64_t called_count;
     bool has_validation_error;

--- a/tests/unit/test_path.c
+++ b/tests/unit/test_path.c
@@ -2,14 +2,6 @@
 #include "sentry_string.h"
 #include "sentry_testsupport.h"
 
-#ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
-#    define sleep_s(SECONDS) Sleep(SECONDS * 1000)
-#else
-#    include <unistd.h>
-#    define sleep_s(SECONDS) sleep(SECONDS)
-#endif
-
 SENTRY_TEST(recursive_paths)
 {
     sentry_path_t *base = sentry__path_from_str(SENTRY_TEST_PATH_PREFIX ".foo");

--- a/tests/unit/test_process.c
+++ b/tests/unit/test_process.c
@@ -2,14 +2,6 @@
 #include "sentry_process.h"
 #include "sentry_testsupport.h"
 
-#ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
-#    define sleep_ms(MILLISECONDS) Sleep(MILLISECONDS)
-#else
-#    include <unistd.h>
-#    define sleep_ms(MILLISECONDS) usleep(MILLISECONDS * 1000)
-#endif
-
 // merely tests that it doesn't crash with invalid arguments
 SENTRY_TEST(process_invalid)
 {

--- a/tests/unit/test_sync.c
+++ b/tests/unit/test_sync.c
@@ -2,14 +2,6 @@
 #include "sentry_sync.h"
 #include "sentry_testsupport.h"
 
-#ifdef SENTRY_PLATFORM_WINDOWS
-#    include <windows.h>
-#    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
-#else
-#    include <unistd.h>
-#    define sleep_s(SECONDS) sleep(SECONDS)
-#endif
-
 struct task_state {
     int executed;
     bool running;


### PR DESCRIPTION
Consolidate duplicate `sleep_s`/`sleep_ms` macro definitions from 5 test files into `sentry_testsupport.h`.

Sleeping in tests isn't something we want to encourage, but since a handful of tests already rely on it, it's better to define the cross-platform macros in one place rather than copy-paste them into every file that needs a delay.