### PR TITLE
fix(native): prevent shared memory leak on crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Crashpad: build for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 - Native: build for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 - Inproc: build vendored libunwind for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+- Native/Linux: prevent shared memory leak on crash. ([#1664](https://github.com/getsentry/sentry-native/pull/1664))
 
 ## 0.13.7
 

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3314,6 +3314,9 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
         }
         sentry_options_free(options);
     }
+    if (crash_processed || !is_parent_alive(ipc->parent_handle)) {
+        sentry__crash_ipc_unlink(ipc);
+    }
     sentry__crash_ipc_free(ipc);
 
     // Close log file

--- a/src/backends/native/sentry_crash_ipc.c
+++ b/src/backends/native/sentry_crash_ipc.c
@@ -269,6 +269,14 @@ sentry__crash_ipc_wait(sentry_crash_ipc_t *ipc, int timeout_ms)
 }
 
 void
+sentry__crash_ipc_unlink(sentry_crash_ipc_t *ipc)
+{
+    if (ipc && ipc->shm_name[0]) {
+        shm_unlink(ipc->shm_name);
+    }
+}
+
+void
 sentry__crash_ipc_free(sentry_crash_ipc_t *ipc)
 {
     if (!ipc) {
@@ -283,8 +291,8 @@ sentry__crash_ipc_free(sentry_crash_ipc_t *ipc)
         close(ipc->shm_fd);
     }
 
-    if (!ipc->is_daemon && ipc->shm_name[0]) {
-        shm_unlink(ipc->shm_name);
+    if (!ipc->is_daemon) {
+        sentry__crash_ipc_unlink(ipc);
     }
 
     if (ipc->notify_fd >= 0) {
@@ -546,6 +554,14 @@ sentry__crash_ipc_wait(sentry_crash_ipc_t *ipc, int timeout_ms)
 }
 
 void
+sentry__crash_ipc_unlink(sentry_crash_ipc_t *ipc)
+{
+    if (ipc && ipc->shm_path[0]) {
+        unlink(ipc->shm_path);
+    }
+}
+
+void
 sentry__crash_ipc_free(sentry_crash_ipc_t *ipc)
 {
     if (!ipc) {
@@ -576,8 +592,8 @@ sentry__crash_ipc_free(sentry_crash_ipc_t *ipc)
         close(ipc->ready_pipe[1]);
     }
 
-    if (!ipc->is_daemon && ipc->shm_path[0]) {
-        unlink(ipc->shm_path);
+    if (!ipc->is_daemon) {
+        sentry__crash_ipc_unlink(ipc);
     }
 
     sentry_free(ipc);
@@ -820,6 +836,12 @@ sentry__crash_ipc_wait(sentry_crash_ipc_t *ipc, int timeout_ms)
             GetLastError());
         return false;
     }
+}
+
+void
+sentry__crash_ipc_unlink(sentry_crash_ipc_t *ipc)
+{
+    (void)ipc;
 }
 
 void

--- a/src/backends/native/sentry_crash_ipc.h
+++ b/src/backends/native/sentry_crash_ipc.h
@@ -120,6 +120,11 @@ void sentry__crash_ipc_notify(sentry_crash_ipc_t *ipc);
 bool sentry__crash_ipc_wait(sentry_crash_ipc_t *ipc, int timeout_ms);
 
 /**
+ * Unlink the shared memory.
+ */
+void sentry__crash_ipc_unlink(sentry_crash_ipc_t *ipc);
+
+/**
  * Clean up IPC resources.
  */
 void sentry__crash_ipc_free(sentry_crash_ipc_t *ipc);


### PR DESCRIPTION
The native backend was leaking a `/dev/shm/s-<id>` entry per crash. The app's `sentry__crash_ipc_free` only unlinks during clean shutdown, and the daemon never unlinked. Under Docker's default 64 MB `/dev/shm`, a few dozen crashes fill the tmpfs and the next `memset` page-fault `SIGBUS`es silently. Surfaced in #1545, which adds more native crash tests.

Add `sentry__crash_ipc_unlink` and call it from the daemon's cleanup path when `crash_processed || !is_parent_alive`. The app keeps unlinking from its own `sentry__crash_ipc_free` via the existing `!is_daemon` guard, so it still owns the unlink during normal teardown.