### PR TITLE
ci: speed up OOM tests with configurable memory limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
       VS_GENERATOR_TOOLSET: ${{ matrix.VS_GENERATOR_TOOLSET }}
       SYSTEM_PYTHON: ${{ matrix.SYSTEM_PYTHON }}
       UTF8_TEST_CWD: ${{ matrix.UTF8_TEST_CWD }}
+      SENTRY_TEST_OOM_LIMIT: "4095" # ~4GB, to speed up OOM tests
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/examples/example.c
+++ b/examples/example.c
@@ -384,6 +384,30 @@ trigger_stack_overflow()
 static void
 trigger_oom(void)
 {
+#ifdef SENTRY_PLATFORM_WINDOWS
+    // Optionally limit process memory to trigger OOM faster.
+    // Set SENTRY_TEST_OOM_LIMIT to the limit in MiB (e.g. "8192" for 8GB).
+    // Without this, OOM exhausts all virtual memory which can take minutes.
+    // Note: a Job Object limit only constrains user-mode allocations and
+    // does not exhaust kernel pool memory like a real system-wide OOM would.
+    const char *oom_limit = getenv("SENTRY_TEST_OOM_LIMIT");
+    if (oom_limit) {
+        unsigned long long limit = strtoull(oom_limit, NULL, 10) * 1024 * 1024;
+        if (limit > 0 && limit <= SIZE_MAX) {
+            HANDLE job = CreateJobObjectW(NULL, NULL);
+            if (job) {
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = { 0 };
+                info.BasicLimitInformation.LimitFlags
+                    = JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+                info.ProcessMemoryLimit = (size_t)limit;
+                SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+                    &info, sizeof(info));
+                AssignProcessToJobObject(job, GetCurrentProcess());
+            }
+        }
+    }
+#endif
+
     size_t count = 1024;
     for (;;) {
         void *p = malloc(count);


### PR DESCRIPTION
Set `SENTRY_TEST_OOM_LIMIT=4095` (MiB, just under 4GB to avoid 32-bit overflow) in CI to limit process memory via a Windows Job Object. Without this, the OOM loop exhausts all virtual memory including pagefile, which is slow due to disk I/O. With the limit, malloc fails fast without paging.

Before, `test_native_oom` and `test_crashpad_oom` were each taking 60-70s in the CI. With the limit, they take only a few seconds using cached builds from other tests. So, this saves about 2 minutes.

NOTE: The limit only constrains user-mode allocations. It does not exhaust kernel pool memory like a real system-wide OOM would. Omit the environment variable to test real OOM behavior and regressions such as the original OOM-related `OpenProcess` bug in the native backend.