### PR TITLE
Merge branch 'release/0.13.4'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.4
 
 **Features**:
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -100,7 +100,7 @@ extern "C" {
 #    endif
 #endif
 #ifndef SENTRY_SDK_VERSION
-#    define SENTRY_SDK_VERSION "0.13.3"
+#    define SENTRY_SDK_VERSION "0.13.4"
 #endif
 #define SENTRY_SDK_USER_AGENT SENTRY_SDK_NAME "/" SENTRY_SDK_VERSION
 

--- a/ndk/gradle.properties
+++ b/ndk/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 android.useAndroidX=true
 
 # Release information, used for maven publishing
-versionName=0.13.3
+versionName=0.13.4
 
 # disable renderscript, it's enabled by default
 android.defaults.buildfeatures.renderscript=false

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,7 +15,7 @@ sourcedir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 # https://docs.pytest.org/en/latest/assert.html#assert-details
 pytest.register_assert_rewrite("tests.assertions")
 
-SENTRY_VERSION = "0.13.3"
+SENTRY_VERSION = "0.13.4"
 
 
 def make_dsn(httpserver, auth="uiaeosnrtdy", id=123456, proxy_host=False):


### PR DESCRIPTION
The release bot failed to merge `release/0.13.4` into `master`.

Not 100% sure what went wrong. There are no conflicts in `CHANGELOG.md`. Only #1604 and #1605 were merged while the release was running. Possibly related to:
```
Error: fatal: could not read Username for 'https://github.com/': No such device or address
```
Anyway, the output contains instructions to manually merge `release/0.13.4` into `master`.


 _Originally posted by @github-actions in [getsentry/publish#7613](https://github.com/getsentry/publish/issues/7613#issuecomment-4145030167)_

> Published successfully: [run#23662543196](https://github.com/getsentry/publish/actions/runs/23662543196)

In the _Publish using Craft_ step:
```
[info]  
[warn] Failed to merge release branch "release/0.13.4" into the target branch.
This is likely due to a merge conflict (e.g., in CHANGELOG.md).
All publish targets completed successfully — only the post-publish merge failed.

To resolve manually:
  1. Merge the release branch into the target branch, resolving conflicts
  2. Delete the release branch: git push origin --delete release/0.13.4

Error: fatal: could not read Username for 'https://github.com/': No such device or address

[success] Version 0.13.4 has been published!
```

#skip-changelog