### PR TITLE
ci: pin ClangCL to windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           - name: Windows (latest, ninja + sccache)
             os: windows-latest
             USE_SCCACHE: 1
-          - name: Windows ClangCL (latest)
+          - name: Windows ClangCL (2022)
             os: windows-2022
             VS_GENERATOR_TOOLSET: ClangCL
           - name: LLVM-Mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
             os: windows-latest
             USE_SCCACHE: 1
           - name: Windows ClangCL (latest)
-            os: windows-latest
+            os: windows-2022
             VS_GENERATOR_TOOLSET: ClangCL
           - name: LLVM-Mingw
             os: windows-latest


### PR DESCRIPTION
GitHub just switched `windows-latest` to `windows-2025-vs2026`, and it broke the ClangCL build that requests VS 2022:

https://github.com/getsentry/sentry-native/blob/0bcc632fa6beee0d3931879f3d8ef7b52e995e9c/tests/cmake.py#L320-L323

Which cannot be found on `windows-2025-vs2026`:

>    Visual Studio 17 2022
>
>  could not find any instance of Visual Studio.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
