### PR TITLE
fix(curl): trim HTTP response header values

### DIFF
--- a/src/transports/sentry_http_transport_curl.c
+++ b/src/transports/sentry_http_transport_curl.c
@@ -3,6 +3,7 @@
 #include "sentry_envelope.h"
 #include "sentry_http_transport.h"
 #include "sentry_options.h"
+#include "sentry_slice.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
 #include "sentry_transport.h"
@@ -155,10 +156,12 @@ header_callback(char *buffer, size_t size, size_t nitems, void *userdata)
     if (sep) {
         *sep = '\0';
         sentry__string_ascii_lower(header);
+        sentry_slice_t value
+            = sentry__slice_trim(sentry__slice_from_str(sep + 1));
         if (sentry__string_eq(header, "retry-after")) {
-            info->retry_after = sentry__string_clone(sep + 1);
+            info->retry_after = sentry__slice_to_owned(value);
         } else if (sentry__string_eq(header, "x-sentry-rate-limits")) {
-            info->x_sentry_rate_limits = sentry__string_clone(sep + 1);
+            info->x_sentry_rate_limits = sentry__slice_to_owned(value);
         }
     }
 


### PR DESCRIPTION
Fixes the CURL transport to trim whitespace around response header values (other transports parse HTTP headers correctly).

For example, `Retry-After: 60\r\n` was stored as `" 60\r\n"`. While this was harmless for existing numeric rate-limit headers because `strtoll()` ignores whitespace, it breaks string-valued headers. For example, TUS `Location`: `Location: /foo/bar\r\n` would be stored as `" /foo/bar\r\n"`, which is not a valid location.

Extracted from:
- #1545

#skip-changelog