### PR TITLE
fix: exclude WER code from Xbox builds in native backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,7 +879,7 @@ elseif(SENTRY_BACKEND_NATIVE)
 
 	# Make sentry library depend on crash daemon so it's always built together
 	add_dependencies(sentry sentry-crash)
-	if(WIN32)
+	if(WIN32 AND NOT XBOX)
 		add_dependencies(sentry sentry-wer)
 	endif()
 
@@ -887,7 +887,7 @@ elseif(SENTRY_BACKEND_NATIVE)
 	install(TARGETS sentry-crash
 		RUNTIME DESTINATION bin
 	)
-	if(WIN32)
+	if(WIN32 AND NOT XBOX)
 		install(TARGETS sentry-wer
 			RUNTIME DESTINATION bin
 			LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,7 +790,7 @@ elseif(SENTRY_BACKEND_NATIVE)
 	# Native backend sources and configuration are in src/CMakeLists.txt
 	# The native backend requires C11 for atomics (set in src/CMakeLists.txt)
 
-	if(WIN32)
+	if(WIN32 AND NOT XBOX)
 		add_library(sentry-wer SHARED
 			src/backends/native/sentry_wer.c
 			src/backends/native/sentry_wer.def

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -11,7 +11,7 @@
 #    if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
 #        include <sys/prctl.h>
 #    endif
-#elif defined(SENTRY_PLATFORM_WINDOWS)
+#elif defined(SENTRY_PLATFORM_WINDOWS) && !defined(SENTRY_PLATFORM_XBOX)
 #    include <werapi.h>
 #endif
 
@@ -65,7 +65,7 @@ static sentry_mutex_t g_ipc_init_mutex = SENTRY__MUTEX_INIT;
 #    endif
 #endif
 
-#if defined(SENTRY_PLATFORM_WINDOWS)
+#if defined(SENTRY_PLATFORM_WINDOWS) && !defined(SENTRY_PLATFORM_XBOX)
 static sentry_wer_registration_t g_wer_registration = { 0 };
 
 static sentry_path_t *g_wer_path = NULL;
@@ -520,7 +520,7 @@ native_backend_startup(
         SENTRY_DEBUG("Daemon signaled ready");
     }
 
-#    if defined(SENTRY_PLATFORM_WINDOWS)
+#    if defined(SENTRY_PLATFORM_WINDOWS) && !defined(SENTRY_PLATFORM_XBOX)
     wer_register_module(tid);
 #    endif
 
@@ -529,7 +529,9 @@ native_backend_startup(
 #    if defined(SENTRY_PLATFORM_UNIX)
         kill(state->daemon_pid, SIGTERM);
 #    elif defined(SENTRY_PLATFORM_WINDOWS)
+#        if !defined(SENTRY_PLATFORM_XBOX)
         wer_unregister_module();
+#        endif
         // On Windows, terminate the daemon process
         HANDLE hDaemon
             = OpenProcess(PROCESS_TERMINATE, FALSE, state->daemon_pid);
@@ -559,7 +561,7 @@ native_backend_shutdown(sentry_backend_t *backend)
         return;
     }
 
-#if defined(SENTRY_PLATFORM_WINDOWS)
+#if defined(SENTRY_PLATFORM_WINDOWS) && !defined(SENTRY_PLATFORM_XBOX)
     wer_unregister_module();
 #endif
 


### PR DESCRIPTION
This PR fixes Xbox build failures in the native backend caused by WER (Windows Error Reporting) code being compiled on Xbox, where `werapi.h`, registry APIs and WER APIs are not available in the GDK.

Xbox defines `SENTRY_PLATFORM_WINDOWS` (because it also defines `_WIN32`), which caused all existing `SENTRY_PLATFORM_WINDOWS` guards around WER-related code to evaluate as true. This PR adds exclusions to those guards to match the existing platform handling patterns already used elsewhere in the codebase.

Additionally, the CMake condition for the `sentry-wer` target has been updated.

Failing CI run: https://github.com/getsentry/sentry-xbox/actions/runs/25810318958/job/75848636085

#skip-changelog