### PR TITLE
test: skip flaky test_native_crash_http with kcov

### DIFF
--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -799,6 +799,7 @@ def test_discarding_before_breadcrumb_http(cmake, httpserver):
     assert_no_breadcrumbs(envelope)
 
 
+@pytest.mark.skipif(is_kcov, reason="kcov exits with 0 even when the process crashes")
 @pytest.mark.skipif(not has_native, reason="test needs native backend")
 def test_native_crash_http(cmake, httpserver):
     """Test native backend crash handling with HTTP transport"""


### PR DESCRIPTION
Same as #1419 - kcov randomly exits with 0 even when the process crashes:
```
kcov: Process exited with signal 11 (SIGSEGV) at 0x7ffff77894c8
...
AssertionError: command unexpectedly successful: ['kcov', ...]
```

- https://github.com/getsentry/sentry-native/actions/runs/23507613701/job/68419673813
- https://github.com/getsentry/sentry-native/actions/runs/23543284679/attempts/1?pr=1595