### PR TITLE
fix(modulefinder): handle ENOSYS in read_safely for Kubernetes seccomp

### DIFF
--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -141,9 +141,13 @@ read_safely(void *dst, void *src, size_t size)
     // See https://github.com/getsentry/sentry-native/issues/578).
     // Also, the syscall is only available in Linux 3.2, meaning Android 17.
     // In that case we get an `EINVAL`.
+    // Additionally, Kubernetes default seccomp profiles (RuntimeDefault) block
+    // `process_vm_readv` and return `ENOSYS`, causing all ELF module
+    // validations to fail and `debug_meta.images` to be absent from
+    // manually-captured events.
     //
-    // In either of these cases, just fall back to an unsafe `memcpy`.
-    if (!rv && (errno == EPERM || errno == EINVAL)) {
+    // In any of these cases, just fall back to an unsafe `memcpy`.
+    if (!rv && (errno == EPERM || errno == EINVAL || errno == ENOSYS)) {
         memcpy(dst, src, size);
         rv = true;
     }


### PR DESCRIPTION
Fixes #1653.

## Problem

When running under Kubernetes with the default `RuntimeDefault` seccomp profile, `process_vm_readv` is blocked and returns `ENOSYS` (errno 38). The existing fallback in `read_safely()` only handles `EPERM` and `EINVAL`, so every ELF module validation fails silently.

The result: `sentry_get_modules_list()` returns 0 modules, `debug_meta.images` is absent from manually-captured events, and every stack frame shows as `unknown_image` in Sentry — even when debug symbols have been uploaded correctly.

## When does this happen?

- [x] Kubernetes pods using the default `RuntimeDefault` seccomp profile
- [ ] Docker containers (Docker default profile returns `EPERM`, already handled)
- [ ] Bare-metal / VMs (syscall is permitted)

Crash events via crashpad are **not** affected because the out-of-process handler enumerates modules from `/proc/<pid>/maps` directly, independent of `sentry_get_modules_list()`.

## Root cause

`read_safely()` in `sentry_modulefinder_linux.c`:

```c
// Before
if (!rv && (errno == EPERM || errno == EINVAL)) {

// After
if (!rv && (errno == EPERM || errno == EINVAL || errno == ENOSYS)) {
```

## Verification

Confirmed with a static test binary copied into a real K8s pod (Flatcar Linux, kernel 6.12, `Seccomp: 2`):

```
FAILED: errno=38 (Function not implemented)
```

Also reproduced locally using Docker with a custom seccomp profile (`SCMP_ACT_ERRNO` / `errnoRet: 38`) — the original code fails, the patched code falls back to `memcpy` and succeeds.

## Fix

One-liner: add `|| errno == ENOSYS` to the existing errno fallback. The address is valid in-process memory, so `memcpy` is safe.