### PR TITLE
test: speed up client_report_concurrent with valgrind

### DIFF
--- a/tests/unit/test_client_report.c
+++ b/tests/unit/test_client_report.c
@@ -484,6 +484,7 @@ discard_thread_func(void *data)
         sentry__client_report_discard(
             SENTRY_DISCARD_REASON_SAMPLE_RATE, SENTRY_DATA_CATEGORY_ERROR, 1);
         sentry__atomic_fetch_and_add((long *)&g_produced, 1);
+        sentry__thread_yield();
     }
     return 0;
 }
@@ -495,6 +496,7 @@ flush_thread_func(void *data)
     while (sentry__atomic_fetch((long *)&g_running)) {
         sentry_client_report_t report;
         if (!sentry__client_report_save(&report)) {
+            sentry__thread_yield();
             continue;
         }
         sentry_envelope_t *envelope = sentry__envelope_new();


### PR DESCRIPTION
The _Linux (GCC 13.3.0 + code-checker + valgrind)_ CI job has become slow (sometimes > 1h): https://github.com/getsentry/sentry-native/actions/runs/25117272965

The slowdown is caused by the `client_report_concurrent` stress test. The flush side of the test spins immediately when there is no client report to save, while the producer side repeatedly discards reports from multiple threads. Under Valgrind, this can spend minutes in scheduler contention.

Yield in both hot loops, matching the approach used for the logs and metrics stress tests in bcd4633758b50f51f40434740563ad92b3250c8e.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
