### PR TITLE
feat(transport): add error log for oversized envelopes (HTTP 413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Add `before_screenshot` hook. ([#1641](https://github.com/getsentry/sentry-native/pull/1641))
+- Add error log for oversized envelopes (HTTP 413 Content Too Large). ([#1647](https://github.com/getsentry/sentry-native/pull/1647))
 
 **Fixes**:
 

--- a/src/transports/sentry_http_transport.c
+++ b/src/transports/sentry_http_transport.c
@@ -202,6 +202,20 @@ http_send_request(http_transport_state_t *state,
     return resp->status_code;
 }
 
+static bool
+http_handle_error(int status_code)
+{
+    switch (status_code) {
+    case 413:
+        SENTRY_ERROR("Envelope was discarded due to size limits (HTTP 413 "
+                     "Content Too Large).");
+        break;
+    default:
+        break;
+    }
+    return status_code >= 400 && status_code != 429;
+}
+
 static void
 http_update_ratelimiter(
     http_transport_state_t *state, sentry_http_response_t *resp)
@@ -252,8 +266,7 @@ retry_send_cb(sentry_envelope_t *envelope, void *_state)
         }
     }
     int status_code = http_send_envelope(envelope, state);
-    if (state->send_client_reports && status_code >= 400
-        && status_code != 429) {
+    if (http_handle_error(status_code) && state->send_client_reports) {
         sentry__client_report_restore(&report);
         size_t buf_len = 0;
         char *buf = sentry_envelope_serialize(envelope, &buf_len);
@@ -322,7 +335,7 @@ http_send_task(void *_envelope, void *_state)
                 SENTRY_DISCARD_REASON_NETWORK_ERROR, state->ratelimiter);
         }
     } else {
-        if (status_code >= 400 && status_code != 429) {
+        if (http_handle_error(status_code)) {
             sentry__client_report_restore(&report);
             sentry__envelope_discard(
                 envelope, SENTRY_DISCARD_REASON_SEND_ERROR, state->ratelimiter);

--- a/tests/test_integration_client_reports.py
+++ b/tests/test_integration_client_reports.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+
 import pytest
 
 from . import make_dsn, run, Envelope
@@ -320,6 +322,35 @@ def test_client_report_send_error(cmake, httpserver):
         envelope,
         [{"reason": "send_error", "category": "error", "quantity": 1}],
     )
+
+
+def test_client_report_content_too_large(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data(
+        "Content Too Large", status=413
+    )
+    httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    result = run(
+        tmp_path,
+        "sentry_example",
+        ["log", "start-session", "capture-event"],
+        env=env,
+        stderr=subprocess.PIPE,
+    )
+
+    assert len(httpserver.log) == 2
+    envelope = Envelope.deserialize(httpserver.log[1][0].get_data())
+
+    assert_session(envelope)
+    assert_client_report(
+        envelope,
+        [{"reason": "send_error", "category": "error", "quantity": 1}],
+    )
+
+    assert b"HTTP 413 Content Too Large" in result.stderr
 
 
 @pytest.mark.skipif(not has_files, reason="test needs a local filesystem")


### PR DESCRIPTION
Per the spec for dealing with network failures, the **SDK SHOULD** log an error when an envelope is discarded due to a HTTP 413 _Content Too Large_ response so users understand why their data was dropped.

https://develop.sentry.dev/sdk/foundations/transport/offline-caching/#dealing-with-network-failures

A partial solution to #1487, Crashpad needs to be addressed separately.