### PR TITLE
test: make libcrash.so in the .NET tests 16KB page-size compatible

### DIFF
--- a/tests/test_dotnet_signals.py
+++ b/tests/test_dotnet_signals.py
@@ -409,6 +409,7 @@ def test_android_signals_inproc(cmake, runtime, strategy):
                 "-Wextra",
                 "-fPIC",
                 "-shared",
+                "-Wl,-z,max-page-size=16384",
                 str(project_fixture_path / "crash.c"),
                 "-o",
                 str(native_lib_dir / "libcrash.so"),


### PR DESCRIPTION
CI warning annotations are flooded with

```
Android 16 will require 16 KB page sizes, shared library 'libcrash.so' does not have a 16 KB page size. Please inform the authors of the NuGet package '<unknown>' version '<unknown>' which contains 'native/x86_64/libcrash.so'. See https://developer.android.com/guide/practices/page-sizes for more details.
```

#skip-changelog
