### PR TITLE
fix: define SENTRY_SIGNAL_SAFE_LOG no-op fallback for non-Unix/Windows platforms

### DIFF
--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -74,6 +74,8 @@ void sentry__logger_disable(void);
                     NULL);                                                     \
             }                                                                  \
         } while (0)
+#else
+#    define SENTRY_SIGNAL_SAFE_LOG(msg) ((void)0)
 #endif
 
 #endif


### PR DESCRIPTION
#1656 introduced `SENTRY_SIGNAL_SAFE_LOG` with branches only for `SENTRY_PLATFORM_UNIX` and `SENTRY_PLATFORM_WINDOWS`.

Platforms outside that split (e.g. `SENTRY_PLATFORM_NX`) end up without a definition, causing call sites in
`sentry_batcher.c`, `sentry_logs.c`, and `sentry_metrics.c` to fail with `-Wimplicit-function-declaration`: https://github.com/getsentry/sentry-switch/actions/runs/24922498892/job/72986445104

This PR adds an `#else` branch with a `((void)0)` fallback so the SDK builds cleanly on platforms that don’t yet have a vetted
async-signal-safe stderr primitive. Behavior on Unix and Windows remains unchanged.

A proper NX implementation (e.g., via `svcOutputDebugString`) can follow later; this change simply unblocks the build.

Related items:
- #1656

#skip-changelog