### PR TITLE
feat(crashpad): support modifying attachments after init on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Auto-populate `event.user.id` with a persistent per-installation UUID when no explicit user ID is set. ([#1661](https://github.com/getsentry/sentry-native/pull/1661))
 - Crashpad: add error log for oversized envelopes (HTTP 413 Content Too Large). ([#1706](https://github.com/getsentry/sentry-native/pull/1706), [crashpad#155](https://github.com/getsentry/crashpad/pull/155))
+- Crashpad: support modifying attachments after `sentry_init` on macOS. ([#1705](https://github.com/getsentry/sentry-native/pull/1705), [crashpad#153](https://github.com/getsentry/crashpad/pull/153))
 
 **Fixes**:
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -42,9 +42,6 @@
  * attachment paths will be resolved according to the current working directory
  * at the time of envelope creation. When adding and removing attachments, they
  * are matched according to their given `path`. No normalization is performed.
- * When using the `crashpad` backend on macOS, the list of attachments that will
- * be added at the time of a hard crash will be frozen at the time of
- * `sentry_init`, and later modifications will not be reflected.
  */
 
 #ifndef SENTRY_H_INCLUDED

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -1012,7 +1012,8 @@ crashpad_backend_prune_database(sentry_backend_t *backend)
     crashpad::PruneCrashReportDatabase(data->db, &condition);
 }
 
-#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_LINUX)
+#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_LINUX)         \
+    || defined(SENTRY_PLATFORM_MACOS)
 static bool
 ensure_unique_path(sentry_attachment_t *attachment)
 {
@@ -1101,7 +1102,8 @@ sentry__backend_new(void)
     backend->user_consent_changed_func = crashpad_backend_user_consent_changed;
     backend->get_last_crash_func = crashpad_backend_last_crash;
     backend->prune_database_func = crashpad_backend_prune_database;
-#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_LINUX)
+#if defined(SENTRY_PLATFORM_WINDOWS) || defined(SENTRY_PLATFORM_LINUX)         \
+    || defined(SENTRY_PLATFORM_MACOS)
     backend->add_attachment_func = crashpad_backend_add_attachment;
     backend->remove_attachment_func = crashpad_backend_remove_attachment;
 #endif

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -535,11 +535,9 @@ def assert_crashpad_upload(req, expect_attachment=False, expect_view_hierarchy=F
     assert_event_meta(attachments.event, integration="crashpad")
     if expect_attachment:
         assert attachments.cmake_cache > 0
-    else:
-        assert attachments.cmake_cache == -1
-    if expect_attachment and (sys.platform == "win32" or sys.platform == "linux"):
         assert attachments.bytes_bin == b"\xc0\xff\xee"
     else:
+        assert attachments.cmake_cache == -1
         assert attachments.bytes_bin == None
     if expect_view_hierarchy:
         assert_attachment_content_view_hierarchy(attachments.view_hierarchy)

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -369,18 +369,10 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
         pytest.param(
             ["attach-after-init"],
             {},
-            marks=pytest.mark.skipif(
-                sys.platform == "darwin",
-                reason="crashpad doesn't support dynamic attachments on macOS",
-            ),
         ),
         pytest.param(
             ["attachment", "attach-after-init", "clear-attachments"],
             {},
-            marks=pytest.mark.skipif(
-                sys.platform == "darwin",
-                reason="crashpad doesn't support dynamic attachments on macOS",
-            ),
         ),
     ],
 )


### PR DESCRIPTION
Required for:
- https://github.com/getsentry/sentry-native/pull/1700

See also:
- https://github.com/getsentry/crashpad/pull/153
