### PR TITLE
fix(CI): don't run `console-check.yml` for dependabot PRs

### DIFF
--- a/.github/workflows/console-check.yml
+++ b/.github/workflows/console-check.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   trigger-console-builds:
-    if: github.event.pull_request.head.repo.fork == false || github.event_name == 'push' # secrets unavailable for fork PRs
+    if: github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.fork == false || github.event_name == 'push') # secrets unavailable for fork/dependabot PRs
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
It doesn't have access to secrets, so we can just always skip it

Follow-up of #1597 

#skip-changelog