### PR TITLE
fix(native): Respect shutdown timeout in daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Guard against internal stringbuilder append and reserve size overflows. ([#1672](https://github.com/getsentry/sentry-native/pull/1672))
 - Preserve attachments added during crash handling ([#1687](https://github.com/getsentry/sentry-native/pull/1687))
 - Fix build-time warnings with C++ builds. ([#1671](https://github.com/getsentry/sentry-native/pull/1671))
+- Native: respect the `shutdown_timeout` option in the daemon. ([#1691](https://github.com/getsentry/sentry-native/pull/1691))
 
 ## 0.13.8
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -548,6 +548,12 @@ main(int argc, char **argv)
 
     sentry_options_set_auto_session_tracking(options, false);
     sentry_options_set_symbolize_stacktraces(options, true);
+    const char *shutdown_timeout
+        = get_arg_value(argc, argv, "shutdown-timeout");
+    if (shutdown_timeout) {
+        sentry_options_set_shutdown_timeout(
+            options, strtoull(shutdown_timeout, NULL, 10));
+    }
 
     sentry_options_set_environment(options, "development");
     // sentry defaults this to the `SENTRY_RELEASE` env variable

--- a/src/backends/native/sentry_crash_context.h
+++ b/src/backends/native/sentry_crash_context.h
@@ -92,8 +92,6 @@ typedef DWORD pid_t;
     5000 // 5 seconds between daemon health checks
 #define SENTRY_CRASH_HANDLER_POLL_INTERVAL_MS                                  \
     100 // 100ms poll interval in exception handler
-#define SENTRY_CRASH_TRANSPORT_SHUTDOWN_TIMEOUT_MS                             \
-    10000 // 10 seconds for transport shutdown (increased for TSAN/ASAN builds)
 
 // Compatibility macros for arm64e (PAC - Pointer Authentication Codes).
 // On arm64e, __darwin_arm_thread_state64 uses opaque members for pointer
@@ -275,6 +273,7 @@ typedef struct {
     bool cache_keep;
     bool require_user_consent;
     bool enable_large_attachments;
+    uint64_t shutdown_timeout;
 
     // Atomic user consent (sentry_user_consent_t), updated whenever user
     // consent changes so the daemon can honor it at crash time.

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3292,6 +3292,7 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     options->cache_keep = ipc->shmem->cache_keep;
     options->enable_large_attachments = ipc->shmem->enable_large_attachments;
     options->http_retry = false;
+    options->shutdown_timeout = ipc->shmem->shutdown_timeout;
 
     // Set custom logger that writes to file
     if (log_file) {
@@ -3426,10 +3427,10 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     if (options) {
         size_t dumped_envelopes = 0;
         if (options->transport) {
-            // Wait up to 10 seconds for transport to send pending envelopes
-            // (crash envelope + logs envelope, etc.)
+            // Wait for the configured SDK shutdown timeout to send pending
+            // envelopes (crash envelope + logs envelope, etc.).
             int rv = sentry__transport_shutdown(
-                options->transport, SENTRY_CRASH_TRANSPORT_SHUTDOWN_TIMEOUT_MS);
+                options->transport, options->shutdown_timeout);
             if (rv != 0) {
                 SENTRY_WARN("transport did not shut down cleanly");
             }

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -195,6 +195,7 @@ native_backend_startup(
     ctx->cache_keep = options->cache_keep;
     ctx->require_user_consent = options->require_user_consent;
     ctx->enable_large_attachments = options->enable_large_attachments;
+    ctx->shutdown_timeout = options->shutdown_timeout;
     sentry__atomic_store(
         &ctx->user_consent, sentry__atomic_fetch(&options->run->user_consent));
 

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -25,12 +25,16 @@ from .assertions import (
     wait_for_file,
     assert_user_feedback,
 )
-from .conditions import has_native, has_oom, is_kcov, is_asan, is_qemu
+from .conditions import has_native, has_oom, is_kcov, is_asan, is_tsan, is_qemu
 
 pytestmark = pytest.mark.skipif(
     not has_native or is_qemu,
     reason="Tests need the native backend enabled",
 )
+
+# Sanitizer builds are slower, so selected native crash tests use the same 10s
+# timeout the native daemon used before it respected the SDK shutdown timeout.
+SANITIZER_ARGS = ["shutdown-timeout", "10000"] if is_asan or is_tsan else []
 
 
 def run_crash(tmp_path, exe, args, env):
@@ -241,7 +245,7 @@ def test_native_multiple_crashes(cmake, httpserver):
             run_crash(
                 tmp_path,
                 "sentry_example",
-                ["log", "stdout", "crash"],
+                ["log", "stdout", "crash"] + SANITIZER_ARGS,
                 env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
             )
     assert waiting.result
@@ -298,7 +302,7 @@ def test_native_multithreaded_crash(cmake, httpserver):
         run_crash(
             tmp_path,
             "sentry_example",
-            ["log", "stdout", "crash"],
+            ["log", "stdout", "crash"] + SANITIZER_ARGS,
             env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
         )
     assert waiting.result

--- a/tests/unit/test_native_backend.c
+++ b/tests/unit/test_native_backend.c
@@ -357,11 +357,15 @@ SENTRY_TEST(crash_context_transport_fields)
     ctx.user_agent[sizeof(ctx.user_agent) - 1] = '\0';
     TEST_CHECK_STRING_EQUAL(ctx.user_agent, test_ua);
 
+    ctx.shutdown_timeout = 12345;
+    TEST_CHECK_UINT64_EQUAL(ctx.shutdown_timeout, 12345);
+
     // Verify fields are zero-initialized when memset to 0
     memset(&ctx, 0, sizeof(ctx));
     TEST_CHECK(ctx.ca_certs[0] == '\0');
     TEST_CHECK(ctx.proxy[0] == '\0');
     TEST_CHECK(ctx.user_agent[0] == '\0');
+    TEST_CHECK_UINT64_EQUAL(ctx.shutdown_timeout, 0);
 #else
     SKIP_TEST();
 #endif
@@ -380,6 +384,7 @@ SENTRY_TEST(crash_context_options_propagation)
 
     sentry_options_set_ca_certs(options, "/path/to/ca-bundle.crt");
     sentry_options_set_proxy(options, "http://myproxy:3128");
+    sentry_options_set_shutdown_timeout(options, 12345);
 
     // Verify options were set correctly
     TEST_CHECK_STRING_EQUAL(
@@ -404,12 +409,14 @@ SENTRY_TEST(crash_context_options_propagation)
             ctx.user_agent, options->user_agent, sizeof(ctx.user_agent) - 1);
         ctx.user_agent[sizeof(ctx.user_agent) - 1] = '\0';
     }
+    ctx.shutdown_timeout = options->shutdown_timeout;
 
     // Verify crash context received the values
     TEST_CHECK_STRING_EQUAL(ctx.ca_certs, "/path/to/ca-bundle.crt");
     TEST_CHECK_STRING_EQUAL(ctx.proxy, "http://myproxy:3128");
     // user_agent should have the default SDK user agent
     TEST_CHECK(ctx.user_agent[0] != '\0');
+    TEST_CHECK_UINT64_EQUAL(ctx.shutdown_timeout, 12345);
 
     sentry_options_free(options);
 #else


### PR DESCRIPTION
Pass the configured SDK shutdown timeout through the native crash context so the daemon uses the same limit as the SDK during transport shutdown.

This is likely the first thing users will try to adjust when it comes to large attachment uploads on shutdown. While a full-screen game may want a relatively high timeout to allow as many crash reports as possible to get uploaded right away, in a desktop environment, it may feel less nice if a GUI app window is stuck in a crashed state for a long time...

As for tests, add a `shutdown-timeout` argument for those tests that most likely need a longer 10s timeout under sanitizers, while keeping most native tests on the production default (2s).