### PR TITLE
fix: Guard against JSON token allocation overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Reject overly deep msgpack payloads during deserialization. ([#1727](https://github.com/getsentry/sentry-native/pull/1727))
+- Guard against JSON token allocation overflow on 32-bit platforms. ([#1733](https://github.com/getsentry/sentry-native/pull/1733))
 
 ## 0.14.2
 

--- a/src/sentry_json.c
+++ b/src/sentry_json.c
@@ -718,7 +718,8 @@ sentry__value_from_json(const char *buf, size_t buflen)
 
     jsmn_init(&jsmn_p);
     token_count = jsmn_parse(&jsmn_p, buf, buflen, NULL, 0);
-    if (token_count <= 0) {
+    if (token_count <= 0
+        || (size_t)token_count > SIZE_MAX / sizeof(jsmntok_t)) {
         return sentry_value_new_null();
     }
 


### PR DESCRIPTION
Reject JSON token counts whose token buffer would overflow `size_t` before allocating the `jsmn` token array. This avoids undersized allocations on 32-bit platforms for large JSON inputs.

The parser already treats invalid or unparseable JSON as `null`, so the overflow case follows the same failure behavior.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
