### PR TITLE
chore(tests): Skip `set_release_and_environment_late` on NX

### DIFF
--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -228,6 +228,9 @@ send_release_env_envelope(sentry_envelope_t *envelope, void *data)
 
 SENTRY_TEST(set_release_and_environment_late)
 {
+#if defined(SENTRY_PLATFORM_NX)
+    SKIP_TEST();
+#endif
     release_env_assertion_t assertion
         = { true, 0, 0, "late_release", "late_env" };
 


### PR DESCRIPTION
This PR forces CI to skip the `set_release_and_environment_late` test on NX platforms, as it tests a scenario (no release at init) that does not apply - the NX `sentry_init` override always [auto-detects](https://github.com/getsentry/sentry-switch/blob/a1001c2a5c610ef823651fc1087d95e0b15b693c/src/sentry_core_nx.cpp#L36-L46) a release from the binary name. The late-update case that does apply on NX is already covered by `update_release_and_environment_late`.

Related items:

- https://github.com/getsentry/sentry-native/pull/1555
- [Failing CI run](https://github.com/getsentry/sentry-switch/actions/runs/23299289296/job/67755404333) for Switch.

#skip-changelog