### PR TITLE
fix(tests): skip unwinder QEMU getenv probe on PlayStation

### DIFF
--- a/tests/unit/test_unwinder.c
+++ b/tests/unit/test_unwinder.c
@@ -56,12 +56,14 @@ find_frame(const sentry_frame_info_t *info, void *data)
 
 SENTRY_TEST(unwinder)
 {
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_XBOX)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_XBOX)               \
+    || defined(SENTRY_PLATFORM_PS)
     SKIP_TEST();
-#endif
+#else
     if (getenv("TEST_QEMU")) {
         SKIP_TEST();
     }
+#endif
 
     void *backtrace1[MAX_FRAMES] = { 0 };
     size_t frame_count1 = invoke_unwinder(backtrace1);


### PR DESCRIPTION
This PR moves the `getenv("TEST_QEMU")` check in `tests/unit/test_unwinder.c` into the `#else` branch of the existing console-platform guard and adds `SENTRY_PLATFORM_PS` to that guard.

On Prospero (PS5), the toolchain doesn’t expose `getenv()` to test units in this configuration even with `<stdlib.h>` included. Because the call currently sits **after** the `#if NX || XBOX → SKIP_TEST(); #endif` guard, it still gets compiled on all platforms, leading to a hard error in downstream PS builds: https://github.com/getsentry/sentry-playstation/actions/runs/24922489037

Related items:
- #1659

#skip-changelog