### PR TITLE
chore: Skip `getenv_double` test on PlayStation

### DIFF
--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -430,7 +430,9 @@ SENTRY_TEST(dsn_auth_header_invalid_dsn)
 
 SENTRY_TEST(getenv_double)
 {
-#if !defined(SENTRY_PLATFORM_PS)
+#if defined(SENTRY_PLATFORM_PS)
+    SKIP_TEST();
+#else
     setenv("SENTRY_TEST_DOUBLE", "", 1);
     TEST_CHECK(sentry__getenv_double("SENTRY_TEST_DOUBLE", 42.0) == 42.0);
 


### PR DESCRIPTION
PlayStation doesn't provide `setenv`/`unsetenv` in its C library, causing linker errors when building the unit tests. The `getenv_double` test relies on these POSIX functions to set up environment variables, so it cannot run meaningfully on this platform.

This PR wraps the test body with `#if !defined(SENTRY_PLATFORM_PS)` to skip it on PlayStation while keeping the test active on all other platforms.

#skip-changelog