### PR TITLE
feat(screenshot): allow downstream Xbox SDK to supply capture implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -271,12 +271,13 @@ if(SENTRY_INTEGRATION_QT)
 endif()
 
 # screenshot
-if(WIN32)
+if(WIN32 AND NOT XBOX)
 	sentry_target_sources_cwd(sentry
 		screenshot/sentry_screenshot_windows.c
 	)
-else()
+elseif(NOT WIN32)
 	sentry_target_sources_cwd(sentry
 		screenshot/sentry_screenshot_none.c
 	)
 endif()
+# Xbox: sentry__screenshot_capture is supplied by the sentry-xbox extension.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -280,4 +280,3 @@ elseif(NOT WIN32)
 		screenshot/sentry_screenshot_none.c
 	)
 endif()
-# Xbox: sentry__screenshot_capture is supplied by the sentry-xbox extension.

--- a/src/screenshot/sentry_screenshot_windows.c
+++ b/src/screenshot/sentry_screenshot_windows.c
@@ -114,10 +114,6 @@ save_bitmap(HBITMAP bitmap, const wchar_t *path)
 static void
 calculate_region(DWORD pid, HRGN region)
 {
-#ifdef SENTRY_PLATFORM_XBOX
-    (DWORD) pid;
-    (HRGN) region;
-#else
     HMODULE dwmapi = load_library(L"dwmapi.dll");
     if (!dwmapi) {
         return;
@@ -149,17 +145,11 @@ calculate_region(DWORD pid, HRGN region)
         }
         hwnd = GetWindow(hwnd, GW_HWNDPREV);
     }
-#endif // SENTRY_PLATFORM_XBOX
 }
 
 bool
 sentry__screenshot_capture(const sentry_path_t *path, uint32_t pid)
 {
-#ifdef SENTRY_PLATFORM_XBOX
-    (sentry_path_t *)path;
-    (uint32_t)pid;
-    return false;
-#else
     // Use provided PID, or current process if 0
     DWORD target_pid = pid ? pid : GetCurrentProcessId();
     HRGN region = CreateRectRgn(0, 0, 0, 0);
@@ -195,5 +185,4 @@ sentry__screenshot_capture(const sentry_path_t *path, uint32_t pid)
     ReleaseDC(NULL, src);
     DeleteObject(region);
     return rv;
-#endif // SENTRY_PLATFORM_XBOX
 }


### PR DESCRIPTION
This PR allows the downstream sentry-xbox extension to provide its own implementation of `sentry__screenshot_capture` by skipping the bundled Windows screenshot module when targeting Xbox.

Related items:
- https://github.com/getsentry/sentry-xbox/pull/135

#skip-changelog