### PR TITLE
test: retry flaky crashpad dumping crash test

### DIFF
--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -5,6 +5,7 @@ import sys
 import time
 
 import pytest
+from flaky import flaky
 
 from . import (
     make_dsn,
@@ -376,6 +377,7 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
         ),
     ],
 )
+@flaky(max_runs=3)
 def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     build_args.update({"SENTRY_BACKEND": "crashpad"})
     tmp_path = cmake(["sentry_example"], build_args)


### PR DESCRIPTION
Unfortunately, #1728 didn't seem to help. The test still randomly fails on Windows:
```
FAILED tests/test_integration_crashpad.py::test_crashpad_dumping_crash[run_args1-build_args1] - AssertionError: assert 1 == 2
```

https://github.com/getsentry/sentry-native/actions/runs/26131499510/job/76857395137?pr=1736

Marking it flaky allows pytest to retry it a couple of times, to reduce the number of unrelated CI failures.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
