### PR TITLE
docs: fix grammar and clarity issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@
 [![codecov](https://codecov.io/gh/getsentry/sentry-native/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-native)
 
 The _Sentry Native SDK_ is an error and crash reporting client for native
-applications, optimized for C and C++. Sentry allows to add tags, breadcrumbs
-and arbitrary custom context to enrich error reports. Supports Sentry _20.6.0_
+applications, optimized for C and C++. Sentry allows adding tags, breadcrumbs, and arbitrary custom context to enrich error reports. Supports Sentry _20.6.0_
 and later.
 
 ### Note <!-- omit in toc -->
@@ -73,7 +72,7 @@ The SDK currently supports and is tested on the following OS/Compiler variations
 - Android API35 built by NDK27 toolchain
 - Android API16 built by NDK19 toolchain
 - PlayStation via [sentry-playstation](https://github.com/getsentry/sentry-playstation). See [PlayStation documentation](https://docs.sentry.io/platforms/playstation/) to get access.
-- Xbox via [sentry-xbox](https://github.com/getsentry/sentry-xbox). See [Xbox documentation](https://docs.sentry.io/platforms/xbox/) to get access.
+- Xbox via [sentry-xbox](https://github.com/getsentry/sentry-xbox). See the [Xbox documentation](https://docs.sentry.io/platforms/xbox/) for access.
 - Nintendo Switch via [sentry-switch](https://github.com/getsentry/sentry-switch). See [Nintendo Switch documentation](https://docs.sentry.io/platforms/nintendo-switch/) to get access.
 
 Additionally, the SDK should support the following platforms, although they are
@@ -87,7 +86,7 @@ The SDK supports different features on the target platform:
 - **HTTP Transport** is currently only supported on Windows and platforms that
   have the `curl` library available. On other platforms, library users need to
   implement their own transport, based on the `function transport` API.
-- **Crashpad Backend** is currently only supported on Linux, Windows and macOS.
+- **Crashpad Backend** is currently only supported on Linux, Windows, and macOS.
 - **Client-side stackwalking** is currently only supported on Linux, Windows, and macOS.
 
 ## Building and Installation
@@ -95,10 +94,10 @@ The SDK supports different features on the target platform:
 The SDK is developed and shipped as a [CMake] project.
 CMake will pick an appropriate compiler and buildsystem toolchain automatically
 per platform, and can also be configured for cross-compilation.
-System-wide installation of the resulting sentry library is also possible via
+System-wide installation of the resulting Sentry library is also possible via
 CMake.
 
-The prerequisites for building differ depending on the platform and backend. You will always need `CMake` to build the code. Additionally, when using the `crashpad` backend, `zlib` is required. On Linux and macOS, `libcurl` is a prerequisite. For more details, check out  the [contribution guide](./CONTRIBUTING.md).
+The prerequisites for building differ by platform and backend. You will always need `CMake` to build the code. Additionally, when using the `crashpad` backend, `zlib` is required. On Linux and macOS, `libcurl` is a prerequisite. For more details, check out  the [contribution guide](./CONTRIBUTING.md).
 
 Building the Breakpad and Crashpad backends requires a `C++17` compatible compiler.
 
@@ -109,7 +108,7 @@ Building the Breakpad and Crashpad backends requires a `C++17` compatible compil
 $ cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 # build the project
 $ cmake --build build --parallel
-# install the resulting artifacts into a specific prefix (use the correct config on windows)
+# install the resulting artifacts into a specific prefix (use the correct config on Windows)
 $ cmake --install build --prefix install --config RelWithDebInfo
 # which will result in the following (on macOS):
 $ exa --tree install
@@ -133,7 +132,7 @@ The CMake project can also be configured to correctly work with the Android NDK,
 see the dedicated [CMake Guide] for details on how to integrate it with Gradle
 or use it on the command line.
 
-The `ndk` folder provides Gradle project which adds a Java JNI layer for Android, suitable for accessing the sentry-native SDK from Java. See the [NDK Readme] for more details about this topic.
+The `ndk` folder provides a Gradle project that adds a Java JNI layer for Android, suitable for accessing the sentry-native SDK from Java. See the [NDK Readme] for more details about this topic.
 
 [cmake]: https://cmake.org/cmake/help/latest/
 [cmake guide]: https://developer.android.com/ndk/guides/cmake
@@ -141,12 +140,12 @@ The `ndk` folder provides Gradle project which adds a Java JNI layer for Android
 
 **MinGW**:
 
-64-bits is the only platform supported for now.
+64-bit is the only platform supported for now.
 LLVM + Clang are mandatory here : they are required to generate .pdb files, used by Crashpad for the report generation.
 
 For your application to generate the appropriate .pdb output, you need to activate CodeView file format generation on your application target. To do so, update your own CMakeLists.txt with something like `target_compile_options(${yourApplicationTarget} PRIVATE -gcodeview)`.
 
-If you use a MSYS2 environment to compile with MinGW, make sure to :
+If you use an MSYS2 environment to compile with MinGW, make sure to :
 
 - Create an environment variable `MINGW_ROOT` (ex : `C:/msys64/mingw64`)
 - Run from `mingw64.exe` : `pacman -S --needed - < ./toolchains/msys2-mingw64-pkglist.txt`
@@ -166,7 +165,7 @@ Building universal binaries/libraries is possible out of the box when using the
 as the default generator:
 
 ```sh
-# using xcode generator:
+# using Xcode generator:
 $ cmake -B xcodebuild -GXcode -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 $ xcodebuild build -project xcodebuild/Sentry-Native.xcodeproj
 $ lipo -info xcodebuild/Debug/libsentry.dylib
@@ -226,24 +225,24 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
   - `6.3` (Windows 8.1 / Server 2012 R2)
   - `10` (Windows 10 / Server 2016 / Server 2019)
 
-  For Windows versions below than `6.0` it is also necessary to use XP toolchain
+  For Windows versions below `6.0`, it is also necessary to use the XP toolchain
   in case of MSVC compiler (pass `-T v141_xp` to CMake command line).
 
 - `SENTRY_TRANSPORT` (Default: depending on platform):
-  Sentry can use different http libraries to send reports to the server.
+  Sentry can use different HTTP libraries to send reports to the server.
 
   - **curl**: This uses the `curl` library for HTTP handling. This requires
     that the development version of the package is available.
   - **winhttp**: This uses the `winhttp` system library, is only supported on
     Windows and is the default there.
-  - **none**: Do not build any http transport. This should be used if users
+  - **none**: Do not build any HTTP transport. This should be used if users
     want to handle uploads themselves
 
 - `SENTRY_BACKEND` (Default: depending on platform):
-  Sentry can use different backends depending on platform.
+  Sentry can use different backends depending on the platform.
 
   - **crashpad**: This uses the out-of-process crashpad handler. It is currently
-    only supported on Desktop OSs, and used as the default on Windows, Linux and macOS.
+    only supported on Desktop OSes and used as the default on Windows, Linux, and macOS.
   - **breakpad**: This uses the in-process breakpad handler. It is currently
     only supported on Desktop OSs.
   - **inproc**: A small in-process handler that is supported on all platforms,
@@ -266,7 +265,7 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 
 - `CRASHPAD_ENABLE_STACKTRACE` (Default: `OFF`):
   This enables client-side stackwalking when using the crashpad backend. Stack unwinding will happen on the client's
-  machine and the result will be submitted to Sentry attached to the generated minidump. **Note that this feature is
+  machine, and the result will be submitted to Sentry attached to the generated minidump. **Note that this feature is
   still experimental**.
 
 - `SENTRY_SDK_NAME` (Default: `sentry.native` or `sentry.native.android`):
@@ -275,27 +274,27 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 
 - `SENTRY_HANDLER_STACK_SIZE` (Default: `64`):
   This specifies the size in KiB of the stack reserved for the crash handler (including hooks like `on_crash` and
-  `before_send`) on Windows, Linux and the `inproc` backend in macOS. Reserving the stack is necessary in case of a
+  `before_send`) on Windows, Linux, and the `inproc` backend in macOS. Reserving the stack is necessary in case of a
   stack-overflow, where the handler could otherwise no longer execute. This parameter allows users to specify their
   target stack size in KiB, because some applications might require a different value from our default. This value can
   be as small as 16KiB (on `crashpad` and `breakpad`) for handlers to work, but we recommend 32KiB as the lower bound
   on 64-bit systems. **The value should be a multiple of the page size**.
 
 - `SENTRY_THREAD_STACK_GUARANTEE_FACTOR` (Default: `10`, only for Windows):
-  Defines the factor by which the thread's stack reserve must be bigger than the specified guarantee for the handler.
-  _Example_: if the `SENTRY_HANDLER_STACK_SIZE` is defined as 64KiB then the thread's stack reserve must at least have
+  Defines the factor by which the thread's stack reserve must exceed the specified guarantee for the handler.
+  _Example_: if the `SENTRY_HANDLER_STACK_SIZE` is defined as 64KiB, then the thread's stack reserve must at least have
   a size of 640KiB.
 - `SENTRY_THREAD_STACK_GUARANTEE_AUTO_INIT` (Default: `ON`, only for Windows):
   Ensures that all threads created after the SDK's initialization will be configured to use the
   `SENTRY_HANDLER_STACK_SIZE` as its handler stack guarantee.
 
   _Note_: assigning this to all threads only works when building the SDK as a shared library. If you build it as a
-  static library and this option is enabled, only the `sentry_init()` thread will have a stack guarantee for the handler
+  static library, and this option is enabled, only the `sentry_init()` thread will have a stack guarantee for the handler
   (other threads must be manually initialized via `sentry_set_thread_stack_guarantee()`).
 
 - `SENTRY_THREAD_STACK_GUARANTEE_VERBOSE_LOG` (Default: `OFF`, only for Windows):
-  Adds info level logs for every successfully set thread stack guarantee. This is `OFF` by default, because depending
-  on the number of threads used (by all dependencies) this could flood the logs. But it will be helpful to anyone
+  Adds info-level logs for every successfully set thread stack guarantee. This is `OFF` by default, because depending
+  on the number of threads used (by all dependencies), this could flood the logs. But it will be helpful to anyone
   tuning the thread stack guarantee parameters. Warnings and errors in the process of setting thread stack guarantees
   will always be logged.
 
@@ -328,8 +327,8 @@ In addition to platform support, the "Advanced Usage" section of the SDK docs no
 
 - `sentry`: This is the main library and the only default build target.
 - `crashpad_handler`: When configured with the `crashpad` backend, this is
-  the out of process crash handler, which will need to be installed along with
-  the projects executable.
+  the out-of-process crash handler, which will need to be installed along with
+  the project's executable.
 - `sentry_test_unit`: These are the main unit-tests, which are conveniently built
   also by the toplevel makefile.
 - `sentry_example`: This is a small example program highlighting the API, which
@@ -338,7 +337,7 @@ In addition to platform support, the "Advanced Usage" section of the SDK docs no
 
 ## Runtime Configuration
 
-A minimal working example looks like this. For a more elaborate example see the [example.c](examples/example.c) file which is also used to run sentries integration tests.
+A minimal working example looks like this. For a more elaborate example, see the [example.c](examples/example.c) file, which is also used to run sentries integration tests.
 
 ```c
 sentry_options_t *options = sentry_options_new();
@@ -352,23 +351,23 @@ sentry_close();
 
 Other important configuration options include:
 
-- `sentry_options_set_database_path`: Sentry needs to persist some cache data across application restarts, especially for proper handling of release health sessions. It is recommended to set an explicit absolute path corresponding to the applications cache directory (equivalent to `AppData/Local` on Windows, and `XDG_CACHE_HOME` on Linux). Sentry should be given its own directory which is not shared with other application data, as the SDK will enumerate and possibly delete files in that directory. An example might be `$XDG_CACHE_HOME/your-app/sentry`.
-  When not set explicitly, sentry will create and use the `.sentry-native` directory inside of the current working directory.
-- `sentry_options_set_handler_path`: When using the crashpad backend, sentry will look for a `crashpad_handler` executable in the same directory as the running executable. It is recommended to set this as an explicit absolute path based on the applications install location.
-- `sentry_options_set_release`: Some features in sentry, including release health, need to have a release version set. This corresponds to the application’s version and needs to be set explicitly. See [Releases](https://docs.sentry.io/product/releases/) for more information.
+- `sentry_options_set_database_path`: Sentry needs to persist some cache data across application restarts, especially for proper handling of release health sessions. It is recommended to set an explicit absolute path corresponding to the application's cache directory (equivalent to `AppData/Local` on Windows, and `XDG_CACHE_HOME` on Linux). Sentry should be given its own directory, not shared with other application data, because the SDK will enumerate and possibly delete files in that directory. An example might be `$XDG_CACHE_HOME/your-app/sentry`.
+  When not explicitly set, Sentry will create and use the `.sentry-native` directory in the current working directory.
+- `sentry_options_set_handler_path`: When using the crashpad backend, Sentry will look for a `crashpad_handler` executable in the same directory as the running executable. It is recommended to set this as an explicit absolute path based on the application's install location.
+- `sentry_options_set_release`: Some features in Sentry, including release health, need to have a release version set. This corresponds to the application’s version and needs to be set explicitly. See [Releases](https://docs.sentry.io/product/releases/) for more information.
 
 ## Known Limitations
 
 - The crashpad backend on macOS currently has no support for notifying the crashing
   process, and can thus not properly terminate sessions or call the registered
   `before_send` or `on_crash` hook. It will also lose any events that have been queued for
-  sending at time of crash.
+  sending at the time of the crash.
 - The Crashpad backend on Windows supports fast-fail crashes, which bypass SEH (Structured
   Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error
   Reporting) module, which signals the `crashpad_handler` to send a minidump when a fast-fail crash occurs
-  But since this process bypasses SEH, the application local exception handler is no longer invoked, which
+  But since this process bypasses SEH, the application's local exception handler is no longer invoked, which
   also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before
-  sending the minidump and thus have no effect.
+  sending the minidump, and thus have no effect.
 - When using the crashpad backend on macOS, the list of attachments that will be sent
   along with crashes is frozen at the time of `sentry_init`.
 


### PR DESCRIPTION
#skip-changelog

using this primarily for release testing.
