### PR TITLE
build(docker): Update Alpine images (3.23 + multi-arch)

### DIFF
--- a/.github/docker/alpine/Dockerfile
+++ b/.github/docker/alpine/Dockerfile
@@ -2,8 +2,7 @@
 ARG BASE=alpine:latest
 FROM ${BASE}
 
-RUN apk update
-RUN apk add \
+RUN apk add --no-cache \
     bash \
     build-base \
     cargo \
@@ -17,6 +16,9 @@ RUN apk add \
     lsb-release-minimal \
     mitmproxy \
     moreutils \
+    nodejs \
+    npm \
+    openssl-dev \
     perl \
     powershell \
     python3 \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         version:
           - '3.21'
+          - '3.23'
 
     permissions:
       contents: read
@@ -34,9 +35,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ${{ env.IMAGE_NAME }}
-        run: docker build --build-arg BASE=alpine:${{ matrix.version }} -t ${{ env.IMAGE_NAME }} .
-        working-directory: .github/docker/alpine
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
-      - name: Push ${{ env.IMAGE_NAME }}
-        run: docker push ${{ env.IMAGE_NAME }}
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.IMAGE_NAME }}
+          context: .github/docker/alpine
+          build-args: |
+            BASE=alpine:${{ matrix.version }}


### PR DESCRIPTION
- Keep the existing 3.21 tag and add a newer 3.23 image for mitmproxy 12.x compatibility (#1643).

    ```
    Collecting mitmproxy-rs<0.13,>=0.12.6 (from mitmproxy==12.2.2->-r tests/requirements.txt (line 10))
    ...
    The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
    ```

- Publish the Alpine Docker image for both amd64 and arm64 with buildx. This allows testing these Docker images locally on a Silicon Mac.

  | Before | After (tested with a fork) |
  |---|---|
  | <img width="669" height="365" alt="image" src="https://github.com/user-attachments/assets/40828756-2a02-4fa7-b435-cc24bddfa589" /> | <img width="669" height="645" alt="image" src="https://github.com/user-attachments/assets/36cedcb6-f37d-4d5c-b1ea-b204870fc097" /> |

  https://github.com/jpnurmi/sentry-native/pkgs/container/sentry-native-alpine/

- Add Node.js, npm, and OpenSSL headers to the image so JavaScript actions and Python packages with OpenSSL extensions can run in the container.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
