### PR TITLE
fix(native): build on aarch64 with musl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Crashpad: build for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 - Native: build for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 - Inproc: build vendored libunwind for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
+- Native: build for 64-bit ARM on Linux with musl. ([#1665](https://github.com/getsentry/sentry-native/pull/1665))
 
 ## 0.13.7
 

--- a/src/backends/native/minidump/sentry_minidump_linux.c
+++ b/src/backends/native/minidump/sentry_minidump_linux.c
@@ -47,7 +47,8 @@ typedef struct {
 #        define FPSIMD_MAGIC 0x46508001
 
 // Only define these if not already provided by system headers
-#        ifndef __ASM_SIGCONTEXT_H
+// (on musl, defined in <bits/signal.h> instead).
+#        if !defined(__ASM_SIGCONTEXT_H) && defined(__GLIBC__)
 // Base header for context blocks in __reserved
 struct _aarch64_ctx {
     uint32_t magic;


### PR DESCRIPTION
Fixes the following compilation error on Alpine (MUSL) aarch64:
```
  [ 64%] Building C object CMakeFiles/sentry-crash.dir/src/backends/native/minidump/sentry_minidump_linux.c.o
  /src/src/backends/native/minidump/sentry_minidump_linux.c:52:8: error: redefinition of 'struct _aarch64_ctx'
     52 | struct _aarch64_ctx {
        |        ^~~~~~~~~~~~
  In file included from /usr/include/signal.h:48,
                   from /src/include/sentry.h:180,
                   from /src/src/sentry_boot.h:40,
                   from /src/src/backends/native/minidump/sentry_minidump_linux.c:1:
  /usr/include/bits/signal.h:29:8: note: originally defined here
     29 | struct _aarch64_ctx {
        |        ^~~~~~~~~~~~
  /src/src/backends/native/minidump/sentry_minidump_linux.c:58:8: error: redefinition of 'struct fpsimd_context'
     58 | struct fpsimd_context {
        |        ^~~~~~~~~~~~~~
  /usr/include/bits/signal.h:33:8: note: originally defined here
     33 | struct fpsimd_context {
        |        ^~~~~~~~~~~~~~
  gmake[3]: *** [CMakeFiles/sentry-crash.dir/build.make:751: CMakeFiles/sentry-crash.dir/src/backends/native/minidump/sentry_minidump_linux.c.o] Error 1
  gmake[2]: *** [CMakeFiles/Makefile2:170: CMakeFiles/sentry-crash.dir/all] Error 2
```