### PR TITLE
ci: sync android emulator time with host time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
           emulator-boot-timeout: 1200
           script: |
             # Sync emulator clock with host to avoid timestamp assertion failures
-            adb shell cmd alarm set-time $(date +%s000)
+            adb shell cmd alarm set-time $(date +%s000) || adb shell su root date $(date -u +%m%d%H%M%Y.%S)
             pip install --upgrade --requirement tests/requirements.txt
             pytest --capture=no --verbose tests
 


### PR DESCRIPTION
potential fix to: https://github.com/getsentry/sentry-native/issues/1535