### PR TITLE
chore(build): avoid unnecessary venv rebuild on every make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,16 +60,17 @@ setup-git: $(GIT_COMMON_DIR)/hooks/pre-commit
 	git submodule update --init --recursive
 .PHONY: setup-git
 
-setup-venv: .venv/bin/python
+setup-venv: .venv/.stamp
 .PHONY: setup-venv
 
 $(GIT_COMMON_DIR)/hooks/pre-commit:
 	@cd $(GIT_COMMON_DIR)/hooks && ln -sf $(PWD)/scripts/git-precommit-hook.sh pre-commit
 
-.venv/bin/python: Makefile tests/requirements.txt
+.venv/.stamp: Makefile tests/requirements.txt
 	@rm -rf .venv
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade --requirement tests/requirements.txt
+	@touch $@
 
 format: setup-venv
 	@.venv/bin/clang-format -i \


### PR DESCRIPTION
Problem: `make style`, `make format`, etc. re-ran `pip install` on every invocation because `.venv/bin/python` is a symlink — make resolves it and sees the system Python's mtime, which is older than `Makefile`, so the target is perpetually out-of-date.

Fix: use a `.venv/.stamp` file as the make target instead.

Before:
```sh
$ git clean -xdf
[...]
$ make style
python3 -m venv .venv
.venv/bin/pip install --upgrade --requirement tests/requirements.txt
[~180 lines...]
Installing collected packages: sortedcontainers, pyperclip, publicsuffix2, passlib, clang-format, Brotli, zstandard, wcwidth, urllib3, typing-extensions, tornado, ruamel.yaml, pyparsing, pylsqpack, pycparser, pyasn1, psutil, protobuf, pluggy, platformdirs, pathspec, packaging, mypy-extensions, msgpack, mitmproxy-rs, MarkupSafe, kaitaistruct, itsdangerous, iniconfig, idna, hyperframe, hpack, h11, flaky, execnet, click, charset_normalizer, certifi, blinker, attrs, asgiref, wsproto, Werkzeug, urwid, requests, pytest, pyasn1-modules, ldap3, Jinja2, h2, cffi, black, pytest-xdist, pytest-httpserver, flask, cryptography, service-identity, pyOpenSSL, aioquic, mitmproxy
Successfully installed Brotli-1.1.0 Jinja2-3.1.6 MarkupSafe-3.0.3 Werkzeug-3.1.6 aioquic-1.2.0 asgiref-3.8.1 attrs-25.4.0 black-24.3.0 blinker-1.9.0 certifi-2026.2.25 cffi-2.0.0 charset_normalizer-3.4.5 clang-format-20.1.5 click-8.3.1 cryptography-43.0.3 execnet-2.1.2 flaky-3.8.1 flask-3.0.3 h11-0.14.0 h2-4.1.0 hpack-4.1.0 hyperframe-6.0.1 idna-3.11 iniconfig-2.3.0 itsdangerous-2.2.0 kaitaistruct-0.10 ldap3-2.9.1 mitmproxy-11.0.0 mitmproxy-rs-0.9.3 msgpack-1.0.8 mypy-extensions-1.1.0 packaging-26.0 passlib-1.7.4 pathspec-1.0.4 platformdirs-4.9.4 pluggy-1.6.0 protobuf-5.28.2 psutil-7.1.1 publicsuffix2-2.20191221 pyOpenSSL-24.2.1 pyasn1-0.6.2 pyasn1-modules-0.4.2 pycparser-3.0 pylsqpack-0.3.23 pyparsing-3.1.4 pyperclip-1.9.0 pytest-8.1.1 pytest-httpserver-1.0.10 pytest-xdist-3.5.0 requests-2.32.4 ruamel.yaml-0.18.6 service-identity-24.2.0 sortedcontainers-2.4.0 tornado-6.4.1 typing-extensions-4.15.0 urllib3-2.6.3 urwid-2.6.15 wcwidth-0.6.0 wsproto-1.2.0 zstandard-0.23.0
All done! ✨ 🍰 ✨
27 files would be left unchanged.
$ make style
python3 -m venv .venv
.venv/bin/pip install --upgrade --requirement tests/requirements.txt
[~180 lines...]
Installing collected packages: sortedcontainers, pyperclip, publicsuffix2, passlib, clang-format, Brotli, zstandard, wcwidth, urllib3, typing-extensions, tornado, ruamel.yaml, pyparsing, pylsqpack, pycparser, pyasn1, psutil, protobuf, pluggy, platformdirs, pathspec, packaging, mypy-extensions, msgpack, mitmproxy-rs, MarkupSafe, kaitaistruct, itsdangerous, iniconfig, idna, hyperframe, hpack, h11, flaky, execnet, click, charset_normalizer, certifi, blinker, attrs, asgiref, wsproto, Werkzeug, urwid, requests, pytest, pyasn1-modules, ldap3, Jinja2, h2, cffi, black, pytest-xdist, pytest-httpserver, flask, cryptography, service-identity, pyOpenSSL, aioquic, mitmproxy
Successfully installed Brotli-1.1.0 Jinja2-3.1.6 MarkupSafe-3.0.3 Werkzeug-3.1.6 aioquic-1.2.0 asgiref-3.8.1 attrs-25.4.0 black-24.3.0 blinker-1.9.0 certifi-2026.2.25 cffi-2.0.0 charset_normalizer-3.4.5 clang-format-20.1.5 click-8.3.1 cryptography-43.0.3 execnet-2.1.2 flaky-3.8.1 flask-3.0.3 h11-0.14.0 h2-4.1.0 hpack-4.1.0 hyperframe-6.0.1 idna-3.11 iniconfig-2.3.0 itsdangerous-2.2.0 kaitaistruct-0.10 ldap3-2.9.1 mitmproxy-11.0.0 mitmproxy-rs-0.9.3 msgpack-1.0.8 mypy-extensions-1.1.0 packaging-26.0 passlib-1.7.4 pathspec-1.0.4 platformdirs-4.9.4 pluggy-1.6.0 protobuf-5.28.2 psutil-7.1.1 publicsuffix2-2.20191221 pyOpenSSL-24.2.1 pyasn1-0.6.2 pyasn1-modules-0.4.2 pycparser-3.0 pylsqpack-0.3.23 pyparsing-3.1.4 pyperclip-1.9.0 pytest-8.1.1 pytest-httpserver-1.0.10 pytest-xdist-3.5.0 requests-2.32.4 ruamel.yaml-0.18.6 service-identity-24.2.0 sortedcontainers-2.4.0 tornado-6.4.1 typing-extensions-4.15.0 urllib3-2.6.3 urwid-2.6.15 wcwidth-0.6.0 wsproto-1.2.0 zstandard-0.23.0
All done! ✨ 🍰 ✨
27 files would be left unchanged.
```

After:
```sh
$ git clean -xdf
[...]
$ make style
python3 -m venv .venv
.venv/bin/pip install --upgrade --requirement tests/requirements.txt
[~180 lines...]
Installing collected packages: sortedcontainers, pyperclip, publicsuffix2, passlib, clang-format, Brotli, zstandard, wcwidth, urllib3, typing-extensions, tornado, ruamel.yaml, pyparsing, pylsqpack, pycparser, pyasn1, psutil, protobuf, pluggy, platformdirs, pathspec, packaging, mypy-extensions, msgpack, mitmproxy-rs, MarkupSafe, kaitaistruct, itsdangerous, iniconfig, idna, hyperframe, hpack, h11, flaky, execnet, click, charset_normalizer, certifi, blinker, attrs, asgiref, wsproto, Werkzeug, urwid, requests, pytest, pyasn1-modules, ldap3, Jinja2, h2, cffi, black, pytest-xdist, pytest-httpserver, flask, cryptography, service-identity, pyOpenSSL, aioquic, mitmproxy
Successfully installed Brotli-1.1.0 Jinja2-3.1.6 MarkupSafe-3.0.3 Werkzeug-3.1.6 aioquic-1.2.0 asgiref-3.8.1 attrs-25.4.0 black-24.3.0 blinker-1.9.0 certifi-2026.2.25 cffi-2.0.0 charset_normalizer-3.4.5 clang-format-20.1.5 click-8.3.1 cryptography-43.0.3 execnet-2.1.2 flaky-3.8.1 flask-3.0.3 h11-0.14.0 h2-4.1.0 hpack-4.1.0 hyperframe-6.0.1 idna-3.11 iniconfig-2.3.0 itsdangerous-2.2.0 kaitaistruct-0.10 ldap3-2.9.1 mitmproxy-11.0.0 mitmproxy-rs-0.9.3 msgpack-1.0.8 mypy-extensions-1.1.0 packaging-26.0 passlib-1.7.4 pathspec-1.0.4 platformdirs-4.9.4 pluggy-1.6.0 protobuf-5.28.2 psutil-7.1.1 publicsuffix2-2.20191221 pyOpenSSL-24.2.1 pyasn1-0.6.2 pyasn1-modules-0.4.2 pycparser-3.0 pylsqpack-0.3.23 pyparsing-3.1.4 pyperclip-1.9.0 pytest-8.1.1 pytest-httpserver-1.0.10 pytest-xdist-3.5.0 requests-2.32.4 ruamel.yaml-0.18.6 service-identity-24.2.0 sortedcontainers-2.4.0 tornado-6.4.1 typing-extensions-4.15.0 urllib3-2.6.3 urwid-2.6.15 wcwidth-0.6.0 wsproto-1.2.0 zstandard-0.23.0
All done! ✨ 🍰 ✨
27 files would be left unchanged.
$ make style
All done! ✨ 🍰 ✨
27 files would be left unchanged.
```
