### PR TITLE
fix(native): Skip scope flush during crash handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Inproc: build vendored libunwind for 32-bit ARM on Linux. ([#1659](https://github.com/getsentry/sentry-native/issues/1659))
 - Native: build for 64-bit ARM on Linux with musl. ([#1665](https://github.com/getsentry/sentry-native/pull/1665))
 - Native/Linux: prevent shared memory leak on crash. ([#1664](https://github.com/getsentry/sentry-native/pull/1664))
+- Native: skip scope flush during crash handling. ([#1668](https://github.com/getsentry/sentry-native/pull/1668))
 
 ## 0.13.7
 

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -73,6 +73,7 @@ typedef struct {
     sentry_path_t *breadcrumb2_path;
     sentry_path_t *envelope_path;
     size_t num_breadcrumbs;
+    volatile long crashed;
 } native_backend_state_t;
 
 static int
@@ -570,7 +571,7 @@ native_backend_flush_scope(
     sentry_backend_t *backend, const sentry_options_t *UNUSED(options))
 {
     native_backend_state_t *state = (native_backend_state_t *)backend->data;
-    if (!state || !state->event_path) {
+    if (!state || !state->event_path || sentry__atomic_fetch(&state->crashed)) {
         return;
     }
 
@@ -804,6 +805,11 @@ native_backend_add_attachment(
 static void
 native_backend_except(sentry_backend_t *backend, const sentry_ucontext_t *uctx)
 {
+    native_backend_state_t *state = (native_backend_state_t *)backend->data;
+    if (state) {
+        sentry__atomic_store(&state->crashed, 1);
+    }
+
     SENTRY_WITH_OPTIONS (options) {
         // Disable logging during crash handling if configured
         if (!options->enable_logging_when_crashed) {
@@ -840,9 +846,6 @@ native_backend_except(sentry_backend_t *backend, const sentry_ucontext_t *uctx)
         }
 
         if (should_handle) {
-            native_backend_state_t *state
-                = (native_backend_state_t *)backend->data;
-
             // Apply before_send hook if on_crash wasn't set
             if (!options->on_crash_func && options->before_send_func) {
                 SENTRY_DEBUG("invoking `before_send` hook");


### PR DESCRIPTION
Came up in:
- https://github.com/getsentry/sentry-native/pull/1667#discussion_r3135657843

`native_backend_flush_scope` writes the current scope to `state->event_path` so the daemon has a fresh snapshot on crash. In the crash handler, however, any scope-mutating code path (e.g. `sentry__scope_apply_to_event` via `SENTRY_WITH_SCOPE_MUT`'s flush-on-unlock) invokes `flush_scope_func` while `native_backend_except` is already writing the real crash event to the same file. The intermediate writes are wasted (the final write overwrites them) and add unnecessary file I/O in crash context.

Mirror the crashpad backend's existing guard: add a `crashed` atomic flag on the state, set it at the entry of `except_func`, and check it in `flush_func` so the flush becomes a no-op for the duration of crash handling:

https://github.com/getsentry/sentry-native/blob/82dbf13a4b9a384da6d50cfd694e29feee47c408/src/backends/sentry_backend_crashpad.cpp#L265-L270