### PR TITLE
test: fix screenshot integration test for native

### DIFF
--- a/tests/fixtures/screenshot/screenshot_win32.c
+++ b/tests/fixtures/screenshot/screenshot_win32.c
@@ -76,6 +76,7 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine,
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_release(options, "sentry-screenshot");
+    sentry_options_set_auto_session_tracking(options, false);
     sentry_options_set_attach_screenshot(options, true);
     sentry_options_set_debug(options, true);
     sentry_init(options);

--- a/tests/test_integration_screenshot.py
+++ b/tests/test_integration_screenshot.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-from . import make_dsn, run
+from . import Envelope, make_dsn, run
 
 
 def assert_screenshot_file(database_path):
@@ -17,6 +17,20 @@ def assert_screenshot_file(database_path):
     screenshot_path = run_dirs[0] / "screenshot.png"
     assert screenshot_path.exists(), "No screenshot was captured"
     assert screenshot_path.stat().st_size > 0, "Screenshot file is empty"
+
+
+def assert_screenshot_envelope(envelope):
+    found_screenshot = False
+    for item in envelope.items:
+        if (
+            item.headers.get("type") == "attachment"
+            and item.headers.get("filename") == "screenshot.png"
+        ):
+            assert item.headers.get("content_type") == "image/png"
+            assert item.headers.get("attachment_type") == "event.attachment"
+            assert len(item.payload.bytes) > 0
+            found_screenshot = True
+    assert found_screenshot, "No screenshot item found in envelope"
 
 
 def assert_screenshot_upload(req):
@@ -35,29 +49,37 @@ def assert_screenshot_upload(req):
     sys.platform != "win32",
     reason="Screenshots are only supported on Windows",
 )
-@pytest.mark.parametrize(
-    "build_args",
-    [
-        ({"SENTRY_BACKEND": "inproc"}),
-        ({"SENTRY_BACKEND": "breakpad"}),
-        pytest.param(
-            {"SENTRY_BACKEND": "native"},
-            marks=pytest.mark.skip(
-                reason="Native daemon cleans up run folder after processing "
-                "so the screenshot file is no longer on disk"
-            ),
-        ),
-    ],
-)
-def test_capture_screenshot(cmake, httpserver, build_args):
-    build_args.update({"SENTRY_TRANSPORT": "none"})
-    tmp_path = cmake(["sentry_screenshot"], build_args)
+@pytest.mark.parametrize("backend", ["inproc", "breakpad"])
+def test_capture_screenshot(cmake, httpserver, backend):
+    tmp_path = cmake(
+        ["sentry_screenshot"], {"SENTRY_BACKEND": backend, "SENTRY_TRANSPORT": "none"}
+    )
 
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
 
     run(tmp_path, "sentry_screenshot", ["crash"], expect_failure=True, env=env)
 
     assert_screenshot_file(tmp_path / ".sentry-native")
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Screenshots are only supported on Windows",
+)
+def test_capture_screenshot_native(cmake, httpserver):
+    tmp_path = cmake(["sentry_screenshot"], {"SENTRY_BACKEND": "native"})
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        run(tmp_path, "sentry_screenshot", ["crash"], expect_failure=True, env=env)
+
+    assert waiting.result
+
+    assert len(httpserver.log) == 1
+    envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
+    assert_screenshot_envelope(envelope)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
The existing inproc & breakpad tests assert for a screenshot file in the database. For native, the integration test was skipped:

> Native daemon cleans up run folder after processing so the screenshot file is no longer on disk

Add an alternative native test variant that captures the envelope instead, and asserts on a screenshot attachment. It's similar to the crashpad test variant but using a different endpoint and upload format.