### PR TITLE
fix(cache): Preserve cached minidump refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Native/Breakpad/Windows: fixed capturing abort(). ([#1708](https://github.com/getsentry/sentry-native/pull/1708))
 - Native/Windows: capture fast-fail and stack buffer overrun crashes via WER. ([#1710](https://github.com/getsentry/sentry-native/pull/1710))
+- Preserve cached minidump refs. ([#1715](https://github.com/getsentry/sentry-native/pull/1715))
 
 ## 0.14.0
 

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -1216,8 +1216,12 @@ write_minidump(const sentry_envelope_item_t *item, void *data)
 {
     const char *att_type = sentry_value_as_string(
         sentry_value_get_by_key(item->headers, "attachment_type"));
+    const char *content_type = sentry_value_as_string(
+        sentry_value_get_by_key(item->headers, "content_type"));
     if (!sentry__string_eq(att_type, "event.minidump") || !item->payload
-        || item->payload_len == 0) {
+        || item->payload_len == 0
+        || (content_type
+            && sentry__string_eq(content_type, SENTRY_ATTACHMENT_REF_MIME))) {
         return false;
     }
 

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -942,7 +942,6 @@ SENTRY_TEST(attachment_ref_copy)
     sentry_path_t *cache_dir = sentry__path_join_str(db_path, "cache");
     sentry_path_t *cached = sentry__path_join_str(
         cache_dir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
-    sentry__path_free(cache_dir);
     TEST_CHECK(sentry__path_is_file(cached));
 
     // envelope carries an attachment-ref item with the expected headers
@@ -951,8 +950,24 @@ SENTRY_TEST(attachment_ref_copy)
         "application/x-dmp", "event.minidump", strlen("minidump_data"),
         "c993afb6-b4ac-48a6-b61b-2558e601d65d.dmp");
 
+    sentry_path_t *cached_envelope = sentry__path_join_str(
+        cache_dir, "c993afb6-b4ac-48a6-b61b-2558e601d65d.envelope");
+    sentry__path_remove(cached_envelope);
+
+    TEST_CHECK_INT_EQUAL(
+        sentry__envelope_write_to_cache(envelope, cache_dir), 0);
+    size_t cached_len = 0;
+    char *cached_payload = sentry__path_read_to_buffer(cached, &cached_len);
+    TEST_ASSERT(!!cached_payload);
+    TEST_CHECK_INT_EQUAL(cached_len, strlen("minidump_data"));
+    TEST_CHECK(memcmp(cached_payload, "minidump_data", cached_len) == 0);
+    sentry_free(cached_payload);
+
     sentry_envelope_free(envelope);
+    sentry__path_remove(cached_envelope);
+    sentry__path_free(cached_envelope);
     sentry__path_remove(cached);
+    sentry__path_free(cache_dir);
     sentry__path_free(cached);
     sentry__path_free(db_path);
     sentry__attachment_free(attachment);


### PR DESCRIPTION
Came up at: https://github.com/getsentry/sentry-native/pull/1700#discussion_r3226035973

Skip minidump extraction for attachment-ref items so the cache writer does not overwrite a cached minidump sibling with the reference JSON payload.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
