### PR TITLE
ci: add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Adds a Dependabot configuration to automatically create PRs for outdated GitHub Actions dependencies on a weekly schedule.

GitHub Actions used in CI workflows can become outdated and may miss security patches or new features. Dependabot automates the process of keeping these up to date by opening PRs when new versions are available (e.g., the recent actions/checkout v4 → v6 bump in #1530).