### PR TITLE
feat: support 32-bit ARM on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
             os: ubuntu-24.04-arm
             CC: arm-linux-gnueabihf-gcc
             CXX: arm-linux-gnueabihf-g++
-            CROSS_ARM32: 1
+            TEST_ARM32: 1
+            TEST_QEMU: 1
           - name: Linux (GCC 9.5.0)
             os: ubuntu-24.04
             CC: gcc-9
@@ -228,7 +229,8 @@ jobs:
       CXX: ${{ matrix.CXX }}
       TEST_X86: ${{ matrix.TEST_X86 }}
       TEST_MINGW: ${{ matrix.TEST_MINGW }}
-      CROSS_ARM32: ${{ matrix.CROSS_ARM32 }}
+      TEST_ARM32: ${{ matrix.TEST_ARM32 }}
+      TEST_QEMU: ${{ matrix.TEST_QEMU }}
       USE_SCCACHE: ${{ matrix.USE_SCCACHE }}
       SCCACHE_GHA_ENABLED: ${{ matrix.USE_SCCACHE && 'true' || '' }}
       ERROR_ON_WARNINGS: ${{ matrix.ERROR_ON_WARNINGS }}
@@ -264,7 +266,7 @@ jobs:
           [ -n "$CC" ] && [ -n "$CXX" ] || { echo "Ubuntu runner configurations require toolchain selection via CC and CXX" >&2; exit 1; }
 
       - name: Installing Linux Dependencies
-        if: ${{ runner.os == 'Linux' && !env['TEST_X86'] && !env['CROSS_ARM32'] && !env['ANDROID_API'] && !matrix.container }}
+        if: ${{ runner.os == 'Linux' && !env['TEST_X86'] && !env['TEST_ARM32'] && !env['ANDROID_API'] && !matrix.container }}
         run: |
           sudo apt update
           # Install common dependencies
@@ -302,7 +304,7 @@ jobs:
           sudo apt install cmake "${CC}-multilib" "${CXX}-multilib" zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386 liblzma-dev:i386
 
       - name: Installing Linux arm32 Dependencies
-        if: ${{ runner.os == 'Linux' && env['CROSS_ARM32'] && !matrix.container }}
+        if: ${{ runner.os == 'Linux' && env['TEST_ARM32'] && !matrix.container }}
         run: |
           sudo dpkg --add-architecture armhf
           sudo apt update
@@ -314,17 +316,11 @@ jobs:
             libcurl4-openssl-dev:armhf \
             liblzma-dev:armhf
 
-      - name: Cross-compile (arm32)
-        if: ${{ env['CROSS_ARM32'] }}
+      - name: Installing qemu-user
+        if: ${{ runner.os == 'Linux' && env['TEST_QEMU'] && !matrix.container }}
         run: |
-          cmake -B build \
-            -DCMAKE_SYSTEM_NAME=Linux \
-            -DCMAKE_SYSTEM_PROCESSOR=arm \
-            -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
-            -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ \
-            -DCMAKE_ASM_COMPILER=arm-linux-gnueabihf-gcc \
-            -DSENTRY_BACKEND=inproc
-          cmake --build build --parallel
+          sudo apt update
+          sudo apt install -y qemu-user-static binfmt-support
 
       - name: Installing Alpine Linux Dependencies
         if: ${{ contains(matrix.container, 'alpine') }}
@@ -465,7 +461,7 @@ jobs:
             pytest --capture=no --verbose tests
 
       - name: Test
-        if: ${{ !env['ANDROID_API'] && !env['CROSS_ARM32'] }}
+        if: ${{ !env['ANDROID_API'] }}
         shell: bash
         run: |
           pip install --upgrade --requirement tests/requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
             CC: gcc-9
             CXX: g++-9
             TEST_X86: 1
+          - name: Linux Arm32 (cross-compile)
+            os: ubuntu-24.04-arm
+            CC: arm-linux-gnueabihf-gcc
+            CXX: arm-linux-gnueabihf-g++
+            CROSS_ARM32: 1
           - name: Linux (GCC 9.5.0)
             os: ubuntu-24.04
             CC: gcc-9
@@ -223,6 +228,7 @@ jobs:
       CXX: ${{ matrix.CXX }}
       TEST_X86: ${{ matrix.TEST_X86 }}
       TEST_MINGW: ${{ matrix.TEST_MINGW }}
+      CROSS_ARM32: ${{ matrix.CROSS_ARM32 }}
       USE_SCCACHE: ${{ matrix.USE_SCCACHE }}
       SCCACHE_GHA_ENABLED: ${{ matrix.USE_SCCACHE && 'true' || '' }}
       ERROR_ON_WARNINGS: ${{ matrix.ERROR_ON_WARNINGS }}
@@ -258,7 +264,7 @@ jobs:
           [ -n "$CC" ] && [ -n "$CXX" ] || { echo "Ubuntu runner configurations require toolchain selection via CC and CXX" >&2; exit 1; }
 
       - name: Installing Linux Dependencies
-        if: ${{ runner.os == 'Linux' && !env['TEST_X86'] && !env['ANDROID_API'] && !matrix.container }}
+        if: ${{ runner.os == 'Linux' && !env['TEST_X86'] && !env['CROSS_ARM32'] && !env['ANDROID_API'] && !matrix.container }}
         run: |
           sudo apt update
           # Install common dependencies
@@ -294,6 +300,31 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt update
           sudo apt install cmake "${CC}-multilib" "${CXX}-multilib" zlib1g-dev:i386 libssl-dev:i386 libcurl4-openssl-dev:i386 liblzma-dev:i386
+
+      - name: Installing Linux arm32 Dependencies
+        if: ${{ runner.os == 'Linux' && env['CROSS_ARM32'] && !matrix.container }}
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo apt update
+          sudo apt install -y \
+            cmake \
+            gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+            zlib1g-dev:armhf \
+            libssl-dev:armhf \
+            libcurl4-openssl-dev:armhf \
+            liblzma-dev:armhf
+
+      - name: Cross-compile (arm32)
+        if: ${{ env['CROSS_ARM32'] }}
+        run: |
+          cmake -B build \
+            -DCMAKE_SYSTEM_NAME=Linux \
+            -DCMAKE_SYSTEM_PROCESSOR=arm \
+            -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
+            -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ \
+            -DCMAKE_ASM_COMPILER=arm-linux-gnueabihf-gcc \
+            -DSENTRY_BACKEND=inproc
+          cmake --build build --parallel
 
       - name: Installing Alpine Linux Dependencies
         if: ${{ contains(matrix.container, 'alpine') }}
@@ -434,7 +465,7 @@ jobs:
             pytest --capture=no --verbose tests
 
       - name: Test
-        if: ${{ !env['ANDROID_API'] }}
+        if: ${{ !env['ANDROID_API'] && !env['CROSS_ARM32'] }}
         shell: bash
         run: |
           pip install --upgrade --requirement tests/requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             CC: gcc-9
             CXX: g++-9
             TEST_X86: 1
-          - name: Linux Arm32 (cross-compile)
+          - name: Linux Arm32 (gcc-arm-linux-gnueabihf + qemu-user)
             os: ubuntu-24.04-arm
             CC: arm-linux-gnueabihf-gcc
             CXX: arm-linux-gnueabihf-g++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,8 @@ jobs:
             zlib1g-dev:armhf \
             libssl-dev:armhf \
             libcurl4-openssl-dev:armhf \
-            liblzma-dev:armhf
+            liblzma-dev:armhf \
+            libstdc++6:armhf
 
       - name: Installing qemu-user
         if: ${{ runner.os == 'Linux' && env['TEST_QEMU'] && !matrix.container }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 **Features**:
 
-- Linux: build vendored libunwind for 32-bit ARM. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+- Linux: support 32-bit ARM. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 
 **Fixes**:
 
 - Linux: handle `ENOSYS` in `read_safely` to fix empty module list in seccomp-restricted environments. ([#1655](https://github.com/getsentry/sentry-native/pull/1655))
 - macOS: avoid stdio deadlock in breakpad exception handler. ([#1656](https://github.com/getsentry/sentry-native/pull/1656))
+- Crashpad: build for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+- Native: build for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+- Inproc: build vendored libunwind for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 
 ## 0.13.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Linux: build vendored libunwind for 32-bit ARM. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+
 **Fixes**:
 
 - Linux: handle `ENOSYS` in `read_safely` to fix empty module list in seccomp-restricted environments. ([#1655](https://github.com/getsentry/sentry-native/pull/1655))

--- a/src/backends/native/minidump/sentry_minidump_format.h
+++ b/src/backends/native/minidump/sentry_minidump_format.h
@@ -308,10 +308,6 @@ typedef struct {
     uint32_t lr; // R14
     uint32_t pc; // R15
     uint32_t cpsr;
-    // VFP/NEON state (matches breakpad's MDRawContextARM / Microsoft's
-    // CONTEXT_ARM floating-point area). We don't populate these today
-    // but the layout needs to match what downstream minidump parsers
-    // (crashpad, rust-minidump, breakpad) expect when reading the stream.
     uint64_t fpscr;
     uint64_t fpregs[32]; // D0-D31
     uint32_t fpextra[8];

--- a/src/backends/native/minidump/sentry_minidump_format.h
+++ b/src/backends/native/minidump/sentry_minidump_format.h
@@ -304,10 +304,17 @@ PACKED_STRUCT_BEGIN
 typedef struct {
     uint32_t context_flags;
     uint32_t r[13]; // R0-R12
-    uint32_t sp;
-    uint32_t lr;
-    uint32_t pc;
+    uint32_t sp; // R13
+    uint32_t lr; // R14
+    uint32_t pc; // R15
     uint32_t cpsr;
+    // VFP/NEON state (matches breakpad's MDRawContextARM / Microsoft's
+    // CONTEXT_ARM floating-point area). We don't populate these today
+    // but the layout needs to match what downstream minidump parsers
+    // (crashpad, rust-minidump, breakpad) expect when reading the stream.
+    uint64_t fpscr;
+    uint64_t fpregs[32]; // D0-D31
+    uint32_t fpextra[8];
 } PACKED_ATTR minidump_context_arm_t;
 PACKED_STRUCT_END
 #endif

--- a/src/backends/native/minidump/sentry_minidump_linux.c
+++ b/src/backends/native/minidump/sentry_minidump_linux.c
@@ -273,6 +273,34 @@ ptrace_get_thread_registers(pid_t tid, ucontext_t *uctx)
         SENTRY_DEBUGF("ptrace(PTRACE_GETREGS) failed for thread %d: %s", tid,
             strerror(errno));
     }
+#    elif defined(__arm__)
+    struct user_regs regs;
+    if (ptrace(PTRACE_GETREGS, tid, NULL, &regs) == 0) {
+        // uregs[0..15] = R0..R15, uregs[16] = CPSR
+        uctx->uc_mcontext.arm_r0 = regs.uregs[0];
+        uctx->uc_mcontext.arm_r1 = regs.uregs[1];
+        uctx->uc_mcontext.arm_r2 = regs.uregs[2];
+        uctx->uc_mcontext.arm_r3 = regs.uregs[3];
+        uctx->uc_mcontext.arm_r4 = regs.uregs[4];
+        uctx->uc_mcontext.arm_r5 = regs.uregs[5];
+        uctx->uc_mcontext.arm_r6 = regs.uregs[6];
+        uctx->uc_mcontext.arm_r7 = regs.uregs[7];
+        uctx->uc_mcontext.arm_r8 = regs.uregs[8];
+        uctx->uc_mcontext.arm_r9 = regs.uregs[9];
+        uctx->uc_mcontext.arm_r10 = regs.uregs[10];
+        uctx->uc_mcontext.arm_fp = regs.uregs[11];
+        uctx->uc_mcontext.arm_ip = regs.uregs[12];
+        uctx->uc_mcontext.arm_sp = regs.uregs[13];
+        uctx->uc_mcontext.arm_lr = regs.uregs[14];
+        uctx->uc_mcontext.arm_pc = regs.uregs[15];
+        uctx->uc_mcontext.arm_cpsr = regs.uregs[16];
+        success = true;
+        SENTRY_DEBUGF("Thread %d: captured registers via ptrace, SP=0x%lx", tid,
+            (unsigned long)regs.uregs[13]);
+    } else {
+        SENTRY_DEBUGF("ptrace(PTRACE_GETREGS) failed for thread %d: %s", tid,
+            strerror(errno));
+    }
 #    endif
 
     // Detach from thread

--- a/src/backends/native/minidump/sentry_minidump_linux.c
+++ b/src/backends/native/minidump/sentry_minidump_linux.c
@@ -749,6 +749,34 @@ write_thread_context(
 
     return write_data(writer, &context, sizeof(context));
 
+#    elif defined(__arm__)
+    (void)tid; // Unused on ARM32 - no VFP capture implemented yet
+
+    minidump_context_arm_t context = { 0 };
+    // CONTEXT_ARM | CONTEXT_CONTROL | CONTEXT_INTEGER
+    context.context_flags = 0x00200003;
+
+    // Copy general purpose registers R0-R10 from Linux ucontext
+    context.r[0] = uctx->uc_mcontext.arm_r0;
+    context.r[1] = uctx->uc_mcontext.arm_r1;
+    context.r[2] = uctx->uc_mcontext.arm_r2;
+    context.r[3] = uctx->uc_mcontext.arm_r3;
+    context.r[4] = uctx->uc_mcontext.arm_r4;
+    context.r[5] = uctx->uc_mcontext.arm_r5;
+    context.r[6] = uctx->uc_mcontext.arm_r6;
+    context.r[7] = uctx->uc_mcontext.arm_r7;
+    context.r[8] = uctx->uc_mcontext.arm_r8;
+    context.r[9] = uctx->uc_mcontext.arm_r9;
+    context.r[10] = uctx->uc_mcontext.arm_r10;
+    context.r[11] = uctx->uc_mcontext.arm_fp; // R11 (FP)
+    context.r[12] = uctx->uc_mcontext.arm_ip; // R12 (IP)
+    context.sp = uctx->uc_mcontext.arm_sp;
+    context.lr = uctx->uc_mcontext.arm_lr;
+    context.pc = uctx->uc_mcontext.arm_pc;
+    context.cpsr = uctx->uc_mcontext.arm_cpsr;
+
+    return write_data(writer, &context, sizeof(context));
+
 #    else
 #        error "Unsupported architecture for Linux"
 #    endif

--- a/src/backends/native/minidump/sentry_minidump_linux.c
+++ b/src/backends/native/minidump/sentry_minidump_linux.c
@@ -1313,6 +1313,8 @@ ptrace_capture_thread(
     ptrace_sp = ptrace_ctx.uc_mcontext.sp;
 #    elif defined(__i386__)
     ptrace_sp = ptrace_ctx.uc_mcontext.gregs[REG_ESP];
+#    elif defined(__arm__)
+    ptrace_sp = ptrace_ctx.uc_mcontext.arm_sp;
 #    endif
 
     if (ptrace_sp != 0) {
@@ -1397,6 +1399,8 @@ write_thread_list_stream(minidump_writer_t *writer, minidump_directory_t *dir)
             sp = uctx->uc_mcontext.sp;
 #    elif defined(__i386__)
             sp = uctx->uc_mcontext.gregs[REG_ESP];
+#    elif defined(__arm__)
+            sp = uctx->uc_mcontext.arm_sp;
 #    endif
 
             SENTRY_DEBUGF("Thread %u: has context, SP=0x%llx",

--- a/src/backends/native/minidump/sentry_minidump_linux.c
+++ b/src/backends/native/minidump/sentry_minidump_linux.c
@@ -781,8 +781,9 @@ write_thread_context(
     (void)tid; // Unused on ARM32 - no VFP capture implemented yet
 
     minidump_context_arm_t context = { 0 };
-    // CONTEXT_ARM | CONTEXT_CONTROL | CONTEXT_INTEGER
-    context.context_flags = 0x00200003;
+    // MD_CONTEXT_ARM | CONTROL | INTEGER — breakpad-style 0x40000000 base
+    // (not Microsoft's 0x00200000; rust-minidump keys off the breakpad value)
+    context.context_flags = 0x40000003;
 
     // Copy general purpose registers R0-R10 from Linux ucontext
     context.r[0] = uctx->uc_mcontext.arm_r0;

--- a/tests/build_config.py
+++ b/tests/build_config.py
@@ -51,6 +51,16 @@ def get_platform_cmake_args():
         args.append("-AWin32")
     elif sys.platform == "linux" and os.environ.get("TEST_X86"):
         args.append("-DSENTRY_BUILD_FORCE32=ON")
+    elif sys.platform == "linux" and os.environ.get("TEST_ARM32"):
+        args.extend(
+            [
+                "-DCMAKE_SYSTEM_NAME=Linux",
+                "-DCMAKE_SYSTEM_PROCESSOR=arm",
+                "-DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc",
+                "-DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++",
+                "-DCMAKE_ASM_COMPILER=arm-linux-gnueabihf-gcc",
+            ]
+        )
 
     if "asan" in os.environ.get("RUN_ANALYZER", ""):
         args.append("-DWITH_ASAN_OPTION=ON")

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -37,7 +37,6 @@ has_crashpad = (
     and not is_android
     and not is_aix
     and not is_tsan
-    and not is_arm32
 )
 # android has no local filesystem
 has_files = not is_android

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -50,6 +50,6 @@ has_oom = sys.platform != "linux" and not is_asan and not is_valgrind
 # Native backend works on all platforms (lightweight, no external dependencies)
 # It's always available - tests explicitly set SENTRY_BACKEND: native in cmake
 # On macOS ASAN, the signal handling conflicts with ASAN's memory interception
-has_native = has_http and not (is_asan and sys.platform == "darwin")
+has_native = has_http and not (is_asan and sys.platform == "darwin") and not is_qemu
 
 has_sccache = os.environ.get("USE_SCCACHE") and shutil.which("sccache")

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -50,6 +50,6 @@ has_oom = sys.platform != "linux" and not is_asan and not is_valgrind
 # Native backend works on all platforms (lightweight, no external dependencies)
 # It's always available - tests explicitly set SENTRY_BACKEND: native in cmake
 # On macOS ASAN, the signal handling conflicts with ASAN's memory interception
-has_native = has_http and not (is_asan and sys.platform == "darwin") and not is_arm32
+has_native = has_http and not (is_asan and sys.platform == "darwin")
 
 has_sccache = os.environ.get("USE_SCCACHE") and shutil.which("sccache")

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -5,6 +5,8 @@ import shutil
 is_aix = sys.platform == "aix" or sys.platform == "os400"
 is_android = os.environ.get("ANDROID_API")
 is_x86 = os.environ.get("TEST_X86")
+is_arm32 = os.environ.get("TEST_ARM32")
+is_qemu = os.environ.get("TEST_QEMU")
 is_asan = "asan" in os.environ.get("RUN_ANALYZER", "")
 is_tsan = "tsan" in os.environ.get("RUN_ANALYZER", "")
 is_kcov = "kcov" in os.environ.get("RUN_ANALYZER", "")

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -37,6 +37,7 @@ has_crashpad = (
     and not is_android
     and not is_aix
     and not is_tsan
+    and not is_arm32
 )
 # android has no local filesystem
 has_files = not is_android
@@ -50,6 +51,6 @@ has_oom = sys.platform != "linux" and not is_asan and not is_valgrind
 # Native backend works on all platforms (lightweight, no external dependencies)
 # It's always available - tests explicitly set SENTRY_BACKEND: native in cmake
 # On macOS ASAN, the signal handling conflicts with ASAN's memory interception
-has_native = has_http and not (is_asan and sys.platform == "darwin")
+has_native = has_http and not (is_asan and sys.platform == "darwin") and not is_arm32
 
 has_sccache = os.environ.get("USE_SCCACHE") and shutil.which("sccache")

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -5,8 +5,8 @@ import shutil
 is_aix = sys.platform == "aix" or sys.platform == "os400"
 is_android = os.environ.get("ANDROID_API")
 is_x86 = os.environ.get("TEST_X86")
-is_arm32 = os.environ.get("TEST_ARM32")
-is_qemu = os.environ.get("TEST_QEMU")
+is_arm32 = bool(os.environ.get("TEST_ARM32"))
+is_qemu = bool(os.environ.get("TEST_QEMU"))
 is_asan = "asan" in os.environ.get("RUN_ANALYZER", "")
 is_tsan = "tsan" in os.environ.get("RUN_ANALYZER", "")
 is_kcov = "kcov" in os.environ.get("RUN_ANALYZER", "")

--- a/tests/conditions.py
+++ b/tests/conditions.py
@@ -50,6 +50,6 @@ has_oom = sys.platform != "linux" and not is_asan and not is_valgrind
 # Native backend works on all platforms (lightweight, no external dependencies)
 # It's always available - tests explicitly set SENTRY_BACKEND: native in cmake
 # On macOS ASAN, the signal handling conflicts with ASAN's memory interception
-has_native = has_http and not (is_asan and sys.platform == "darwin") and not is_qemu
+has_native = has_http and not (is_asan and sys.platform == "darwin")
 
 has_sccache = os.environ.get("USE_SCCACHE") and shutil.which("sccache")

--- a/tests/test_build_static.py
+++ b/tests/test_build_static.py
@@ -2,7 +2,7 @@ import subprocess
 import sys
 import os
 import pytest
-from .conditions import has_breakpad, has_crashpad, has_native, is_android
+from .conditions import has_breakpad, has_crashpad, has_native, is_android, is_qemu
 
 
 def test_static_lib(cmake):
@@ -16,7 +16,7 @@ def test_static_lib(cmake):
     )
 
     # on linux we can use `ldd` to check that we don’t link to `libsentry.so`
-    if sys.platform == "linux" and not is_android:
+    if sys.platform == "linux" and not is_android and not is_qemu:
         output = subprocess.check_output("ldd sentry_example", cwd=tmp_path, shell=True)
         assert b"libsentry.so" not in output
 
@@ -40,9 +40,8 @@ def test_static_lib(cmake):
         output = subprocess.check_output(
             "file sentry_example", cwd=tmp_path, shell=True
         )
-        assert (
-            b"ELF 32-bit" if os.environ.get("TEST_X86") else b"ELF 64-bit"
-        ) in output
+        is_32bit = os.environ.get("TEST_X86") or os.environ.get("TEST_ARM32")
+        assert (b"ELF 32-bit" if is_32bit else b"ELF 64-bit") in output
 
 
 @pytest.mark.skipif(not has_crashpad, reason="test needs crashpad backend")

--- a/tests/test_dotnet_signals.py
+++ b/tests/test_dotnet_signals.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 from tests import adb
-from tests.conditions import is_android, is_tsan, is_x86, is_asan
+from tests.conditions import is_android, is_arm32, is_tsan, is_x86, is_asan
 
 project_fixture_path = pathlib.Path("tests/fixtures/dotnet_signal")
 
@@ -67,7 +67,14 @@ def run_dotnet_native_crash(tmp_path):
 
 
 @pytest.mark.skipif(
-    bool(sys.platform != "linux" or is_x86 or is_asan or is_tsan or is_android),
+    bool(
+        sys.platform != "linux"
+        or is_x86
+        or is_arm32
+        or is_asan
+        or is_tsan
+        or is_android
+    ),
     reason="dotnet signal handling is currently only supported on 64-bit Linux without sanitizers",
 )
 def test_dotnet_signals_inproc(cmake):
@@ -171,7 +178,14 @@ def run_aot_native_crash(tmp_path):
 
 
 @pytest.mark.skipif(
-    bool(sys.platform != "linux" or is_x86 or is_asan or is_tsan or is_android),
+    bool(
+        sys.platform != "linux"
+        or is_x86
+        or is_arm32
+        or is_asan
+        or is_tsan
+        or is_android
+    ),
     reason="dotnet AOT signal handling is currently only supported on 64-bit Linux without sanitizers",
 )
 def test_aot_signals_inproc(cmake):

--- a/tests/test_embedded_info.py
+++ b/tests/test_embedded_info.py
@@ -88,6 +88,7 @@ def test_embedded_info_binary_inspection(cmake):
     cwd = cmake(
         ["sentry"],  # Build the library itself
         {
+            "SENTRY_BACKEND": "none",
             "SENTRY_EMBED_INFO": "ON",
             "SENTRY_BUILD_PLATFORM": "binary-test",
             "SENTRY_BUILD_VARIANT": "inspection",
@@ -157,6 +158,7 @@ def test_sdk_version_override(cmake):
     cwd = cmake(
         ["sentry"],
         {
+            "SENTRY_BACKEND": "none",
             "SENTRY_EMBED_INFO": "ON",
             "SENTRY_BUILD_PLATFORM": "version-test",
             "SENTRY_BUILD_VARIANT": "override",
@@ -204,6 +206,7 @@ def test_sdk_version_override_with_explicit_build_id(cmake):
     cwd = cmake(
         ["sentry"],
         {
+            "SENTRY_BACKEND": "none",
             "SENTRY_EMBED_INFO": "ON",
             "SENTRY_BUILD_PLATFORM": "version-test",
             "SENTRY_BUILD_VARIANT": "explicit-build",

--- a/tests/test_integration_cache.py
+++ b/tests/test_integration_cache.py
@@ -3,7 +3,7 @@ import time
 import pytest
 
 from . import run
-from .conditions import has_breakpad, has_files, has_http
+from .conditions import has_breakpad, has_files, has_http, is_qemu
 
 pytestmark = [
     pytest.mark.skipif(not has_files, reason="tests need local filesystem"),
@@ -19,7 +19,7 @@ pytestmark = [
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],
@@ -67,7 +67,7 @@ def test_cache_keep(cmake, backend, cache_keep, unreachable_dsn):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],
@@ -121,7 +121,7 @@ def test_cache_max_size(cmake, backend, unreachable_dsn):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],
@@ -176,7 +176,7 @@ def test_cache_max_age(cmake, backend, unreachable_dsn):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],
@@ -216,7 +216,7 @@ def test_cache_max_items(cmake, backend, unreachable_dsn):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -16,7 +16,7 @@ from . import (
     is_logs_envelope,
     is_feedback_envelope,
 )
-from .conditions import has_crashpad, has_oom, is_qemu
+from .conditions import has_crashpad, has_oom
 from .proxy import (
     setup_proxy_env_vars,
     cleanup_proxy_env_vars,
@@ -44,7 +44,6 @@ pytestmark = pytest.mark.skipif(
 flushes_state = sys.platform != "darwin"
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_capture(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -76,7 +75,6 @@ def _setup_crashpad_proxy_test(cmake, httpserver, proxy):
     return env, proxy_process, tmp_path, port
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_crash_proxy_env(cmake, httpserver):
     if not shutil.which("mitmdump"):
         pytest.skip("mitmdump is not installed")
@@ -131,7 +129,6 @@ def test_crashpad_crash_proxy_env_port_incorrect(cmake, httpserver):
         proxy_test_finally(0, httpserver, proxy_process)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_proxy_set_empty(cmake, httpserver):
     if not shutil.which("mitmdump"):
         pytest.skip("mitmdump is not installed")
@@ -162,7 +159,6 @@ def test_crashpad_proxy_set_empty(cmake, httpserver):
         proxy_test_finally(1, httpserver, proxy_process, expected_proxy_logsize=0)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_proxy_https_not_http(cmake, httpserver):
     if not shutil.which("mitmdump"):
         pytest.skip("mitmdump is not installed")
@@ -238,7 +234,6 @@ def test_crashpad_crash_proxy(cmake, httpserver, run_args, proxy_running):
         proxy_test_finally(expected_logsize, httpserver, proxy_process)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_reinstall(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -347,7 +342,6 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
     assert wait_for_no_werfault()
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "run_args,build_args",
     [
@@ -445,7 +439,6 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     assert wait_for_file(minidump)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "stack_size",
     [
@@ -543,7 +536,6 @@ def test_crashpad_oom(cmake, httpserver):
     assert_crashpad_upload(multipart)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
@@ -621,7 +613,6 @@ def test_crashpad_crash_after_shutdown(cmake, httpserver):
     assert_crashpad_upload(httpserver.log[0][0])
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
 def test_crashpad_dump_inflight(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -647,7 +638,6 @@ def test_crashpad_dump_inflight(cmake, httpserver):
     assert len(httpserver.log) >= 11
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
 def test_crashpad_logs_on_crash(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -680,7 +670,6 @@ def test_crashpad_logs_on_crash(cmake, httpserver):
     assert_logs(logs_envelope, 1)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
 def test_crashpad_logs_and_session_on_crash(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -717,7 +706,6 @@ def test_crashpad_logs_and_session_on_crash(cmake, httpserver):
     assert session_envelope is not None
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_disable_backend(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -770,7 +758,6 @@ def test_crashpad_retry(cmake, httpserver):
     assert len(httpserver.log) == 1
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "run_args",
     [
@@ -828,7 +815,6 @@ def test_crashpad_external_crash_reporter_wer(cmake, httpserver, run_args):
     test_crashpad_external_crash_reporter(cmake, httpserver, run_args)
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize("cache_keep", [True, False])
 def test_crashpad_cache_keep(cmake, httpserver, cache_keep):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -880,7 +866,6 @@ def test_crashpad_cache_keep(cmake, httpserver, cache_keep):
         assert cache_files[0].stem == dmp_files[0].stem
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_cache_max_size(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
     cache_dir = tmp_path.joinpath(".sentry-native/cache")
@@ -937,7 +922,6 @@ def test_crashpad_cache_max_size(cmake, httpserver):
     assert sum(f.stat().st_size for f in cache_files) <= 4 * 1024 * 1024
 
 
-@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_cache_max_age(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
     cache_dir = tmp_path.joinpath(".sentry-native/cache")

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -16,7 +16,7 @@ from . import (
     is_logs_envelope,
     is_feedback_envelope,
 )
-from .conditions import has_crashpad, has_oom
+from .conditions import has_crashpad, has_oom, is_qemu
 from .proxy import (
     setup_proxy_env_vars,
     cleanup_proxy_env_vars,
@@ -44,6 +44,7 @@ pytestmark = pytest.mark.skipif(
 flushes_state = sys.platform != "darwin"
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_capture(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -75,6 +76,7 @@ def _setup_crashpad_proxy_test(cmake, httpserver, proxy):
     return env, proxy_process, tmp_path, port
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_crash_proxy_env(cmake, httpserver):
     if not shutil.which("mitmdump"):
         pytest.skip("mitmdump is not installed")
@@ -129,6 +131,7 @@ def test_crashpad_crash_proxy_env_port_incorrect(cmake, httpserver):
         proxy_test_finally(0, httpserver, proxy_process)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_proxy_set_empty(cmake, httpserver):
     if not shutil.which("mitmdump"):
         pytest.skip("mitmdump is not installed")
@@ -159,6 +162,7 @@ def test_crashpad_proxy_set_empty(cmake, httpserver):
         proxy_test_finally(1, httpserver, proxy_process, expected_proxy_logsize=0)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_proxy_https_not_http(cmake, httpserver):
     if not shutil.which("mitmdump"):
         pytest.skip("mitmdump is not installed")
@@ -234,6 +238,7 @@ def test_crashpad_crash_proxy(cmake, httpserver, run_args, proxy_running):
         proxy_test_finally(expected_logsize, httpserver, proxy_process)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_reinstall(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -342,6 +347,7 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
     assert wait_for_no_werfault()
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "run_args,build_args",
     [
@@ -439,6 +445,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     assert wait_for_file(minidump)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "stack_size",
     [
@@ -536,6 +543,7 @@ def test_crashpad_oom(cmake, httpserver):
     assert_crashpad_upload(multipart)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
@@ -613,6 +621,7 @@ def test_crashpad_crash_after_shutdown(cmake, httpserver):
     assert_crashpad_upload(httpserver.log[0][0])
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
 def test_crashpad_dump_inflight(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -638,6 +647,7 @@ def test_crashpad_dump_inflight(cmake, httpserver):
     assert len(httpserver.log) >= 11
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
 def test_crashpad_logs_on_crash(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -670,6 +680,7 @@ def test_crashpad_logs_on_crash(cmake, httpserver):
     assert_logs(logs_envelope, 1)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.skipif(not flushes_state, reason="test needs state flushing")
 def test_crashpad_logs_and_session_on_crash(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -706,6 +717,7 @@ def test_crashpad_logs_and_session_on_crash(cmake, httpserver):
     assert session_envelope is not None
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_disable_backend(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -758,6 +770,7 @@ def test_crashpad_retry(cmake, httpserver):
     assert len(httpserver.log) == 1
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "run_args",
     [
@@ -815,6 +828,7 @@ def test_crashpad_external_crash_reporter_wer(cmake, httpserver, run_args):
     test_crashpad_external_crash_reporter(cmake, httpserver, run_args)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize("cache_keep", [True, False])
 def test_crashpad_cache_keep(cmake, httpserver, cache_keep):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
@@ -866,6 +880,7 @@ def test_crashpad_cache_keep(cmake, httpserver, cache_keep):
         assert cache_files[0].stem == dmp_files[0].stem
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_cache_max_size(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
     cache_dir = tmp_path.joinpath(".sentry-native/cache")
@@ -922,6 +937,7 @@ def test_crashpad_cache_max_size(cmake, httpserver):
     assert sum(f.stat().st_size for f in cache_files) <= 4 * 1024 * 1024
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_crashpad_cache_max_age(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
     cache_dir = tmp_path.joinpath(".sentry-native/cache")

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -811,7 +811,7 @@ def test_discarding_before_breadcrumb_http(cmake, httpserver):
 
 
 @pytest.mark.skipif(is_kcov, reason="kcov exits with 0 even when the process crashes")
-@pytest.mark.skipif(not has_native, reason="test needs native backend")
+@pytest.mark.skipif(not has_native or is_qemu, reason="test needs native backend")
 def test_native_crash_http(cmake, httpserver):
     """Test native backend crash handling with HTTP transport"""
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -33,7 +33,15 @@ from .assertions import (
     assert_before_breadcrumb,
     assert_no_breadcrumbs,
 )
-from .conditions import has_http, has_breakpad, has_native, has_files, is_kcov, is_asan
+from .conditions import (
+    has_http,
+    has_breakpad,
+    has_native,
+    has_files,
+    is_kcov,
+    is_asan,
+    is_qemu,
+)
 
 
 def get_asan_crash_env(env):
@@ -67,6 +75,7 @@ auth_header = (
 # fmt: on
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 @pytest.mark.parametrize(
     "build_args",
     [
@@ -298,7 +307,7 @@ def test_user_report_http(cmake, httpserver):
         pytest.param(
             {"SENTRY_BACKEND": "breakpad"},
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="test needs breakpad backend"
+                not has_breakpad or is_qemu, reason="test needs breakpad backend"
             ),
         ),
     ],
@@ -351,6 +360,7 @@ def test_external_crash_reporter_http(cmake, httpserver, build_args):
     assert_user_feedback(envelope)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_exception_and_session_http(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
 
@@ -535,7 +545,7 @@ def test_inproc_dump_inflight(cmake, httpserver):
     assert len(httpserver.log) >= 11
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 @pytest.mark.parametrize(
     "build_args",
     [
@@ -589,7 +599,7 @@ def test_breakpad_crash_http(cmake, httpserver, build_args):
     assert_minidump(envelope)
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 def test_breakpad_reinstall(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "breakpad"})
 
@@ -617,7 +627,7 @@ def test_breakpad_reinstall(cmake, httpserver):
     assert len(httpserver.log) == 1
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 @flaky(max_runs=3)
 def test_breakpad_dump_inflight(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "breakpad"})

--- a/tests/test_integration_logger.py
+++ b/tests/test_integration_logger.py
@@ -7,7 +7,7 @@ import pytest
 import os
 
 from . import run
-from .conditions import has_breakpad, has_crashpad, has_native, is_android
+from .conditions import has_breakpad, has_crashpad, has_native, is_android, is_qemu
 
 
 def _run_logger_crash_test(backend, cmake, logger_option):
@@ -108,7 +108,7 @@ def parse_logger_output(output):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
         pytest.param(
@@ -162,7 +162,7 @@ def test_logger_enabled_when_crashed(backend, cmake):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
         pytest.param(

--- a/tests/test_integration_logger.py
+++ b/tests/test_integration_logger.py
@@ -127,7 +127,7 @@ def parse_logger_output(output):
             "native",
             marks=[
                 pytest.mark.skipif(
-                    not has_native, reason="native backend not available"
+                    not has_native or is_qemu, reason="native backend not available"
                 ),
             ],
         ),
@@ -175,7 +175,7 @@ def test_logger_enabled_when_crashed(backend, cmake):
             "native",
             marks=[
                 pytest.mark.skipif(
-                    not has_native, reason="native backend not available"
+                    not has_native or is_qemu, reason="native backend not available"
                 ),
             ],
         ),

--- a/tests/test_integration_logs.py
+++ b/tests/test_integration_logs.py
@@ -14,7 +14,7 @@ from .assertions import (
     assert_event,
     assert_logs,
 )
-from .conditions import has_http, has_breakpad, has_native
+from .conditions import has_http, has_breakpad, has_native, is_qemu
 
 pytestmark = pytest.mark.skipif(not has_http, reason="tests need http")
 
@@ -227,7 +227,7 @@ def test_logs_on_crash_none(cmake, httpserver):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],

--- a/tests/test_integration_logs.py
+++ b/tests/test_integration_logs.py
@@ -268,7 +268,7 @@ def test_logs_on_crash(cmake, httpserver, backend):
     assert_logs(logs_envelope, 1)
 
 
-@pytest.mark.skipif(not has_native, reason="test needs native backend")
+@pytest.mark.skipif(not has_native or is_qemu, reason="test needs native backend")
 @pytest.mark.parametrize("rerun", [True, False], ids=["rerun", "no-rerun"])
 def test_logs_on_crash_native(cmake, httpserver, rerun):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})

--- a/tests/test_integration_metrics.py
+++ b/tests/test_integration_metrics.py
@@ -14,7 +14,7 @@ from .assertions import (
     assert_event,
     assert_metrics,
 )
-from .conditions import has_http, has_breakpad, has_native
+from .conditions import has_http, has_breakpad, has_native, is_qemu
 
 pytestmark = pytest.mark.skipif(not has_http, reason="tests need http")
 
@@ -380,7 +380,7 @@ def test_metrics_on_crash_none(cmake, httpserver):
         pytest.param(
             "breakpad",
             marks=pytest.mark.skipif(
-                not has_breakpad, reason="breakpad backend not available"
+                not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
     ],

--- a/tests/test_integration_metrics.py
+++ b/tests/test_integration_metrics.py
@@ -421,7 +421,7 @@ def test_metrics_on_crash(cmake, httpserver, backend):
     assert_metrics(metrics_envelope, 1)
 
 
-@pytest.mark.skipif(not has_native, reason="test needs native backend")
+@pytest.mark.skipif(not has_native or is_qemu, reason="test needs native backend")
 @pytest.mark.parametrize("rerun", [True, False], ids=["rerun", "no-rerun"])
 def test_metrics_on_crash_native(cmake, httpserver, rerun):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -25,10 +25,10 @@ from .assertions import (
     wait_for_file,
     assert_user_feedback,
 )
-from .conditions import has_native, has_oom, is_kcov, is_asan
+from .conditions import has_native, has_oom, is_kcov, is_asan, is_qemu
 
 pytestmark = pytest.mark.skipif(
-    not has_native,
+    not has_native or is_qemu,
     reason="Tests need the native backend enabled",
 )
 

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -22,9 +22,10 @@ from .assertions import (
     assert_breakpad_crash,
     assert_exception,
 )
-from .conditions import has_breakpad, has_files
+from .conditions import has_breakpad, has_files, is_qemu
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_capture_stdout(cmake):
     tmp_path = cmake(
         ["sentry_example"],
@@ -185,6 +186,7 @@ def test_inproc_crash_stdout(cmake):
     assert_inproc_crash(envelope)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_inproc_abort_stdout(cmake):
     """Test that a normal abort() call is captured by inproc backend.
 
@@ -203,6 +205,7 @@ def test_inproc_abort_stdout(cmake):
     assert_inproc_crash(envelope)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_inproc_crash_stdout_before_send(cmake):
     tmp_path, output = run_crash_stdout_for("inproc", cmake, ["before-send"])
 
@@ -216,6 +219,7 @@ def test_inproc_crash_stdout_before_send(cmake):
     assert_before_send(envelope)
 
 
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
 def test_inproc_crash_stdout_discarding_on_crash(cmake):
     tmp_path, output = run_crash_stdout_for("inproc", cmake, ["discarding-on-crash"])
 
@@ -273,7 +277,7 @@ def test_inproc_stack_overflow_stdout(cmake, stack_size):
     assert_inproc_crash(envelope)
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout(cmake):
     tmp_path, output = run_crash_stdout_for("breakpad", cmake, [])
 
@@ -287,7 +291,7 @@ def test_breakpad_crash_stdout(cmake):
     assert_breakpad_crash(envelope)
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout_before_send(cmake):
     tmp_path, output = run_crash_stdout_for("breakpad", cmake, ["before-send"])
 
@@ -302,7 +306,7 @@ def test_breakpad_crash_stdout_before_send(cmake):
     assert_breakpad_crash(envelope)
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout_discarding_on_crash(cmake):
     tmp_path, output = run_crash_stdout_for("breakpad", cmake, ["discarding-on-crash"])
 
@@ -312,7 +316,7 @@ def test_breakpad_crash_stdout_discarding_on_crash(cmake):
     assert_crash_timestamp(has_files, tmp_path)
 
 
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
     tmp_path, output = run_crash_stdout_for(
         "breakpad", cmake, ["before-send", "on-crash"]
@@ -350,7 +354,7 @@ def test_breakpad_crash_stdout_before_send_and_on_crash(cmake):
         ),
     ],
 )
-@pytest.mark.skipif(not has_breakpad, reason="test needs breakpad backend")
+@pytest.mark.skipif(not has_breakpad or is_qemu, reason="test needs breakpad backend")
 def test_breakpad_stack_overflow_stdout(cmake, stack_size):
     env = dict(os.environ)
     if stack_size:

--- a/tests/unit/test_unwinder.c
+++ b/tests/unit/test_unwinder.c
@@ -1,6 +1,7 @@
 #include "sentry_boot.h"
 #include "sentry_symbolizer.h"
 #include "sentry_testsupport.h"
+#include <stdlib.h>
 
 #ifdef SENTRY_WITH_UNWINDER_LIBUNWIND
 #    include "unwinder/sentry_unwinder.h"
@@ -58,6 +59,9 @@ SENTRY_TEST(unwinder)
 #if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_XBOX)
     SKIP_TEST();
 #endif
+    if (getenv("TEST_QEMU")) {
+        SKIP_TEST();
+    }
 
     void *backtrace1[MAX_FRAMES] = { 0 };
     size_t frame_count1 = invoke_unwinder(backtrace1);

--- a/vendor/libunwind/CMakeLists.txt
+++ b/vendor/libunwind/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMakeLists.txt for vendored libunwind (Linux only, x86_64 and aarch64)
+# CMakeLists.txt for vendored libunwind (Linux only; x86_64, aarch64, x86, arm)
 # This builds only the local unwinding library (libunwind.a equivalent)
 
 # Vendored libunwind - built as a subdirectory of the main project.
@@ -22,6 +22,9 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
     set(UNWIND_ELF "elf64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86|x86")
     set(UNWIND_ARCH "x86")
+    set(UNWIND_ELF "elf32")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|ARM)")
+    set(UNWIND_ARCH "arm")
     set(UNWIND_ELF "elf32")
 else()
     message(FATAL_ERROR "Unsupported architecture for vendored libunwind: ${CMAKE_SYSTEM_PROCESSOR}")
@@ -158,6 +161,31 @@ elseif(UNWIND_ARCH STREQUAL "x86")
         ${LIBUNWIND_SRC}/x86/Lresume.c
         ${LIBUNWIND_SRC}/x86/Lstep.c
     )
+elseif(UNWIND_ARCH STREQUAL "arm")
+    set(UNWIND_ARCH_SOURCES
+        # common
+        ${LIBUNWIND_SRC}/arm/is_fpreg.c
+        ${LIBUNWIND_SRC}/arm/regname.c
+        # os_local (Linux)
+        ${LIBUNWIND_SRC}/arm/Los-linux.c
+        # arch-specific local
+        ${LIBUNWIND_SRC}/arm/getcontext.S
+        ${LIBUNWIND_SRC}/arm/Lapply_reg_state.c
+        ${LIBUNWIND_SRC}/arm/Lcreate_addr_space.c
+        ${LIBUNWIND_SRC}/arm/Lex_tables.c
+        ${LIBUNWIND_SRC}/arm/Lget_proc_info.c
+        ${LIBUNWIND_SRC}/arm/Lget_save_loc.c
+        ${LIBUNWIND_SRC}/arm/Lglobal.c
+        ${LIBUNWIND_SRC}/arm/Linit.c
+        ${LIBUNWIND_SRC}/arm/Linit_local.c
+        ${LIBUNWIND_SRC}/arm/Linit_remote.c
+        ${LIBUNWIND_SRC}/arm/Lregs.c
+        ${LIBUNWIND_SRC}/arm/Lreg_states_iterate.c
+        ${LIBUNWIND_SRC}/arm/Lresume.c
+        ${LIBUNWIND_SRC}/arm/Lstash_frame.c
+        ${LIBUNWIND_SRC}/arm/Lstep.c
+        ${LIBUNWIND_SRC}/arm/Ltrace.c
+    )
 endif()
 
 add_library(unwind STATIC
@@ -240,6 +268,9 @@ elseif(UNWIND_ARCH STREQUAL "aarch64")
 elseif(UNWIND_ARCH STREQUAL "x86")
     target_include_directories(unwind PRIVATE ${LIBUNWIND_INC}/tdep-x86)
     target_compile_definitions(unwind PRIVATE UNW_TARGET_X86=1)
+elseif(UNWIND_ARCH STREQUAL "arm")
+    target_include_directories(unwind PRIVATE ${LIBUNWIND_INC}/tdep-arm)
+    target_compile_definitions(unwind PRIVATE UNW_TARGET_ARM=1)
 endif()
 
 target_compile_definitions(unwind PRIVATE

--- a/vendor/libunwind/VENDORING.md
+++ b/vendor/libunwind/VENDORING.md
@@ -19,6 +19,7 @@ Linux without requiring users to install any external packages.  Only the
 | x86_64             | `src/x86_64/`  | `include/tdep-x86_64/`  |
 | x86 (i686, 32-bit) | `src/x86/`     | `include/tdep-x86/`     |
 | aarch64            | `src/aarch64/` | `include/tdep-aarch64/` |
+| arm (32-bit)       | `src/arm/`     | `include/tdep-arm/`     |
 
 Core shared code: `src/mi/`, `src/dwarf/`, `src/os-linux.c`,
 `src/dl-iterate-phdr.c`.
@@ -82,7 +83,6 @@ custom `CMakeLists.txt`:
 
 | Path                                                                                                     | Notes                                                                                                                                      |
 |----------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `src/arm/`, `include/tdep-arm/`                                                                          | ARM 32-bit — kept for potential future use                                                                                                 |
 | `src/riscv/`, `include/tdep-riscv/`                                                                      | RISC-V — kept for potential future use                                                                                                     |
 | `src/unwind/`, `src/mi/_ReadULEB.c`, `src/mi/_ReadSLEB.c`                                                | C++ exception ABI conflicts with `libgcc_eh.a`; see [above](#excluded-c-exception-abi-sources)                                             |
 | `include/libunwind-*.h` for removed arches                                                               | Referenced via `#ifdef` in `include/libunwind.h` — harmless dead code                                                                      |
@@ -163,7 +163,7 @@ both GCC and Clang.
      `__attribute__((aligned(...)))`.
    - Scan for other C11/C23 constructs incompatible with C99.
 
-7. Build and test on all three architectures: x86_64, x86 (32-bit), aarch64.
+7. Build and test on all four architectures: x86_64, x86 (32-bit), aarch64, arm (32-bit).
 
 8. To add a **new architecture**, also:
    - Keep its `src/<arch>/` and `include/tdep-<arch>/` directories from the


### PR DESCRIPTION
Adds 32-bit ARM support to Linux builds across all three affected components.

- `vendor/libunwind/CMakeLists.txt` gets an ARM branch that compiles the appropriate source set from `src/arm/` and `include/tdep-arm/`. Source list mirrors the upstream 1.8.3 `ARCH_ARM` block: https://github.com/libunwind/libunwind/blob/v1.8.3/src/Makefile.am#L481-L501

- `src/backends/native/minidump/sentry_minidump_linux.c` grows a `__arm__` branch in `write_thread_context` that maps the Linux ucontext into `minidump_context_arm_t`, following breakpad's `ucontext_reader.cc`. `CONTEXT_ARM` uses Microsoft's `0x00200000` numbering to match the other arches in the file.

- `external/crashpad` is bumped to pick up a one-character `%progbits` fix in `crashpad_info_note.S` — `@progbits` is silently dropped on ARM since `@` is the comment char there, which was causing the assembler to reject the rest of the `.section` directive.

<!--
The existing CI test matrix gets a "Linux Arm32 (gcc-arm-linux-gnueabihf + qemu-user)" entry on `ubuntu-24.04-arm`. armhf binaries aren't natively executable on the arm64 runner CPU, so `qemu-user-static` + `binfmt-support` dispatch them transparently. Crash-driven tests (most of `test_integration_native.py`, breakpad/native/crashpad-parametrized crash tests across `test_integration_{http,cache,logger,logs,metrics,stdout}.py`) are skipped under qemu because the daemon/signal coordination doesn't survive qemu's signal-frame emulation — that's tracked inline with `or is_qemu` on each `has_breakpad`/`has_native`/`has_crashpad` skipif; `has_*` themselves stay clean so build-only tests (`test_static_breakpad`, `test_static_crashpad`, `test_static_native`) keep running. On a real arm32 kernel none of these qemu-specific skips would apply.
-->

<!--
This PR adds an ARM branch to `vendor/libunwind/CMakeLists.txt` so Linux ARM (32-bit) targets compile the appropriate source set from `src/arm/` and `include tdep-arm/`. Source list mirrors the upstream 1.8.3 `ARCH_ARM` block: https://github.com/libunwind/libunwind/blob/v1.8.3/src/Makefile.am#L481-L501

Extend the existing CI test matrix with a `CROSS_ARM32` entry on `ubuntu-24.04-arm` using `gcc-arm-linux-gnueabihf` to cross-compile the inproc backend. The arm32 binaries are not executable on the arm64 runner, so this row skips pytest and runs a direct `cmake --build` against `SENTRY_BACKEND=inproc` instead. QEMU-user was considered but ruled out: its synthetic signal frames don't match the kernel layout that libunwind's signal-frame detection expects, so the crash/signal test paths would fail for qemu reasons rather than real arm32 issues.
-->

Close: #1587