### PR TITLE
fix: reset client report counters during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 
 **Fixes**:
 
-<<<<<<< fix/discard-count-reset
 - Reset client report counters during initialization ([#1632](https://github.com/getsentry/sentry-native/pull/1632))
-=======
 - macOS: cache VM regions for FP validation in the new unwinder. ([#1634](https://github.com/getsentry/sentry-native/pull/1634))
->>>>>>> master
 
 ## 0.13.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+**Fixes**:
+
+- Reset client report counters during initialization ([#1632](https://github.com/getsentry/sentry-native/pull/1632))
+
 ## 0.13.6
 
 **Features**:

--- a/src/sentry_client_report.c
+++ b/src/sentry_client_report.c
@@ -64,3 +64,13 @@ sentry__client_report_restore(sentry_client_report_t *report)
     }
     memset(report, 0, sizeof(*report));
 }
+
+void
+sentry__client_report_reset(void)
+{
+    for (int r = 0; r < SENTRY_DISCARD_REASON_MAX; r++) {
+        for (int c = 0; c < SENTRY_DATA_CATEGORY_MAX; c++) {
+            sentry__atomic_store((long *)&g_discard_counts[r][c], 0);
+        }
+    }
+}

--- a/src/sentry_client_report.h
+++ b/src/sentry_client_report.h
@@ -63,4 +63,11 @@ bool sentry__client_report_save(sentry_client_report_t *report);
  */
 void sentry__client_report_restore(sentry_client_report_t *report);
 
+/**
+ * Reset all pending discard counters to zero.
+ * Called during sentry_init() so that stale counts from a previous session
+ * do not leak into the new one.
+ */
+void sentry__client_report_reset(void);
+
 #endif

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -172,6 +172,8 @@ sentry_init(sentry_options_t *options)
 
     sentry_close();
 
+    sentry__client_report_reset();
+
     sentry_logger_t logger = { NULL, NULL, SENTRY_LEVEL_DEBUG };
 
     if (options->debug) {


### PR DESCRIPTION
This PR fixes a bug where the global `g_discard_counts` array in the client report system is not reset between
`sentry_close()` / `sentry_init()` cycles. As a result, discard counts from a previous SDK session leak into the next
one within the same process.

This causes the `client_report_concurrent` unit test to fail on platforms that run all tests in a single process (e.g.
Xbox, where process forking is unavailable). A prior test leaves one residual discard count, causing the concurrent
test to observe 80,001 instead of the expected 80,000 ([failing Xbox CI run example](https://github.com/getsentry/sentry-xbox/actions/runs/24232220598/job/70746222828)).

The fix introduces `sentry__client_report_reset()` and calls it at the start of `sentry_init()`, ensuring that each SDK
initialization begins with a clean state. This is also semantically correct for production: applications that
re-initialize the SDK within a single process should not carry over stale discard counts into a new session.

Related items:
- https://github.com/getsentry/sentry-native/pull/1549