### PR TITLE
feat(crashpad): add error log for oversized crash reports (HTTP 413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**:
 
 - Auto-populate `event.user.id` with a persistent per-installation UUID when no explicit user ID is set. ([#1661](https://github.com/getsentry/sentry-native/pull/1661))
+- Crashpad: add error log for oversized envelopes (HTTP 413 Content Too Large). ([#1706](https://github.com/getsentry/sentry-native/pull/1706), [crashpad#155](https://github.com/getsentry/crashpad/pull/155))
 
 ## 0.14.0
 


### PR DESCRIPTION
Bump Crashpad to latest with getsentry/crashpad#155 that implemented #1487 for Crashpad.

Close: #1487