### PR TITLE
fix: clean up inproc handler sync

### DIFF
--- a/tests/fixtures/inproc_stress/main.c
+++ b/tests/fixtures/inproc_stress/main.c
@@ -311,11 +311,6 @@ test_handler_thread_crash(PATH_TYPE database_path)
 static int
 test_handler_abort_crash(PATH_TYPE database_path)
 {
-#ifdef _WIN32
-    // Suppress the Windows abort dialog that would block CI
-    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
-#endif
-
     if (setup_sentry_with_aborting_on_crash(database_path) != 0) {
         return 1;
     }
@@ -405,6 +400,9 @@ test_simple_crash(PATH_TYPE database_path)
 int
 wmain(int argc, wchar_t *argv[])
 {
+    // Suppress the abort() dialog so CI doesn't block.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+
     if (argc < 2) {
         fwprintf(stderr, L"Usage: %ls <test-name> [database-path]\n", argv[0]);
         fwprintf(stderr, L"Tests:\n");


### PR DESCRIPTION
I just saw that, due to the wait for the `inproc` handler thread in the recent changes, our `inproc` init benchmark regressed unnecessarily because of the poll loop's rather coarse 10ms granularity.

I took this as an inspiration to clean up the handler sync a bit:

* This PR doesn't spin on an atomic with a sleep interval each loop iteration but uses OS-level polling (`pollfd` on a `pipe` and `WaitForSingleObject` on an `Event` respectively) with a timeout. That should dramatically reduce the init wait without any wasteful sleeping on our side.
* It also extracts a significant part of the signal-handler-to-handler-thread sync into functions, so that the rather noisy sync primitives don't flood the actual behavioral code.

Would be great to pack this in before the breaking `0.13.0`.

(since this is a follow-up to the unreleased #1446)
#skip-changelog