### PR TITLE
test(crashpad): Wait for dump upload in crash test

### DIFF
--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -393,6 +393,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
                 "start-session",
                 "attach-view-hierarchy",
                 "overflow-breadcrumbs",
+                "crashpad-wait-for-upload",
                 "crash",
             ]
             + run_args,


### PR DESCRIPTION
Make `test_crashpad_dumping_crash` pass `crashpad-wait-for-upload` before triggering the crash so the handler waits for the minidump upload to finish. Hopefully, this stabilizes the CI test without retrying the whole parameterized case.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
