### PR TITLE
feat(native): TUS upload for large attachments

### DIFF
--- a/src/backends/native/sentry_crash_context.h
+++ b/src/backends/native/sentry_crash_context.h
@@ -274,6 +274,7 @@ typedef struct {
     bool attach_screenshot; // Screenshot attachment enabled in parent process
     bool cache_keep;
     bool require_user_consent;
+    bool enable_large_attachments;
 
     // Atomic user consent (sentry_user_consent_t), updated whenever user
     // consent changes so the daemon can honor it at crash time.

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -281,8 +281,10 @@ add_attachment_refs(sentry_envelope_t *envelope,
             break;
         }
         materialized = true;
-        sentry__cache_attachment_refs(
-            envelope, &attachment, options, options->run->cache_path, NULL);
+        if (!sentry__cache_attachment_ref(
+                envelope, &attachment, options->run->cache_path, NULL)) {
+            SENTRY_WARN("failed to cache attachment-ref");
+        }
         sentry__path_free(attachment.path);
         sentry__path_free(attachment.filename);
     }

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3434,7 +3434,7 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
             dumped_envelopes = sentry__transport_dump_queue(
                 options->transport, options->run);
             if (rv == 0 && !dumped_envelopes && options->run) {
-                sentry__run_clean(options->run);
+                sentry__run_clean(options->run, true);
             }
         }
         sentry_options_free(options);

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -2,6 +2,7 @@
 
 #include "minidump/sentry_minidump_writer.h"
 #include "sentry_alloc.h"
+#include "sentry_attachment.h"
 #include "sentry_core.h"
 #include "sentry_crash_ipc.h"
 #include "sentry_database.h"
@@ -192,6 +193,100 @@ write_attachment_to_envelope(int fd, const char *file_path,
     _close(attach_fd);
 #endif
     return true;
+}
+
+static bool
+attachment_is_placeholder(const sentry_options_t *options, const char *path)
+{
+    sentry_attachment_t attachment = { 0 };
+    attachment.path = sentry__path_from_str(path);
+    if (!attachment.path) {
+        return false;
+    }
+    attachment.type = ATTACHMENT;
+    bool is_placeholder
+        = sentry__attachment_is_placeholder(&attachment, options);
+    sentry__path_free(attachment.path);
+    return is_placeholder;
+}
+
+// For each large attachment listed in `<run_folder>/__sentry-attachments`,
+// cache it as an attachment-ref item. Small attachments were already inlined
+// during envelope writing.
+static void
+add_attachment_refs(sentry_envelope_t *envelope,
+    const sentry_options_t *options, const sentry_path_t *run_folder)
+{
+    if (!envelope || !options || !options->run
+        || !options->enable_large_attachments || !run_folder) {
+        return;
+    }
+    sentry_path_t *attach_list_path
+        = sentry__path_join_str(run_folder, "__sentry-attachments");
+    if (!attach_list_path) {
+        SENTRY_WARN("Failed to resolve attachment manifest path");
+        return;
+    }
+    size_t attach_json_len = 0;
+    char *attach_json
+        = sentry__path_read_to_buffer(attach_list_path, &attach_json_len);
+    sentry__path_free(attach_list_path);
+    if (!attach_json) {
+        return;
+    }
+    sentry_value_t list = attach_json_len > 0
+        ? sentry__value_from_json(attach_json, attach_json_len)
+        : sentry_value_new_null();
+    sentry_free(attach_json);
+    if (sentry_value_is_null(list)) {
+        SENTRY_WARN("Failed to parse attachment manifest");
+        return;
+    }
+
+    bool materialized = false;
+    size_t len = sentry_value_get_length(list);
+    for (size_t i = 0; i < len; i++) {
+        sentry_value_t info = sentry_value_get_by_index(list, i);
+        const char *path
+            = sentry_value_as_string(sentry_value_get_by_key(info, "path"));
+        const char *filename
+            = sentry_value_as_string(sentry_value_get_by_key(info, "filename"));
+        const char *content_type = sentry_value_as_string(
+            sentry_value_get_by_key(info, "content_type"));
+        if (!path || !*path || !filename || !*filename) {
+            SENTRY_WARN("Skipping malformed attachment manifest entry");
+            continue;
+        }
+        sentry_attachment_t attachment = { 0 };
+        attachment.path = sentry__path_from_str(path);
+        attachment.filename = sentry__path_from_str(filename);
+        if (!attachment.path || !attachment.filename) {
+            SENTRY_WARNF("Failed to allocate attachment paths for: %s", path);
+            sentry__path_free(attachment.path);
+            sentry__path_free(attachment.filename);
+            continue;
+        }
+        attachment.type = ATTACHMENT;
+        attachment.content_type
+            = (char *)((content_type && *content_type) ? content_type : NULL);
+        if (!sentry__attachment_is_placeholder(&attachment, options)) {
+            sentry__path_free(attachment.path);
+            sentry__path_free(attachment.filename);
+            continue;
+        }
+        if (!materialized && !sentry__envelope_materialize(envelope)) {
+            SENTRY_WARN("Failed to materialize envelope for attachment-refs");
+            sentry__path_free(attachment.path);
+            sentry__path_free(attachment.filename);
+            break;
+        }
+        materialized = true;
+        sentry__cache_attachment_refs(
+            envelope, &attachment, options, options->run->cache_path, NULL);
+        sentry__path_free(attachment.path);
+        sentry__path_free(attachment.filename);
+    }
+    sentry_value_decref(list);
 }
 
 #if defined(SENTRY_PLATFORM_UNIX)
@@ -2384,7 +2479,8 @@ write_envelope_with_native_stacktrace(const sentry_options_t *options,
                         const char *content_type
                             = sentry_value_as_string(content_type_val);
 
-                        if (path && filename) {
+                        if (path && filename
+                            && !attachment_is_placeholder(options, path)) {
                             write_attachment_to_envelope(
                                 fd, path, filename, content_type);
                         }
@@ -2619,7 +2715,8 @@ write_envelope_with_minidump(const sentry_options_t *options,
                         const char *content_type
                             = sentry_value_as_string(content_type_val);
 
-                        if (path && filename) {
+                        if (path && filename
+                            && !attachment_is_placeholder(options, path)) {
                             write_attachment_to_envelope(
                                 fd, path, filename, content_type);
                         }
@@ -2930,10 +3027,21 @@ sentry__process_crash(const sentry_options_t *options, sentry_crash_ipc_t *ipc)
         goto cleanup;
     }
 
+    add_attachment_refs(envelope, options, run_folder);
+
+    bool has_attachment_refs = sentry__envelope_has_content_type(
+        envelope, SENTRY_ATTACHMENT_REF_MIME);
+
     SENTRY_DEBUG("Envelope loaded, capturing");
 
     // Capture directly, or pass to external crash reporter
     if (!sentry__launch_external_crash_reporter(options, envelope)) {
+        if (has_attachment_refs && options && options->run) {
+            if (!sentry__run_write_envelope(options->run, envelope)) {
+                SENTRY_WARN(
+                    "Failed to dump crash envelope for resend on restart");
+            }
+        }
         if (options && options->transport && options->run) {
             SENTRY_DEBUG("Capturing crash envelope");
             sentry__capture_envelope(options->transport, envelope, options);
@@ -3010,9 +3118,6 @@ cleanup:
     SENTRY_DEBUG("Crash processing completed successfully");
 
 done:
-    // Mark as done
-    SENTRY_DEBUG("Marking crash state as DONE");
-    sentry__atomic_store(&ctx->state, SENTRY_CRASH_STATE_DONE);
     SENTRY_DEBUG("Processing crash - END");
     SENTRY_DEBUG("Crash processing complete");
 }
@@ -3183,6 +3288,7 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     sentry_options_set_debug(options, ipc->shmem->debug_enabled);
     options->attach_screenshot = ipc->shmem->attach_screenshot;
     options->cache_keep = ipc->shmem->cache_keep;
+    options->enable_large_attachments = ipc->shmem->enable_large_attachments;
     options->http_retry = false;
 
     // Set custom logger that writes to file
@@ -3316,13 +3422,27 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 
     // Cleanup
     if (options) {
+        size_t dumped_envelopes = 0;
         if (options->transport) {
             // Wait up to 10 seconds for transport to send pending envelopes
             // (crash envelope + logs envelope, etc.)
-            sentry__transport_shutdown(
+            int rv = sentry__transport_shutdown(
                 options->transport, SENTRY_CRASH_TRANSPORT_SHUTDOWN_TIMEOUT_MS);
+            if (rv != 0) {
+                SENTRY_WARN("transport did not shut down cleanly");
+            }
+            dumped_envelopes = sentry__transport_dump_queue(
+                options->transport, options->run);
+            if (rv == 0 && !dumped_envelopes && options->run) {
+                sentry__run_clean(options->run);
+            }
         }
         sentry_options_free(options);
+    }
+    if (crash_processed) {
+        // Mark as done
+        SENTRY_DEBUG("Marking crash state as DONE");
+        sentry__atomic_store(&ipc->shmem->state, SENTRY_CRASH_STATE_DONE);
     }
     if (crash_processed || !is_parent_alive(ipc->parent_handle)) {
         sentry__crash_ipc_unlink(ipc);

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -194,6 +194,7 @@ native_backend_startup(
     ctx->attach_screenshot = options->attach_screenshot;
     ctx->cache_keep = options->cache_keep;
     ctx->require_user_consent = options->require_user_consent;
+    ctx->enable_large_attachments = options->enable_large_attachments;
     sentry__atomic_store(
         &ctx->user_consent, sentry__atomic_fetch(&options->run->user_consent));
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -369,7 +369,7 @@ sentry_close(void)
         }
         if ((!options->backend
                 || !options->backend->can_capture_after_shutdown)) {
-            sentry__run_clean(options->run);
+            sentry__run_clean(options->run, false);
         }
         sentry_options_free(options);
     } else {

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -140,9 +140,9 @@ sentry__run_incref(sentry_run_t *run)
 }
 
 void
-sentry__run_clean(sentry_run_t *run)
+sentry__run_clean(sentry_run_t *run, bool force)
 {
-    if (sentry__atomic_fetch(&run->retain)) {
+    if (!force && sentry__atomic_fetch(&run->retain)) {
         sentry__filelock_unlock(run->lock);
         return;
     }

--- a/src/sentry_database.h
+++ b/src/sentry_database.h
@@ -51,7 +51,7 @@ sentry_run_t *sentry__run_incref(sentry_run_t *run);
 /**
  * This will clean up all the files belonging to this run.
  */
-void sentry__run_clean(sentry_run_t *run);
+void sentry__run_clean(sentry_run_t *run, bool force);
 
 /**
  * Free the previously allocated run.

--- a/tests/test_integration_tus.py
+++ b/tests/test_integration_tus.py
@@ -558,3 +558,11 @@ def test_tus_crash_native(cmake, httpserver):
                 break
     assert attachment_ref is not None
     assert attachment_ref.payload.json["location"] == location
+
+    db_dir = os.path.join(tmp_path, ".sentry-native")
+    run_dirs = [
+        d
+        for d in os.listdir(db_dir)
+        if d.endswith(".run") and os.path.isdir(os.path.join(db_dir, d))
+    ]
+    assert run_dirs == []

--- a/tests/test_integration_tus.py
+++ b/tests/test_integration_tus.py
@@ -12,7 +12,7 @@ from . import (
     SENTRY_VERSION,
 )
 from .assertions import assert_attachment
-from .conditions import has_breakpad, has_files, has_http, is_qemu
+from .conditions import has_breakpad, has_files, has_http, has_native, is_qemu
 
 pytestmark = [
     pytest.mark.skipif(not has_http, reason="tests need http transport"),
@@ -488,3 +488,73 @@ def test_tus_crash_restart(cmake, httpserver, backend):
     # Staged sibling files should be cleaned up after successful send.
     leftover_siblings = [f for f in os.listdir(cache_dir) if f.startswith(base)]
     assert leftover_siblings == []
+
+
+@pytest.mark.skipif(not has_native or is_qemu, reason="native backend not available")
+def test_tus_crash_native(cmake, httpserver):
+    # The native backend's daemon process handles the crash out-of-process: it
+    # caches the large attachment, writes the envelope with attachment-ref
+    # items, and uploads via TUS itself when the server responds within the
+    # crash transport shutdown window.
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
+
+    upload_uri = "/api/123456/upload/abc123def456789/"
+    upload_qs = "length=104857600&signature=xyz"
+    location = httpserver.url_for(upload_uri) + "?" + upload_qs
+
+    httpserver.expect_oneshot_request(
+        "/api/123456/upload/",
+        headers={"tus-resumable": "1.0.0"},
+    ).respond_with_data("OK", status=201, headers={"Location": location})
+
+    httpserver.expect_oneshot_request(
+        upload_uri,
+        method="PATCH",
+        headers={"tus-resumable": "1.0.0"},
+        query_string=upload_qs,
+    ).respond_with_data("", status=204)
+
+    httpserver.expect_oneshot_request(
+        "/api/123456/envelope/",
+        headers={"x-sentry-auth": auth_header},
+    ).respond_with_data("OK")
+
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    with httpserver.wait(timeout=15) as waiting:
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "large-attachment", "crash"],
+            expect_failure=True,
+            env=env,
+        )
+    assert waiting.result
+
+    create_req = upload_req = envelope_req = None
+    for entry in httpserver.log:
+        req = entry[0]
+        if req.path == "/api/123456/upload/" and req.method == "POST":
+            create_req = req
+        elif upload_uri in req.path and req.method == "PATCH":
+            upload_req = req
+        elif "/envelope/" in req.path:
+            envelope_req = req
+    assert create_req is not None
+    assert upload_req is not None
+    assert envelope_req is not None
+    assert int(create_req.headers.get("upload-length")) == 100 * 1024 * 1024
+
+    body = envelope_req.get_data()
+    envelope = Envelope.deserialize(body)
+    attachment_ref = None
+    for item in envelope:
+        if (
+            item.headers.get("content_type")
+            == "application/vnd.sentry.attachment-ref+json"
+        ):
+            if hasattr(item.payload, "json") and "location" in item.payload.json:
+                attachment_ref = item
+                break
+    assert attachment_ref is not None
+    assert attachment_ref.payload.json["location"] == location


### PR DESCRIPTION
Follows up on #1545 with TUS/large-attachment support for the native daemon.

<img width="859" height="227" alt="image" src="https://github.com/user-attachments/assets/5e5e3cf4-de9c-47a5-813f-d0bf8022411d" />

https://sentry-sdks.sentry.io/issues/7452013648/?project=4506178389999616

#skip-changelog (in #1545)