### PR TITLE
test(session): clear any leftovers from previous tests

### DIFF
--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -1,4 +1,6 @@
 #include "sentry_envelope.h"
+#include "sentry_options.h"
+#include "sentry_path.h"
 #include "sentry_session.h"
 #include "sentry_testsupport.h"
 #include "sentry_value.h"
@@ -57,6 +59,8 @@ SENTRY_TEST(session_basics)
 {
     uint64_t called = 0;
     SENTRY_TEST_OPTIONS_NEW(options);
+    // clear any leftover from previous test runs
+    sentry__path_remove_all(options->database_path);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_transport_t *transport = sentry_transport_new(send_envelope);
     sentry_transport_set_state(transport, &called);
@@ -143,6 +147,8 @@ SENTRY_TEST(count_sampled_events)
     session_assertion_t assertion = { false, 0 };
 
     SENTRY_TEST_OPTIONS_NEW(options);
+    // clear any leftover from previous test runs
+    sentry__path_remove_all(options->database_path);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_transport_t *transport = sentry_transport_new(send_sampled_envelope);
     sentry_transport_set_state(transport, &assertion);


### PR DESCRIPTION
When running session tests with a non-clean database, old envelopes get picked up during SDK init. The `send_envelope` callback in `session_basics` assumes every envelope contains exactly one session item, and crashes when it encounters an unexpected raw envelope:

```
Test session_basics...                          [ FAILED ]
  test_session.c:12: Check 0 == 1... failed

Program received signal SIGSEGV, Segmentation fault.
sentry__envelope_item_get_header (item=item@entry=0x0, key=key@entry=0x5555555d4d6e "type") at src/sentry_envelope.c:1047
1047        return sentry_value_get_by_key(item->headers, key);
(gdb) bt
#0  sentry__envelope_item_get_header (item=0x0, key=0x5555555d4d6e "type") at src/sentry_envelope.c:1047
#1  0x00005555555bbc84 in send_envelope (envelope=0x5555556324d0, data=0x7fffffffd388) at tests/unit/test_session.c:15
#2  0x00005555555848df in sentry__process_old_runs (options=0x5555556210d0, last_crash=0) at src/sentry_database.c:293
#3  0x000055555557f922 in sentry_init (options=0x5555556210d0) at src/sentry_core.c:288
#4  0x00005555555bc4ff in test_sentry_session_basics () at tests/unit/test_session.c:76
#5  0x00005555555a630e in test_do_run__ (test=test@entry=0x5555555fc440 <test_list__+2848>, index=index@entry=0) at include/../vendor/acutest.h:943
#6  0x000055555556f292 in test_run__ (test=0x5555555fc440 <test_list__+2848>, index=0, master_index=178) at include/../vendor/acutest.h:1114
#7  main (argc=<optimized out>, argv=<optimized out>) at include/../vendor/acutest.h:1623
```

This clears the database before SDK init in both `session_basics` and `count_sampled_events`, making the tests resilient to leftover state.