### PR TITLE
feat(native): enable the native backend on Xbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Enable experimental `native` backend on Xbox ([#1666](https://github.com/getsentry/sentry-native/pull/1666))
+
 **Fixes**:
 
 - Linux: handle `ENOSYS` in `read_safely` to fix empty module list in seccomp-restricted environments. ([#1655](https://github.com/getsentry/sentry-native/pull/1655))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Features**:
 
-- Enable experimental `native` backend on Xbox ([#1666](https://github.com/getsentry/sentry-native/pull/1666))
+- Enable experimental `native` backend on Xbox. ([#1666](https://github.com/getsentry/sentry-native/pull/1666))
 - Linux: support 32-bit ARM. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 
 **Fixes**:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,8 +202,12 @@ elseif(SENTRY_BACKEND_NATIVE)
 			${SECURITY_LIBRARY}
 		)
 	elseif(WIN32)
-		# Windows needs dbghelp for MiniDumpWriteDump
-		target_link_libraries(sentry PRIVATE dbghelp)
+		if(NOT XBOX)
+			# Windows needs dbghelp for MiniDumpWriteDump. On Xbox console
+			# MiniDumpWriteDump is supplied by xgameplatform.lib (linked by
+			# the Xbox toolchain as a standard library), so skip dbghelp.
+			target_link_libraries(sentry PRIVATE dbghelp)
+		endif()
 	endif()
 
 	# Enable C11 for atomics support

--- a/src/backends/native/minidump/sentry_minidump_windows.c
+++ b/src/backends/native/minidump/sentry_minidump_windows.c
@@ -15,7 +15,7 @@
  * On Xbox, MiniDumpWriteDump is provided by xgameplatform.lib
  * (linked by the Xbox toolchain), not dbghelp.lib.
  */
-#    if !defined(_GAMING_XBOX)
+#    if !defined(SENTRY_PLATFORM_XBOX)
 #        pragma comment(lib, "dbghelp.lib")
 #    endif
 

--- a/src/backends/native/minidump/sentry_minidump_windows.c
+++ b/src/backends/native/minidump/sentry_minidump_windows.c
@@ -11,9 +11,11 @@
 #    include "sentry_minidump_writer.h"
 #    include "sentry_string.h"
 
+/**
+ * On Xbox, MiniDumpWriteDump is provided by xgameplatform.lib
+ * (linked by the Xbox toolchain), not dbghelp.lib.
+ */
 #    if !defined(_GAMING_XBOX)
-// On Xbox console MiniDumpWriteDump is supplied by xgameplatform.lib
-// (linked by the Xbox toolchain), not dbghelp.lib.
 #        pragma comment(lib, "dbghelp.lib")
 #    endif
 

--- a/src/backends/native/minidump/sentry_minidump_windows.c
+++ b/src/backends/native/minidump/sentry_minidump_windows.c
@@ -11,7 +11,11 @@
 #    include "sentry_minidump_writer.h"
 #    include "sentry_string.h"
 
-#    pragma comment(lib, "dbghelp.lib")
+#    if !defined(_GAMING_XBOX)
+// On Xbox console MiniDumpWriteDump is supplied by xgameplatform.lib
+// (linked by the Xbox toolchain), not dbghelp.lib.
+#        pragma comment(lib, "dbghelp.lib")
+#    endif
 
 /**
  * Windows minidump writer

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3610,6 +3610,16 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 // When built as standalone executable, provide main entry point
 #ifdef SENTRY_CRASH_DAEMON_STANDALONE
 
+#    if defined(SENTRY_PLATFORM_XBOX)
+#        include <XGameRuntime.h>
+
+// Forward declared here; implemented by the downstream SDK (sentry-xbox's
+// sentry_transport_xbox.cpp) and linked into the daemon. The same contract
+// is already assumed by sentry_http_transport_winhttp.c under
+// SENTRY_PLATFORM_XBOX.
+extern bool sentry__xbox_ensure_network_initialized(void);
+#    endif
+
 int
 main(int argc, char **argv)
 {
@@ -3652,8 +3662,34 @@ main(int argc, char **argv)
     unsigned long long ready_event_val = strtoull(argv[4], NULL, 10);
     HANDLE event_handle = (HANDLE)(uintptr_t)event_handle_val;
     HANDLE ready_event_handle = (HANDLE)(uintptr_t)ready_event_val;
-    return sentry__crash_daemon_main(
+
+#        if defined(SENTRY_PLATFORM_XBOX)
+    // XGameRuntime must be initialized before any XGameRuntime / XNetworking
+    // API call. Without this, the Xbox transport's connectivity check fails
+    // and the daemon cannot upload crash reports.
+    HRESULT init_hr = XGameRuntimeInitialize();
+    if (FAILED(init_hr)) {
+        fprintf(stderr,
+            "sentry-crash: XGameRuntimeInitialize failed: 0x%08lX\n",
+            (unsigned long)init_hr);
+        return 1;
+    }
+    // Pre-warm XNetworking so the upload path inside the crash handler is
+    // fast. The parent's exception filter only waits up to
+    // SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS for the daemon to finish, and a
+    // cold XNetworking init can exceed that window — so pay the cost here,
+    // before the crash arrives. Failure is non-fatal; the transport's lazy
+    // init will retry.
+    (void)sentry__xbox_ensure_network_initialized();
+#        endif
+
+    int rv = sentry__crash_daemon_main(
         app_pid, app_tid, event_handle, ready_event_handle);
+
+#        if defined(SENTRY_PLATFORM_XBOX)
+    XGameRuntimeUninitialize();
+#        endif
+    return rv;
 #    else
     fprintf(stderr, "Platform not supported\n");
     return 1;

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3676,35 +3676,17 @@ main(int argc, char **argv)
     HANDLE ready_event_handle = (HANDLE)(uintptr_t)ready_event_val;
 
 #        if defined(SENTRY_PLATFORM_XBOX)
-    // XGameRuntime must be initialized before any XGameRuntime / XNetworking
-    // API call. Without this, the Xbox transport's connectivity check fails
-    // and the daemon cannot upload crash reports.
-    HRESULT init_hr = XGameRuntimeInitialize();
-    if (FAILED(init_hr)) {
-        fprintf(stderr,
-            "sentry-crash: XGameRuntimeInitialize failed: 0x%08lX\n",
-            (unsigned long)init_hr);
-        return 1;
-    }
-    // Pre-warm XNetworking on a detached thread so the daemon can enter
-    // sentry__crash_daemon_main() immediately and signal ready to the parent
-    // within SENTRY_CRASH_DAEMON_READY_TIMEOUT_MS. A cold XNetworking init
-    // can take up to 60s; running it inline would miss the deadline. The
-    // transport's send-time call to sentry__xbox_ensure_network_initialized
-    // will pick up (or race with, safely) the background warm-up result.
-    HANDLE prewarm_thread = CreateThread(
-        NULL, 0, sentry__xbox_network_prewarm_thread_proc, NULL, 0, NULL);
-    if (prewarm_thread) {
-        CloseHandle(prewarm_thread);
-    }
+    // DIAGNOSTIC: XGameRuntimeInitialize and the network pre-warm are
+    // temporarily removed to test whether one of them is blocking the
+    // daemon from reaching sentry__crash_daemon_main(). Without network
+    // init, the daemon won't be able to actually upload a crash envelope,
+    // but we should at least see the daemon's own log file appear in
+    // the database dir if IPC init succeeds. Restore before merge.
 #        endif
 
     int rv = sentry__crash_daemon_main(
         app_pid, app_tid, event_handle, ready_event_handle);
 
-#        if defined(SENTRY_PLATFORM_XBOX)
-    XGameRuntimeUninitialize();
-#        endif
     return rv;
 #    else
     fprintf(stderr, "Platform not supported\n");

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -1726,10 +1726,10 @@ get_thread_name(HANDLE hThread, sentry_thread_context_windows_t *tctx)
 static void
 enumerate_threads_from_process(sentry_crash_context_t *ctx)
 {
-#ifdef SENTRY_PLATFORM_XBOX
+#    ifdef SENTRY_PLATFORM_XBOX
     (void)ctx;
     return;
-#else
+#    else
     HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hSnapshot == INVALID_HANDLE_VALUE) {
         SENTRY_WARN("CreateToolhelp32Snapshot failed");
@@ -1826,7 +1826,7 @@ enumerate_threads_from_process(sentry_crash_context_t *ctx)
     ctx->platform.num_threads = thread_count;
     SENTRY_DEBUGF("Enumerated %u threads from process %d", thread_count,
         ctx->crashed_pid);
-#endif // SENTRY_PLATFORM_XBOX
+#    endif // SENTRY_PLATFORM_XBOX
 }
 #endif // SENTRY_PLATFORM_WINDOWS
 
@@ -3611,16 +3611,9 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 #ifdef SENTRY_CRASH_DAEMON_STANDALONE
 
 #    if defined(SENTRY_PLATFORM_XBOX)
-// Forward-declare the two XGameRuntime entry points we need rather than
-// #include <XGameRuntime.h> — that header (transitively) requires C++11
-// and the daemon is compiled as C.
 extern HRESULT XGameRuntimeInitialize(void);
 extern void XGameRuntimeUninitialize(void);
 
-// Forward declared here; implemented by the downstream SDK (sentry-xbox's
-// sentry_transport_xbox.cpp) and linked into the daemon. The same contract
-// is already assumed by sentry_http_transport_winhttp.c under
-// SENTRY_PLATFORM_XBOX.
 extern bool sentry__xbox_ensure_network_initialized(void);
 
 static DWORD WINAPI
@@ -3676,9 +3669,8 @@ main(int argc, char **argv)
     HANDLE ready_event_handle = (HANDLE)(uintptr_t)ready_event_val;
 
 #        if defined(SENTRY_PLATFORM_XBOX)
-    // XGameRuntime must be initialized before any XGameRuntime / XNetworking
-    // API call. Without this, the Xbox transport's connectivity check fails
-    // and the daemon cannot upload crash reports.
+    // Required before any XNetworking call the transport makes at
+    // crash-upload time.
     HRESULT init_hr = XGameRuntimeInitialize();
     if (FAILED(init_hr)) {
         fprintf(stderr,
@@ -3686,21 +3678,11 @@ main(int argc, char **argv)
             (unsigned long)init_hr);
         return 1;
     }
-    // Pre-warm XNetworking on a detached thread so the daemon can enter
-    // sentry__crash_daemon_main() immediately and signal ready to the parent
-    // within SENTRY_CRASH_DAEMON_READY_TIMEOUT_MS. Per GDK docs, network
-    // initialization "usually takes a couple of seconds on both resume and
-    // title launch and varies, based on console type and the user's network
-    // environment" — near-instant on dev kits but non-trivial on retail
-    // cold-boots (MS provides xbconfig NetworkInitDelayInSeconds up to 30s
-    // for simulating this). Running the warm-up inline would push the
-    // daemon's ready signal past the parent's timeout on retail hardware.
-    // The transport's send-time call to sentry__xbox_ensure_network_initialized
-    // will pick up (or race with, safely) the background warm-up result.
-    HANDLE prewarm_thread = CreateThread(
+
+    HANDLE network_prewarm_thread = CreateThread(
         NULL, 0, sentry__xbox_network_prewarm_thread_proc, NULL, 0, NULL);
-    if (prewarm_thread) {
-        CloseHandle(prewarm_thread);
+    if (network_prewarm_thread) {
+        CloseHandle(network_prewarm_thread);
     }
 #        endif
 

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -1717,10 +1717,19 @@ get_thread_name(HANDLE hThread, sentry_thread_context_windows_t *tctx)
 /**
  * Enumerate threads from the crashed process for the native event on Windows
  * Captures thread contexts for stack walking.
+ *
+ * Not available on Xbox (the ToolHelp32 API is not part of the gaming
+ * partition). MiniDumpWriteDump still captures all thread contexts from the
+ * target process independently, so skipping this only loses supplementary
+ * per-thread metadata from the Sentry event payload.
  */
 static void
 enumerate_threads_from_process(sentry_crash_context_t *ctx)
 {
+#ifdef SENTRY_PLATFORM_XBOX
+    (void)ctx;
+    return;
+#else
     HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
     if (hSnapshot == INVALID_HANDLE_VALUE) {
         SENTRY_WARN("CreateToolhelp32Snapshot failed");
@@ -1817,6 +1826,7 @@ enumerate_threads_from_process(sentry_crash_context_t *ctx)
     ctx->platform.num_threads = thread_count;
     SENTRY_DEBUGF("Enumerated %u threads from process %d", thread_count,
         ctx->crashed_pid);
+#endif // SENTRY_PLATFORM_XBOX
 }
 #endif // SENTRY_PLATFORM_WINDOWS
 

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -1726,7 +1726,7 @@ get_thread_name(HANDLE hThread, sentry_thread_context_windows_t *tctx)
 static void
 enumerate_threads_from_process(sentry_crash_context_t *ctx)
 {
-#    ifdef SENTRY_PLATFORM_XBOX
+#    if defined(SENTRY_PLATFORM_XBOX)
     (void)ctx;
     return;
 #    else

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3702,35 +3702,12 @@ main(int argc, char **argv)
     if (prewarm_thread) {
         CloseHandle(prewarm_thread);
     }
-
-    // Phase markers track whether main() is reached and whether
-    // sentry__crash_daemon_main() returns — the daemon's Sentry logger
-    // isn't available until after IPC init, so these pre-logger markers
-    // are the only way to observe early-startup failures from the outside.
-    char _diag_path[128];
-    snprintf(_diag_path, sizeof(_diag_path),
-        "D:\\Logs\\sentry-daemon-diag-%lu.log", (unsigned long)app_pid);
-    {
-        FILE *f = fopen(_diag_path, "w");
-        if (f) {
-            fprintf(f, "[A] main entered, app_pid=%lu app_tid=0x%llx\n",
-                (unsigned long)app_pid, (unsigned long long)app_tid);
-            fclose(f);
-        }
-    }
 #        endif
 
     int rv = sentry__crash_daemon_main(
         app_pid, app_tid, event_handle, ready_event_handle);
 
 #        if defined(SENTRY_PLATFORM_XBOX)
-    {
-        FILE *f = fopen(_diag_path, "a");
-        if (f) {
-            fprintf(f, "[B] daemon_main returned rv=%d\n", rv);
-            fclose(f);
-        }
-    }
     XGameRuntimeUninitialize();
 #        endif
     return rv;

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3678,15 +3678,37 @@ main(int argc, char **argv)
 #        if defined(SENTRY_PLATFORM_XBOX)
     // DIAGNOSTIC: XGameRuntimeInitialize and the network pre-warm are
     // temporarily removed to test whether one of them is blocking the
-    // daemon from reaching sentry__crash_daemon_main(). Without network
-    // init, the daemon won't be able to actually upload a crash envelope,
-    // but we should at least see the daemon's own log file appear in
-    // the database dir if IPC init succeeds. Restore before merge.
+    // daemon from reaching sentry__crash_daemon_main(). Restore before merge.
+    //
+    // Phase markers below track whether main() is reached and whether
+    // sentry__crash_daemon_main() returns, since the daemon's normal
+    // Sentry logger isn't available until after IPC init — and IPC init
+    // is the current suspect for the silent-exit behavior seen in Unreal.
+    char _diag_path[128];
+    snprintf(_diag_path, sizeof(_diag_path),
+        "D:\\Logs\\sentry-daemon-diag-%lu.log", (unsigned long)app_pid);
+    {
+        FILE *f = fopen(_diag_path, "w");
+        if (f) {
+            fprintf(f, "[A] main entered, app_pid=%lu app_tid=0x%llx\n",
+                (unsigned long)app_pid, (unsigned long long)app_tid);
+            fclose(f);
+        }
+    }
 #        endif
 
     int rv = sentry__crash_daemon_main(
         app_pid, app_tid, event_handle, ready_event_handle);
 
+#        if defined(SENTRY_PLATFORM_XBOX)
+    {
+        FILE *f = fopen(_diag_path, "a");
+        if (f) {
+            fprintf(f, "[B] daemon_main returned rv=%d\n", rv);
+            fclose(f);
+        }
+    }
+#        endif
     return rv;
 #    else
     fprintf(stderr, "Platform not supported\n");

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3681,15 +3681,17 @@ main(int argc, char **argv)
 
     HANDLE network_prewarm_thread = CreateThread(
         NULL, 0, sentry__xbox_network_prewarm_thread_proc, NULL, 0, NULL);
-    if (network_prewarm_thread) {
-        CloseHandle(network_prewarm_thread);
-    }
 #        endif
 
     int rv = sentry__crash_daemon_main(
         app_pid, app_tid, event_handle, ready_event_handle);
 
 #        if defined(SENTRY_PLATFORM_XBOX)
+    if (network_prewarm_thread) {
+        WaitForSingleObject(network_prewarm_thread, INFINITE);
+        CloseHandle(network_prewarm_thread);
+    }
+
     XGameRuntimeUninitialize();
 #        endif
     return rv;

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3622,6 +3622,14 @@ extern void XGameRuntimeUninitialize(void);
 // is already assumed by sentry_http_transport_winhttp.c under
 // SENTRY_PLATFORM_XBOX.
 extern bool sentry__xbox_ensure_network_initialized(void);
+
+static DWORD WINAPI
+sentry__xbox_network_prewarm_thread_proc(LPVOID param)
+{
+    (void)param;
+    (void)sentry__xbox_ensure_network_initialized();
+    return 0;
+}
 #    endif
 
 int
@@ -3678,13 +3686,17 @@ main(int argc, char **argv)
             (unsigned long)init_hr);
         return 1;
     }
-    // Pre-warm XNetworking so the upload path inside the crash handler is
-    // fast. The parent's exception filter only waits up to
-    // SENTRY_CRASH_HANDLER_WAIT_TIMEOUT_MS for the daemon to finish, and a
-    // cold XNetworking init can exceed that window — so pay the cost here,
-    // before the crash arrives. Failure is non-fatal; the transport's lazy
-    // init will retry.
-    (void)sentry__xbox_ensure_network_initialized();
+    // Pre-warm XNetworking on a detached thread so the daemon can enter
+    // sentry__crash_daemon_main() immediately and signal ready to the parent
+    // within SENTRY_CRASH_DAEMON_READY_TIMEOUT_MS. A cold XNetworking init
+    // can take up to 60s; running it inline would miss the deadline. The
+    // transport's send-time call to sentry__xbox_ensure_network_initialized
+    // will pick up (or race with, safely) the background warm-up result.
+    HANDLE prewarm_thread = CreateThread(
+        NULL, 0, sentry__xbox_network_prewarm_thread_proc, NULL, 0, NULL);
+    if (prewarm_thread) {
+        CloseHandle(prewarm_thread);
+    }
 #        endif
 
     int rv = sentry__crash_daemon_main(

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3611,7 +3611,11 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 #ifdef SENTRY_CRASH_DAEMON_STANDALONE
 
 #    if defined(SENTRY_PLATFORM_XBOX)
-#        include <XGameRuntime.h>
+// Forward-declare the two XGameRuntime entry points we need rather than
+// #include <XGameRuntime.h> — that header (transitively) requires C++11
+// and the daemon is compiled as C.
+extern HRESULT XGameRuntimeInitialize(void);
+extern void XGameRuntimeUninitialize(void);
 
 // Forward declared here; implemented by the downstream SDK (sentry-xbox's
 // sentry_transport_xbox.cpp) and linked into the daemon. The same contract

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3676,14 +3676,37 @@ main(int argc, char **argv)
     HANDLE ready_event_handle = (HANDLE)(uintptr_t)ready_event_val;
 
 #        if defined(SENTRY_PLATFORM_XBOX)
-    // DIAGNOSTIC: XGameRuntimeInitialize and the network pre-warm are
-    // temporarily removed to test whether one of them is blocking the
-    // daemon from reaching sentry__crash_daemon_main(). Restore before merge.
-    //
-    // Phase markers below track whether main() is reached and whether
-    // sentry__crash_daemon_main() returns, since the daemon's normal
-    // Sentry logger isn't available until after IPC init — and IPC init
-    // is the current suspect for the silent-exit behavior seen in Unreal.
+    // XGameRuntime must be initialized before any XGameRuntime / XNetworking
+    // API call. Without this, the Xbox transport's connectivity check fails
+    // and the daemon cannot upload crash reports.
+    HRESULT init_hr = XGameRuntimeInitialize();
+    if (FAILED(init_hr)) {
+        fprintf(stderr,
+            "sentry-crash: XGameRuntimeInitialize failed: 0x%08lX\n",
+            (unsigned long)init_hr);
+        return 1;
+    }
+    // Pre-warm XNetworking on a detached thread so the daemon can enter
+    // sentry__crash_daemon_main() immediately and signal ready to the parent
+    // within SENTRY_CRASH_DAEMON_READY_TIMEOUT_MS. Per GDK docs, network
+    // initialization "usually takes a couple of seconds on both resume and
+    // title launch and varies, based on console type and the user's network
+    // environment" — near-instant on dev kits but non-trivial on retail
+    // cold-boots (MS provides xbconfig NetworkInitDelayInSeconds up to 30s
+    // for simulating this). Running the warm-up inline would push the
+    // daemon's ready signal past the parent's timeout on retail hardware.
+    // The transport's send-time call to sentry__xbox_ensure_network_initialized
+    // will pick up (or race with, safely) the background warm-up result.
+    HANDLE prewarm_thread = CreateThread(
+        NULL, 0, sentry__xbox_network_prewarm_thread_proc, NULL, 0, NULL);
+    if (prewarm_thread) {
+        CloseHandle(prewarm_thread);
+    }
+
+    // Phase markers track whether main() is reached and whether
+    // sentry__crash_daemon_main() returns — the daemon's Sentry logger
+    // isn't available until after IPC init, so these pre-logger markers
+    // are the only way to observe early-startup failures from the outside.
     char _diag_path[128];
     snprintf(_diag_path, sizeof(_diag_path),
         "D:\\Logs\\sentry-daemon-diag-%lu.log", (unsigned long)app_pid);
@@ -3708,6 +3731,7 @@ main(int argc, char **argv)
             fclose(f);
         }
     }
+    XGameRuntimeUninitialize();
 #        endif
     return rv;
 #    else

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3611,8 +3611,10 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 #ifdef SENTRY_CRASH_DAEMON_STANDALONE
 
 #    if defined(SENTRY_PLATFORM_XBOX)
-extern HRESULT XGameRuntimeInitialize(void);
-extern void XGameRuntimeUninitialize(void);
+// Thin wrappers provided by sentry-xbox; the daemon doesn't link XGameRuntime
+// directly so these indirections keep all Xbox-platform coupling on that side.
+extern bool sentry__xbox_game_runtime_initialize(void);
+extern void sentry__xbox_game_runtime_uninitialize(void);
 
 extern bool sentry__xbox_ensure_network_initialized(void);
 
@@ -3671,11 +3673,7 @@ main(int argc, char **argv)
 #        if defined(SENTRY_PLATFORM_XBOX)
     // Required before any XNetworking call the transport makes at
     // crash-upload time.
-    HRESULT init_hr = XGameRuntimeInitialize();
-    if (FAILED(init_hr)) {
-        fprintf(stderr,
-            "sentry-crash: XGameRuntimeInitialize failed: 0x%08lX\n",
-            (unsigned long)init_hr);
+    if (!sentry__xbox_game_runtime_initialize()) {
         return 1;
     }
 
@@ -3692,7 +3690,7 @@ main(int argc, char **argv)
         CloseHandle(network_prewarm_thread);
     }
 
-    XGameRuntimeUninitialize();
+    sentry__xbox_game_runtime_uninitialize();
 #        endif
     return rv;
 #    else

--- a/src/backends/native/sentry_crash_ipc.c
+++ b/src/backends/native/sentry_crash_ipc.c
@@ -730,8 +730,20 @@ sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
     ipc->shm_handle
         = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, ipc->shm_name);
     if (!ipc->shm_handle) {
-        SENTRY_WARNF(
-            "daemon: failed to open shared memory: %lu", GetLastError());
+        DWORD _err = GetLastError();
+#if defined(SENTRY_PLATFORM_XBOX)
+        // DIAGNOSTIC: the daemon's sentry logger isn't wired up yet at
+        // this point, so failures here are otherwise invisible. Write
+        // directly to a known-writable path on Xbox.
+        FILE *_f = fopen("D:\\Logs\\sentry-ipc-diag.log", "a");
+        if (_f) {
+            fprintf(_f,
+                "OpenFileMappingW(shm) failed: GetLastError=%lu, name=%ls\n",
+                _err, ipc->shm_name);
+            fclose(_f);
+        }
+#endif
+        SENTRY_WARNF("daemon: failed to open shared memory: %lu", _err);
         sentry_free(ipc);
         return NULL;
     }
@@ -760,7 +772,17 @@ sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
 
     ipc->event_handle = OpenEventW(SYNCHRONIZE, FALSE, ipc->event_name);
     if (!ipc->event_handle) {
-        SENTRY_WARNF("daemon: failed to open event: %lu", GetLastError());
+        DWORD _err = GetLastError();
+#if defined(SENTRY_PLATFORM_XBOX)
+        FILE *_f = fopen("D:\\Logs\\sentry-ipc-diag.log", "a");
+        if (_f) {
+            fprintf(_f,
+                "OpenEventW(notify) failed: GetLastError=%lu, name=%ls\n",
+                _err, ipc->event_name);
+            fclose(_f);
+        }
+#endif
+        SENTRY_WARNF("daemon: failed to open event: %lu", _err);
         UnmapViewOfFile(ipc->shmem);
         CloseHandle(ipc->shm_handle);
         sentry_free(ipc);
@@ -774,7 +796,17 @@ sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
     ipc->ready_event_handle
         = OpenEventW(EVENT_MODIFY_STATE, FALSE, ipc->ready_event_name);
     if (!ipc->ready_event_handle) {
-        SENTRY_WARNF("daemon: failed to open ready event: %lu", GetLastError());
+        DWORD _err = GetLastError();
+#if defined(SENTRY_PLATFORM_XBOX)
+        FILE *_f = fopen("D:\\Logs\\sentry-ipc-diag.log", "a");
+        if (_f) {
+            fprintf(_f,
+                "OpenEventW(ready) failed: GetLastError=%lu, name=%ls\n",
+                _err, ipc->ready_event_name);
+            fclose(_f);
+        }
+#endif
+        SENTRY_WARNF("daemon: failed to open ready event: %lu", _err);
         CloseHandle(ipc->event_handle);
         UnmapViewOfFile(ipc->shmem);
         CloseHandle(ipc->shm_handle);

--- a/src/backends/native/sentry_crash_ipc.c
+++ b/src/backends/native/sentry_crash_ipc.c
@@ -730,20 +730,8 @@ sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
     ipc->shm_handle
         = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, ipc->shm_name);
     if (!ipc->shm_handle) {
-        DWORD _err = GetLastError();
-#if defined(SENTRY_PLATFORM_XBOX)
-        // DIAGNOSTIC: the daemon's sentry logger isn't wired up yet at
-        // this point, so failures here are otherwise invisible. Write
-        // directly to a known-writable path on Xbox.
-        FILE *_f = fopen("D:\\Logs\\sentry-ipc-diag.log", "a");
-        if (_f) {
-            fprintf(_f,
-                "OpenFileMappingW(shm) failed: GetLastError=%lu, name=%ls\n",
-                _err, ipc->shm_name);
-            fclose(_f);
-        }
-#endif
-        SENTRY_WARNF("daemon: failed to open shared memory: %lu", _err);
+        SENTRY_WARNF(
+            "daemon: failed to open shared memory: %lu", GetLastError());
         sentry_free(ipc);
         return NULL;
     }
@@ -772,17 +760,7 @@ sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
 
     ipc->event_handle = OpenEventW(SYNCHRONIZE, FALSE, ipc->event_name);
     if (!ipc->event_handle) {
-        DWORD _err = GetLastError();
-#if defined(SENTRY_PLATFORM_XBOX)
-        FILE *_f = fopen("D:\\Logs\\sentry-ipc-diag.log", "a");
-        if (_f) {
-            fprintf(_f,
-                "OpenEventW(notify) failed: GetLastError=%lu, name=%ls\n",
-                _err, ipc->event_name);
-            fclose(_f);
-        }
-#endif
-        SENTRY_WARNF("daemon: failed to open event: %lu", _err);
+        SENTRY_WARNF("daemon: failed to open event: %lu", GetLastError());
         UnmapViewOfFile(ipc->shmem);
         CloseHandle(ipc->shm_handle);
         sentry_free(ipc);
@@ -796,17 +774,7 @@ sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
     ipc->ready_event_handle
         = OpenEventW(EVENT_MODIFY_STATE, FALSE, ipc->ready_event_name);
     if (!ipc->ready_event_handle) {
-        DWORD _err = GetLastError();
-#if defined(SENTRY_PLATFORM_XBOX)
-        FILE *_f = fopen("D:\\Logs\\sentry-ipc-diag.log", "a");
-        if (_f) {
-            fprintf(_f,
-                "OpenEventW(ready) failed: GetLastError=%lu, name=%ls\n",
-                _err, ipc->ready_event_name);
-            fclose(_f);
-        }
-#endif
-        SENTRY_WARNF("daemon: failed to open ready event: %lu", _err);
+        SENTRY_WARNF("daemon: failed to open ready event: %lu", GetLastError());
         CloseHandle(ipc->event_handle);
         UnmapViewOfFile(ipc->shmem);
         CloseHandle(ipc->shm_handle);


### PR DESCRIPTION
## Summary

This PR enables the `native` (out-of-process) backend for the Xbox GDK (XSX, XboxOne) and WinGDK targets that previously fell back to `breakpad` by default and couldn't select `native` due to build-time link errors plus a handful of runtime-API usages incompatible with the Xbox gaming partition.

Now, `SENTRY_BACKEND=native` produces a working out-of-process daemon that spawns at `sentry_init`, captures minidumps via `MiniDumpWriteDump`, and uploads envelopes over WinHTTP on Xbox.

Enabler for https://github.com/getsentry/sentry-xbox/pull/128.

## Changes

### Build

- Skip the explicit `dbghelp.lib` link and the `#pragma comment(lib, "dbghelp.lib")` directive when targeting Xbox. On consoles, `MiniDumpWriteDump` is provided by `xgameplatform.lib` (via an API set), while the desktop `dbghelp.lib` is intentionally excluded by the Xbox toolchain’s `/NODEFAULTLIB` list. Verified via the Xbox GDK sample [`AdvancedExceptionHandling`](https://github.com/microsoft/Xbox-GDK-Samples/tree/main/Samples/System/AdvancedExceptionHandling), where XSX configurations link `$(Console_Libs)` (without `Dbghelp.lib`) and successfully call `MiniDumpWriteDump`.

### Thread enumeration

- Guard `enumerate_threads_from_process` with `SENTRY_PLATFORM_XBOX` - the ToolHelp32 API (`CreateToolhelp32Snapshot`, `THREADENTRY32`, `Thread32First/Next`) is not available in the Xbox gaming partition. `MiniDumpWriteDump` still captures all thread contexts from the target PID; the skipped code only populated supplementary per-thread metadata for the Sentry event payload.

### Daemon startup on Xbox

- Call `XGameRuntimeInitialize` at daemon `main` entry - required before any XNetworking calls made by the transport during crash upload. Pair with `XGameRuntimeUninitialize` on exit.
- Pre-warm XNetworking on a detached thread rather than inline. Per the [GDK docs on network initialization](https://learn.microsoft.com/en-us/gaming/gdk/docs/features/console/networking/initialization-connectivity-networking):

  > Network initialization usually takes a couple of seconds on both resume and title launch and varies based on console type and the user's network environment.

Running the warm-up inline could push the daemon’s ready signal past the parent’s `SENTRY_CRASH_DAEMON_READY_TIMEOUT_MS` window on retail cold boots; backgrounding keeps `sentry_init` fast while ensuring the network stack is typically ready by the time a crash occurs.

## Related items
- https://github.com/getsentry/sentry-xbox/pull/128