### PR TITLE
fix: build on consoles

### DIFF
--- a/tests/unit/test_process.c
+++ b/tests/unit/test_process.c
@@ -16,7 +16,8 @@ SENTRY_TEST(process_invalid)
     sentry__path_free(nul);
 }
 
-#ifndef SENTRY_PLATFORM_WINDOWS
+#if defined(SENTRY_PLATFORM_MACOS)                                             \
+    || (defined(SENTRY_PLATFORM_LINUX) && !defined(SENTRY_PLATFORM_ANDROID))
 void
 find_cp_path(char *buf, size_t buf_len)
 {


### PR DESCRIPTION
The `find_cp_path` helper used `popen`/`pclose` which are unavailable on consoles. Narrow the guard to match the platforms where the function is actually called: macOS and desktop Linux.

<details><summary>ps</summary>

```
  test_process.c
C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-src\tests\unit\test_process.c(23,16): error : call to undeclared function 'popen'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration] [C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-build\tests\unit\sentry_test_unit.vcxproj]
     23 |     FILE *fp = popen("command -v cp 2>/dev/null", "r");
        |                ^
  C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-src\tests\unit\test_process.c(23,16): note: did you mean 'fopen'?
  C:\Program Files (x86)\SCE\Prospero SDKs\11.000/target/include\stdio.h(259,7): note: 'fopen' declared here
    259 | FILE *fopen(const char *_Restrict, const char *_Restrict);
        |       ^
  fix-it:"C:\\github_runners\\vie_runner_4\\_work\\sentry-playstation\\sentry-playstation\\build\\ps5\\_deps\\sentry-native-src\\tests\\unit\\test_process.c":{23:16-23:21}:"fopen"
C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-src\tests\unit\test_process.c(23,11): error : incompatible integer to pointer conversion initializing 'FILE *' (aka 'struct __sFILE *') with an expression of type 'int' [-Wint-conversion] [C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-build\tests\unit\sentry_test_unit.vcxproj]
     23 |     FILE *fp = popen("command -v cp 2>/dev/null", "r");
        |           ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-src\tests\unit\test_process.c(28,9): error : call to undeclared function 'pclose'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration] [C:\github_runners\vie_runner_4\_work\sentry-playstation\sentry-playstation\build\ps5\_deps\sentry-native-build\tests\unit\sentry_test_unit.vcxproj]
     28 |         pclose(fp);
        |         ^
  3 errors generated.
```
</details>
<details><summary>nx</summary>

```
ld.lld: error: undefined symbol: popen
>>> referenced by test_process.c:23 (C:/github_runners/vie_runner_7/_work/sentry-switch/sentry-switch/build/nx64/_deps/sentry-native-src/tests/unit\test_process.c:23)
>>>               _deps/sentry-native-build/tests/unit/CMakeFiles/sentry_test_unit.dir/Develop/test_process.c.obj:(find_cp_path)
>>> did you mean: fopen
>>> defined in: ...
ld.lld: error: undefined symbol: pclose
>>> referenced by test_process.c:28 (C:/github_runners/vie_runner_7/_work/sentry-switch/sentry-switch/build/nx64/_deps/sentry-native-src/tests/unit\test_process.c:28)
>>>               _deps/sentry-native-build/tests/unit/CMakeFiles/sentry_test_unit.dir/Develop/test_process.c.obj:(find_cp_path)
>>> did you mean: fclose
>>> defined in: ...
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
</details>

#skip-changelog
