### PR TITLE
chore: Force BUILD_ONLY mode for all console checks

### DIFF
--- a/.github/workflows/console-check.yml
+++ b/.github/workflows/console-check.yml
@@ -65,9 +65,9 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [[ "$EVENT_NAME" == "push" && "$REF" == refs/heads/release/* ]]; then
-            echo "mode=FULL_TEST" >> "$GITHUB_OUTPUT"
+            echo "mode=BUILD_ONLY" >> "$GITHUB_OUTPUT"
           elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/master" ]]; then
-            echo "mode=UNIT_TEST" >> "$GITHUB_OUTPUT"
+            echo "mode=BUILD_ONLY" >> "$GITHUB_OUTPUT"
           else
             echo "mode=BUILD_ONLY" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
This PR temporarily forces all console checks to use `BUILD_ONLY` mode due to issues with Switch devkit connectivity.

#skip-changelog