### PR TITLE
ref(string): recurring null-or-empty checks

### DIFF
--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -253,7 +253,7 @@ add_attachment_refs(sentry_envelope_t *envelope,
             = sentry_value_as_string(sentry_value_get_by_key(info, "filename"));
         const char *content_type = sentry_value_as_string(
             sentry_value_get_by_key(info, "content_type"));
-        if (!path || !*path || !filename || !*filename) {
+        if (sentry__string_empty(path) || sentry__string_empty(filename)) {
             SENTRY_WARN("Skipping malformed attachment manifest entry");
             continue;
         }
@@ -268,7 +268,7 @@ add_attachment_refs(sentry_envelope_t *envelope,
         }
         attachment.type = ATTACHMENT;
         attachment.content_type
-            = (char *)((content_type && *content_type) ? content_type : NULL);
+            = sentry__string_empty(content_type) ? NULL : (char *)content_type;
         if (!sentry__attachment_is_placeholder(&attachment, options)) {
             sentry__path_free(attachment.path);
             sentry__path_free(attachment.filename);
@@ -2327,13 +2327,13 @@ write_envelope_with_native_stacktrace(const sentry_options_t *options,
         = options && options->dsn ? sentry_options_get_dsn(options) : NULL;
     char header_buf[SENTRY_CRASH_ENVELOPE_HEADER_SIZE];
     int header_len;
-    if (dsn && event_id && event_id[0] != '\0') {
+    if (dsn && !sentry__string_empty(event_id)) {
         header_len = snprintf(header_buf, sizeof(header_buf),
             "{\"dsn\":\"%s\",\"event_id\":\"%s\"}\n", dsn, event_id);
     } else if (dsn) {
         header_len = snprintf(
             header_buf, sizeof(header_buf), "{\"dsn\":\"%s\"}\n", dsn);
-    } else if (event_id && event_id[0] != '\0') {
+    } else if (!sentry__string_empty(event_id)) {
         header_len = snprintf(header_buf, sizeof(header_buf),
             "{\"event_id\":\"%s\"}\n", event_id);
     } else {
@@ -2563,13 +2563,13 @@ write_envelope_with_minidump(const sentry_options_t *options,
         = options && options->dsn ? sentry_options_get_dsn(options) : NULL;
     char header_buf[SENTRY_CRASH_ENVELOPE_HEADER_SIZE];
     int header_len;
-    if (dsn && event_id && event_id[0] != '\0') {
+    if (dsn && !sentry__string_empty(event_id)) {
         header_len = snprintf(header_buf, sizeof(header_buf),
             "{\"dsn\":\"%s\",\"event_id\":\"%s\"}\n", dsn, event_id);
     } else if (dsn) {
         header_len = snprintf(
             header_buf, sizeof(header_buf), "{\"dsn\":\"%s\"}\n", dsn);
-    } else if (event_id && event_id[0] != '\0') {
+    } else if (!sentry__string_empty(event_id)) {
         header_len = snprintf(header_buf, sizeof(header_buf),
             "{\"event_id\":\"%s\"}\n", event_id);
     } else {
@@ -3483,7 +3483,7 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 
     // Resolve daemon path
     char daemon_path[SENTRY_CRASH_MAX_PATH];
-    if (handler_path && handler_path[0] != '\0') {
+    if (!sentry__string_empty(handler_path)) {
         strncpy(daemon_path, handler_path, sizeof(daemon_path) - 1);
         daemon_path[sizeof(daemon_path) - 1] = '\0';
     } else {
@@ -3592,7 +3592,7 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
         char *argv[]
             = { "sentry-crash", pid_str, tid_str, notify_str, ready_str, NULL };
 
-        if (handler_path && handler_path[0] != '\0') {
+        if (!sentry__string_empty(handler_path)) {
             execv(handler_path, argv);
         } else {
             char exe_path[SENTRY_CRASH_MAX_PATH];
@@ -3630,7 +3630,7 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     wchar_t daemon_path_w[SENTRY_CRASH_MAX_PATH];
 
     // If handler_path was explicitly set via options, use it directly
-    if (handler_path && handler_path[0] != '\0') {
+    if (!sentry__string_empty(handler_path)) {
         wchar_t *wpath = sentry__string_to_wstr(handler_path);
         if (wpath) {
             wcsncpy(daemon_path_w, wpath, SENTRY_CRASH_MAX_PATH - 1);

--- a/src/path/sentry_path.c
+++ b/src/path/sentry_path.c
@@ -85,7 +85,7 @@ sentry__path_remove_all(const sentry_path_t *path)
 sentry_path_t *
 sentry__path_unique(const sentry_path_t *dir, const char *basename)
 {
-    if (!dir || !basename || !*basename) {
+    if (!dir || sentry__string_empty(basename)) {
         return NULL;
     }
 

--- a/src/process/sentry_process_unix.c
+++ b/src/process/sentry_process_unix.c
@@ -140,7 +140,7 @@ spawn_process(char **argv)
 void
 sentry__process_spawn(const sentry_path_t *executable, const char *arg0, ...)
 {
-    if (!executable || !executable->path || strcmp(executable->path, "") == 0) {
+    if (!executable || sentry__string_empty(executable->path)) {
         return;
     }
 

--- a/src/process/sentry_process_windows.c
+++ b/src/process/sentry_process_windows.c
@@ -2,6 +2,7 @@
 
 #include "sentry_alloc.h"
 #include "sentry_logger.h"
+#include "sentry_string.h"
 
 #include <stdarg.h>
 #include <windows.h>
@@ -70,7 +71,7 @@ quote_arg(const char *src, char *dst)
 void
 sentry__process_spawn(const sentry_path_t *executable, const char *arg0, ...)
 {
-    if (!executable || !executable->path || strcmp(executable->path, "") == 0) {
+    if (!executable || sentry__string_empty(executable->path)) {
         return;
     }
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -1679,8 +1679,7 @@ sentry__launch_external_crash_reporter(
     const sentry_options_t *options, sentry_envelope_t *envelope)
 {
     if (!options || !options->run || !options->external_crash_reporter
-        || !options->external_crash_reporter->path
-        || options->external_crash_reporter->path[0] == '\0') {
+        || sentry__string_empty(options->external_crash_reporter->path)) {
         return false;
     }
 

--- a/src/sentry_metrics.c
+++ b/src/sentry_metrics.c
@@ -4,6 +4,7 @@
 #include "sentry_envelope.h"
 #include "sentry_options.h"
 #include "sentry_scope.h"
+#include "sentry_string.h"
 #include "sentry_utils.h"
 #include "sentry_value.h"
 
@@ -43,7 +44,7 @@ construct_metric(sentry_metric_type_t type, const char *name,
         metric, "type", sentry_value_new_string(metric_type_string(type)));
     sentry_value_set_by_key(metric, "name", sentry_value_new_string(name));
     sentry_value_set_by_key(metric, "value", value);
-    if (unit && unit[0] != '\0') {
+    if (!sentry__string_empty(unit)) {
         sentry_value_set_by_key(metric, "unit", sentry_value_new_string(unit));
     }
 

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -326,7 +326,7 @@ sentry__scope_apply_to_event(const sentry_scope_t *scope,
 #define SET(Key, Value) sentry_value_set_by_key(event, Key, Value)
 #define PLACE_STRING(Key, Source)                                              \
     do {                                                                       \
-        if (IS_NULL(Key) && Source && *Source) {                               \
+        if (IS_NULL(Key) && !sentry__string_empty(Source)) {                   \
             SET(Key, sentry_value_new_string(Source));                         \
         }                                                                      \
     } while (0)

--- a/src/sentry_string.h
+++ b/src/sentry_string.h
@@ -187,6 +187,15 @@ sentry__guarded_strlen(const char *s)
 }
 
 /**
+ * Checks whether a string is NULL or zero-length.
+ */
+static inline bool
+sentry__string_empty(const char *s)
+{
+    return !s || s[0] == '\0';
+}
+
+/**
  * Converts an int64_t into a string.
  */
 static inline char *

--- a/src/transports/sentry_http_transport.c
+++ b/src/transports/sentry_http_transport.c
@@ -435,7 +435,7 @@ collect_attachment_refs(const sentry_envelope_t *envelope)
         if (!sentry__envelope_item_get_attachment_ref(item, &ref)) {
             continue;
         }
-        if (ref.path && *ref.path) {
+        if (!sentry__string_empty(ref.path)) {
             sentry_value_append(list, sentry_value_new_string(ref.path));
         }
         sentry__attachment_ref_cleanup(&ref);
@@ -493,7 +493,8 @@ prune_attachment_refs(const sentry_run_t *run, sentry_value_t paths,
     for (size_t i = 0; i < count; i++) {
         const char *path
             = sentry_value_as_string(sentry_value_get_by_index(paths, i));
-        if (!path || !*path || (keep && has_attachment_ref_path(keep, path))) {
+        if (sentry__string_empty(path)
+            || (keep && has_attachment_ref_path(keep, path))) {
             continue;
         }
         sentry_path_t *p = sentry__path_join_str(run->cache_path, path);
@@ -537,13 +538,13 @@ resolve_attachment_refs(
             continue;
         }
 
-        if (ref.location && *ref.location) {
+        if (!sentry__string_empty(ref.location)) {
             // Crash-resume: TUS already done on a prior attempt. Nothing to do.
             sentry__attachment_ref_cleanup(&ref);
             i++;
             continue;
         }
-        if (!ref.path || !*ref.path) {
+        if (sentry__string_empty(ref.path)) {
             sentry__attachment_ref_cleanup(&ref);
             if (!sentry__envelope_remove_item(envelope, item)) {
                 return RESULT_ERROR;


### PR DESCRIPTION
Triggered by https://github.com/getsentry/sentry-native/pull/1700#discussion_r3188065482. Add `sentry__string_empty` for internal checks where it makes existing null-or-empty checks more streamlined without changing behavior.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
