### PR TITLE
fix(native): Fix build-time warnings with C++ builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix event ownership (potential double-decref) in sentry_capture_minidump. ([#1669](https://github.com/getsentry/sentry-native/pull/1669))
 - Guard against internal stringbuilder append and reserve size overflows. ([#1672](https://github.com/getsentry/sentry-native/pull/1672))
 - Preserve attachments added during crash handling ([#1687](https://github.com/getsentry/sentry-native/pull/1687))
+- Fix build-time warnings with C++ builds. ([#1671](https://github.com/getsentry/sentry-native/pull/1671))
 
 ## 0.13.8
 

--- a/src/backends/native/minidump/sentry_minidump_linux.c
+++ b/src/backends/native/minidump/sentry_minidump_linux.c
@@ -544,7 +544,7 @@ write_system_info_stream(minidump_writer_t *writer, minidump_directory_t *dir)
 
     // Populate OS version from uname(), matching Crashpad behavior
     struct utsname uts;
-    char csd_version[256] = "";
+    char csd_version[512] = "";
     if (uname(&uts) == 0) {
         int major = 0, minor = 0, patch = 0;
         sscanf(uts.release, "%d.%d.%d", &major, &minor, &patch);

--- a/src/transports/sentry_http_transport.c
+++ b/src/transports/sentry_http_transport.c
@@ -257,7 +257,7 @@ static int
 retry_send_cb(sentry_envelope_t *envelope, void *_state)
 {
     http_transport_state_t *state = _state;
-    sentry_client_report_t report = { { 0 } };
+    sentry_client_report_t report = { 0 };
     if (state->send_client_reports
         && sentry__envelope_can_add_client_report(
             envelope, state->ratelimiter)) {
@@ -299,7 +299,7 @@ http_send_task(void *_envelope, void *_state)
     sentry_envelope_t *envelope = _envelope;
     http_transport_state_t *state = _state;
 
-    sentry_client_report_t report = { { 0 } };
+    sentry_client_report_t report = { 0 };
     if (state->send_client_reports
         && sentry__envelope_can_add_client_report(
             envelope, state->ratelimiter)) {


### PR DESCRIPTION
* Fix build-time warnings with C++ builds

---

Summed size of `utsname` fields could be larger than the 256 bytes we allow for the `csd_version` string. (see [linux/sysname.h](https://github.com/torvalds/linux/blob/master/include/uapi/linux/utsname.h#L17-L23)`). Thus we increase the size to fit these fields.


> _deps/sentry-build/CMakeFiles/sentry.dir/src/transports/sentry_http_transport.c.o
/home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/transports/sentry_http_transport.c: In function ‘retry_send_cb’:
/home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/transports/sentry_http_transport.c:258:37: warning: missing braces around initializer [-Wmissing-braces]
  258 |     sentry_client_report_t report = { { 0 } };
      |                                     ^
      |                                         { }
/home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/transports/sentry_http_transport.c: In function ‘http_send_task’:
/home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/transports/sentry_http_transport.c:305:37: warning: missing braces around initializer [-Wmissing-braces]
  305 |     sentry_client_report_t report = { { 0 } };
      |                                     ^
      |                                         { }

> /home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/backends/native/minidump/sentry_minidump_linux.c: In function ‘write_system_info_stream’:
> /home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/backends/native/minidump/sentry_minidump_linux.c:526:62: warning: ‘%s’ directive output may be truncated writing up to 64 bytes into a region of size between 61 and 253 [-Wformat-truncation=]
>   526 |         snprintf(csd_version, sizeof(csd_version), "%s %s %s %s", uts.sysname,
>       |                                                              ^~
>   527 |             uts.release, uts.version, uts.machine);
>       |                                       ~~~~~~~~~~~             
> /home/runner/work/teapot/teapot/build/debug/_deps/sentry-src/src/backends/native/minidump/sentry_minidump_linux.c:526:9: note: ‘snprintf’ output between 4 and 260 bytes into a destination of size 256
>   526 |         snprintf(csd_version, sizeof(csd_version), "%s %s %s %s", uts.sysname,
>       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>   527 |             uts.release, uts.version, uts.machine);
>       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~