### PR TITLE
docs: update notes and limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,12 +365,11 @@ Other important configuration options include:
   process, and can thus not properly terminate sessions or call the registered
   `before_send` or `on_crash` hook. It will also lose any events that have been queued for
   sending at the time of the crash.
-- The crashpad and native backends on Windows support fast-fail crashes, which bypass
-  SEH (Structured Exception Handling) primarily for security reasons. `sentry-native`
-  registers a WER (Windows Error Reporting) module, which signals the out-of-process
-  crash handler when a fast-fail crash occurs. Since this bypasses SEH, the
-  application's local exception handler is not invoked, which also means that for
-  these kinds of crashes, `before_send` and `on_crash` will not be invoked before
+- The crashpad and native backends on Windows support fast-fail crashes, which bypass SEH (Structured
+  Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error
+  Reporting) module, which signals the out-of-process crash handler when a fast-fail crash occurs.
+  Since this bypasses SEH, the application's local exception handler is not invoked, which
+  also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before
   sending the crash report, and thus have no effect.
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Other important configuration options include:
   process, and can thus not properly terminate sessions or call the registered
   `before_send` or `on_crash` hook. It will also lose any events that have been queued for
   sending at the time of the crash.
-- The crashpad and native backends on Windows support fast-fail crashes, which bypass SEH (Structured
+- On Windows, the crashpad and native backends support fast-fail crashes, which bypass SEH (Structured
   Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error
   Reporting) module, which signals the out-of-process crash handler when a fast-fail crash occurs.
   Since this bypasses SEH, the application's local exception handler is not invoked, which

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Other important configuration options include:
 - On Windows, the crashpad and native backends support fast-fail crashes, which bypass SEH (Structured
   Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error
   Reporting) module, which signals the out-of-process crash handler when a fast-fail crash occurs.
-  Since this bypasses SEH, the application's local exception handler is not invoked, which
+  But since this process bypasses SEH, the application's local exception handler is no longer invoked, which
   also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before
   sending the crash report, and thus have no effect.
 

--- a/README.md
+++ b/README.md
@@ -365,14 +365,13 @@ Other important configuration options include:
   process, and can thus not properly terminate sessions or call the registered
   `before_send` or `on_crash` hook. It will also lose any events that have been queued for
   sending at the time of the crash.
-- The Crashpad backend on Windows supports fast-fail crashes, which bypass SEH (Structured
-  Exception Handling) primarily for security reasons. `sentry-native` registers a WER (Windows Error
-  Reporting) module, which signals the `crashpad_handler` to send a minidump when a fast-fail crash occurs
-  But since this process bypasses SEH, the application's local exception handler is no longer invoked, which
-  also means that for these kinds of crashes, `before_send` and `on_crash` will not be invoked before
-  sending the minidump, and thus have no effect.
-- When using the crashpad backend on macOS, the list of attachments that will be sent
-  along with crashes is frozen at the time of `sentry_init`.
+- The crashpad and native backends on Windows support fast-fail crashes, which bypass
+  SEH (Structured Exception Handling) primarily for security reasons. `sentry-native`
+  registers a WER (Windows Error Reporting) module, which signals the out-of-process
+  crash handler when a fast-fail crash occurs. Since this bypasses SEH, the
+  application's local exception handler is not invoked, which also means that for
+  these kinds of crashes, `before_send` and `on_crash` will not be invoked before
+  sending the crash report, and thus have no effect.
 
 ## Benchmarks
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1618,8 +1618,8 @@ SENTRY_API void sentry_options_add_view_hierarchy_n(
  *
  * This feature is currently supported by all backends on Windows. The
  * `crashpad` and `native` backends capture screenshots from an out-of-process
- * handler. Only the `crashpad` backend can capture screenshots of fast-fail
- * crashes that bypass SEH (structured exception handling).
+ * handler. Only the `crashpad` and `native` backends can capture screenshots of
+ * fast-fail crashes that bypass SEH (structured exception handling).
  *
  * To decide per-event whether a screenshot should be captured, set a
  * `before_screenshot` callback via `sentry_options_set_before_screenshot`.

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1154,10 +1154,10 @@ SENTRY_API void sentry_options_set_send_default_pii(
  *
  * https://develop.sentry.dev/sdk/sessions/#filter-order
  *
- * On Windows the crashpad backend can capture fast-fail crashes which bypass
- * SEH. Since the `before_send` is called by a local exception-handler, it will
- * not be invoked when such a crash happened, even though a minidump will be
- * sent.
+ * On Windows the crashpad and native backends can capture fast-fail crashes
+ * which bypass SEH. Since the `before_send` callback is called by a local
+ * exception-handler, it will not be invoked when such a crash happened, even
+ * though a crash report will be sent.
  */
 typedef sentry_value_t (*sentry_event_function_t)(
     sentry_value_t event, void *hint, void *user_data);
@@ -1215,10 +1215,10 @@ SENTRY_API void sentry_options_set_before_send(
  *
  *  - does not work with crashpad on macOS.
  *  - for breakpad on Linux the `uctx` parameter is always NULL.
- *  - on Windows the crashpad backend can capture fast-fail crashes which
- *    bypass SEH. Since `on_crash` is called by a local exception-handler, it
- *    will not be invoked when such a crash happened, even though a minidump
- *    will be sent.
+ *  - on Windows the crashpad and native backends can capture fast-fail crashes
+ *    which bypass SEH. Since `on_crash` is called by a local
+ *    exception-handler, it will not be invoked when such a crash happened, even
+ *    though a crash report will be sent.
  */
 typedef sentry_value_t (*sentry_crash_function_t)(
     const sentry_ucontext_t *uctx, sentry_value_t event, void *user_data);

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1154,7 +1154,7 @@ SENTRY_API void sentry_options_set_send_default_pii(
  *
  * https://develop.sentry.dev/sdk/sessions/#filter-order
  *
- * On Windows the crashpad and native backends can capture fast-fail crashes
+ * On Windows, the crashpad and native backends can capture fast-fail crashes
  * which bypass SEH. Since the `before_send` callback is called by a local
  * exception-handler, it will not be invoked when such a crash happened, even
  * though a crash report will be sent.
@@ -1215,7 +1215,7 @@ SENTRY_API void sentry_options_set_before_send(
  *
  *  - does not work with crashpad on macOS.
  *  - for breakpad on Linux the `uctx` parameter is always NULL.
- *  - on Windows the crashpad and native backends can capture fast-fail crashes
+ *  - on Windows, the crashpad and native backends can capture fast-fail crashes
  *    which bypass SEH. Since `on_crash` is called by a local
  *    exception-handler, it will not be invoked when such a crash happened, even
  *    though a crash report will be sent.


### PR DESCRIPTION
Outdated notes and limitations found while working on getsentry/sentry-docs#17773.

- Remove another stale macOS crashpad attachment limitation, and
- document that Windows fast-fail crashes bypass local hooks for both crashpad and native backends.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
