### PR TITLE
feat(crashpad): capture handler logs (+ client stderr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Linux: support 32-bit ARM. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+- Crashpad: capture handler process log output to `<run>/crashpad-handler.log`, matching the SDK's `debug` verbosity. ([#1658](https://github.com/getsentry/sentry-native/pull/1658))
 
 **Fixes**:
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #    pragma clang diagnostic ignored                                           \
         "-Winconsistent-missing-destructor-override"
 #endif
+#include "base/logging.h"
 #include "client/crash_report_database.h"
 #include "client/crashpad_client.h"
 #include "client/crashpad_info.h"
@@ -694,6 +695,38 @@ crashpad_backend_startup(
     }
 
     std::vector<std::string> arguments { "--no-rate-limit" };
+
+    // Map sentry's log level to mini_chromium's LogSeverity. They diverge at
+    // FATAL (sentry=3, mini_chromium=4); otherwise 1:1.
+    int level = static_cast<int>(options->logger.logger_level);
+    switch (options->logger.logger_level) {
+    case SENTRY_LEVEL_TRACE:
+    case SENTRY_LEVEL_DEBUG:
+        level = -1; // LOG_VERBOSE
+        break;
+    case SENTRY_LEVEL_INFO:
+    case SENTRY_LEVEL_WARNING:
+    case SENTRY_LEVEL_ERROR:
+        // LOG_INFO/WARNING/ERROR (0/1/2) match 1:1
+        break;
+    case SENTRY_LEVEL_FATAL:
+        level = 4; // LOG_FATAL
+        break;
+    }
+
+    sentry_path_t *log_path
+        = sentry__path_join_str(current_run_folder, "crashpad-handler.log");
+    if (log_path) {
+        arguments.push_back(std::string("--log-file=") + log_path->path);
+        sentry__path_free(log_path);
+    }
+    if (options->debug) {
+        logging::LoggingSettings settings;
+        settings.logging_dest = logging::LOG_TO_STDERR;
+        settings.min_log_level = level;
+        logging::InitLogging(settings);
+        arguments.push_back("--log-level=" + std::to_string(level));
+    }
 
     char report_id[37];
     sentry_uuid_as_string(&data->crash_event_id, report_id);


### PR DESCRIPTION
Capture `crashpad_handler`'s log output in the run directory: `<run>/crashpad-handler.log`. The log file is automatically cleaned up with the rest of the `.run` directory on the next `sentry_init`, so it doesn't bloat the database. When `debug` is enabled, forward the SDK's log level via `--log-level=N` so the file matches the configured verbosity. `TRACE` and `DEBUG` map to `mini_chromium`'s `LOG_VERBOSE`, `FATAL` to `LOG_FATAL`, the rest 1:1.

As a side bonus, client-side logs are also routed to stderr when `debug` is enabled — previously only POSIX routed non-`ERROR` levels there by default.

Example:
```
>type .sentry-native\503a7424-7c3f-4644-755a-4b2d0469dbc4.run\crashpad-handler.log
[18468:19016:20260417,172034.322:ERROR filesystem_win.cc:115] GetFileAttributes C:\Users\jpnurmi\Projects\sentry\sentry-playground\build\Desktop_Qt_6_9_1_MSVC2022_64bit-RelWithDebInfo\.sentry-native\attachments\3d5e3570-9cbd-4f6f-40f5-1bdd786d7254\__sentry-event: The system cannot find the file specified. (2)
[18468:19016:20260417,172034.323:ERROR filesystem_win.cc:115] GetFileAttributes C:\Users\jpnurmi\Projects\sentry\sentry-playground\build\Desktop_Qt_6_9_1_MSVC2022_64bit-RelWithDebInfo\.sentry-native\attachments\3d5e3570-9cbd-4f6f-40f5-1bdd786d7254\__sentry-breadcrumb1: The system cannot find the file specified. (2)
[18468:19016:20260417,172034.324:ERROR filesystem_win.cc:115] GetFileAttributes C:\Users\jpnurmi\Projects\sentry\sentry-playground\build\Desktop_Qt_6_9_1_MSVC2022_64bit-RelWithDebInfo\.sentry-native\attachments\3d5e3570-9cbd-4f6f-40f5-1bdd786d7254\__sentry-breadcrumb2: The system cannot find the file specified. (2)
[18468:19016:20260417,172034.377:ERROR filesystem_win.cc:115] GetFileAttributes C:\Users\jpnurmi\Projects\sentry\sentry-playground\build\Desktop_Qt_6_9_1_MSVC2022_64bit-RelWithDebInfo\.sentry-native\attachments\3d5e3570-9cbd-4f6f-40f5-1bdd786d7254\screenshot.png: The system cannot find the file specified. (2)
```

See also:
- getsentry/crashpad#148
- getsentry/mini_chromium#6

Close: #1468