### PR TITLE
fix(CI): disable `client_report_concurrent` test on NX platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 **Fixes**:
 
 - Linux: handle `ENOSYS` in `read_safely` to fix empty module list in seccomp-restricted environments. ([#1655](https://github.com/getsentry/sentry-native/pull/1655))
-- Disable `client_report_concurrent` test on NX platform ([#1657](https://github.com/getsentry/sentry-native/pull/1657))
 
 ## 0.13.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Linux: handle `ENOSYS` in `read_safely` to fix empty module list in seccomp-restricted environments. ([#1655](https://github.com/getsentry/sentry-native/pull/1655))
+- Disable `client_report_concurrent` test on NX platform ([#1657](https://github.com/getsentry/sentry-native/pull/1657))
 
 ## 0.13.7
 

--- a/tests/unit/test_client_report.c
+++ b/tests/unit/test_client_report.c
@@ -523,6 +523,12 @@ flush_thread_func(void *data)
 
 SENTRY_TEST(client_report_concurrent)
 {
+#if defined(SENTRY_PLATFORM_NX)
+    // Hot busy-wait in flush_thread_func saturates the devkit and trips the
+    // Nintendo OS watchdog, which terminates the process with
+    // `ExitKind: InterruptByOtherProcess`.
+    SKIP_TEST();
+#endif
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_init(options);
 


### PR DESCRIPTION
This PR skips the `client_report_concurrent` unit test on Nintendo Switch (`SENTRY_PLATFORM_NX`).

The test spawns 16 threads - 8 discard producers plus 8 flush consumers, which is CPU-intensive on desktop but finishes quickly. On a Switch devkit, 16 threads with no yield saturate the cores long enough for the Nintendo OS watchdog to terminate the process ([failing CI run example](https://github.com/getsentry/sentry-switch/actions/runs/24511827952/job/71673803886)).

#skip-changelog