### PR TITLE
test: disable Android CoreCLR warning noise in the CI

### DIFF
--- a/tests/test_dotnet_signals.py
+++ b/tests/test_dotnet_signals.py
@@ -430,6 +430,7 @@ def test_android_signals_inproc(cmake, runtime, strategy):
             "-p:RuntimeIdentifier={}".format(rid_map[arch]),
             "-p:Configuration=Release",
             "-p:UseMonoRuntime={}".format(str(use_mono).lower()),
+            "-p:EnablePreviewFeatures=true",
         ]
         if is_preload:
             build_args += [


### PR DESCRIPTION
I added this for the same reason I opened #1635. There is a good chance we will use preview features in our tests in the future, too, and there is no reason to warn us about using them in production.

```
The CoreCLR runtime on Android is an experimental feature and not yet suitable for production use. File issues at: https://github.com/dotnet/android/issues
```

#skip-changelog