### PR TITLE
fix(user-id): preserve global user after local scope merge

### DIFF
--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -72,7 +72,7 @@ init_scope(sentry_scope_t *scope)
     scope->environment = NULL;
     scope->transaction = NULL;
     scope->fingerprint = sentry_value_new_null();
-    scope->user = sentry_value_new_object();
+    scope->user = sentry_value_new_null();
     scope->tags = sentry_value_new_object();
     scope->extra = sentry_value_new_object();
     scope->attributes = sentry_value_new_object();
@@ -97,6 +97,7 @@ get_scope(void)
 
     memset(&g_scope, 0, sizeof(sentry_scope_t));
     init_scope(&g_scope);
+    g_scope.user = sentry_value_new_object();
     sentry_value_set_by_key(g_scope.contexts, "os", sentry__get_os_context());
     g_scope.client_sdk = get_client_sdk();
 

--- a/tests/unit/test_scope.c
+++ b/tests/unit/test_scope.c
@@ -473,6 +473,24 @@ SENTRY_TEST(scope_user_id)
         sentry_value_decref(event);
     }
 
+    // empty local scope does not shadow global user ID
+    sentry_set_user(sentry_value_new_user("12345", "dave", NULL, NULL));
+    sentry_value_t event = sentry_value_new_object();
+    sentry_scope_t *local_scope = sentry_local_scope_new();
+    sentry__scope_apply_to_event(
+        local_scope, options, event, SENTRY_SCOPE_BREADCRUMBS);
+    sentry__scope_free(local_scope);
+    SENTRY_WITH_SCOPE (scope) {
+        sentry__scope_apply_to_event(scope, options, event, SENTRY_SCOPE_ALL);
+    }
+    sentry_value_t user = sentry_value_get_by_key(event, "user");
+    TEST_CHECK_STRING_EQUAL(
+        sentry_value_as_string(sentry_value_get_by_key(user, "id")), "12345");
+    TEST_CHECK_STRING_EQUAL(
+        sentry_value_as_string(sentry_value_get_by_key(user, "username")),
+        "dave");
+    sentry_value_decref(event);
+
     // remove_user -> no user on event (installation ID suppressed)
     sentry_remove_user();
     SENTRY_WITH_SCOPE (scope) {


### PR DESCRIPTION
The issue surfaced in Switch/Unreal integration tests after adding the default installation user ID in #1661. `CaptureMessageWithScope` applies a local scope before the global scope, and a userless local scope started adding an `installation-id` user to the event first.

Keep new local scopes userless so applying a local scope cannot shadow an explicit global user. Initialize the global scope with the empty user object that drives the default user ID.

Tested by:
- https://github.com/getsentry/sentry-switch/pull/134

#skip-changelog (non-user-facing fixup; #1661 was not released yet)

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
