### PR TITLE
fix: increased `CRASH_MAX_MODULES` to `2048`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Fixes**:
 
+- Native: raise `SENTRY_CRASH_MAX_MODULES` from `512` to `2048` so processes that load many shared libraries no longer have their minidump module list truncated, which left frames in unrecorded modules without a `debug_id` and unsymbolicatable.
+  ([#1738](https://github.com/getsentry/sentry-native/pull/1738))
 - Reject overly deep msgpack payloads during deserialization. ([#1727](https://github.com/getsentry/sentry-native/pull/1727))
 - Read lengths for variadic fingerprints. ([#1730](https://github.com/getsentry/sentry-native/pull/1730))
 - Guard against JSON token allocation overflow on 32-bit platforms. ([#1733](https://github.com/getsentry/sentry-native/pull/1733))

--- a/src/backends/native/sentry_crash_context.h
+++ b/src/backends/native/sentry_crash_context.h
@@ -34,7 +34,7 @@ typedef DWORD pid_t;
 
 // Limits for crash context (used in shared memory and minidump writers)
 #define SENTRY_CRASH_MAX_THREADS 256
-#define SENTRY_CRASH_MAX_MODULES 512
+#define SENTRY_CRASH_MAX_MODULES 2048
 #define SENTRY_CRASH_MAX_MAPPINGS 4096
 
 // Max path length in crash context

--- a/tests/unit/test_native_backend.c
+++ b/tests/unit/test_native_backend.c
@@ -336,36 +336,41 @@ SENTRY_TEST(m128a_size)
 SENTRY_TEST(crash_context_transport_fields)
 {
 #ifdef SENTRY_BACKEND_NATIVE
-    sentry_crash_context_t ctx;
-    memset(&ctx, 0, sizeof(ctx));
+    // Heap-allocate: sentry_crash_context_t is multiple MB due to the inline
+    // modules[] array and would overflow smaller thread stacks.
+    sentry_crash_context_t *ctx = sentry_malloc(sizeof(*ctx));
+    TEST_ASSERT(!!ctx);
+    memset(ctx, 0, sizeof(*ctx));
 
     // Verify ca_certs field exists and can hold a typical path
     const char *test_ca = "/etc/ssl/certs/ca-certificates.crt";
-    strncpy(ctx.ca_certs, test_ca, sizeof(ctx.ca_certs) - 1);
-    ctx.ca_certs[sizeof(ctx.ca_certs) - 1] = '\0';
-    TEST_CHECK_STRING_EQUAL(ctx.ca_certs, test_ca);
+    strncpy(ctx->ca_certs, test_ca, sizeof(ctx->ca_certs) - 1);
+    ctx->ca_certs[sizeof(ctx->ca_certs) - 1] = '\0';
+    TEST_CHECK_STRING_EQUAL(ctx->ca_certs, test_ca);
 
     // Verify proxy field exists and can hold a typical proxy URL
     const char *test_proxy = "http://proxy.example.com:8080";
-    strncpy(ctx.proxy, test_proxy, sizeof(ctx.proxy) - 1);
-    ctx.proxy[sizeof(ctx.proxy) - 1] = '\0';
-    TEST_CHECK_STRING_EQUAL(ctx.proxy, test_proxy);
+    strncpy(ctx->proxy, test_proxy, sizeof(ctx->proxy) - 1);
+    ctx->proxy[sizeof(ctx->proxy) - 1] = '\0';
+    TEST_CHECK_STRING_EQUAL(ctx->proxy, test_proxy);
 
     // Verify user_agent field exists
     const char *test_ua = "sentry.native/0.8.0";
-    strncpy(ctx.user_agent, test_ua, sizeof(ctx.user_agent) - 1);
-    ctx.user_agent[sizeof(ctx.user_agent) - 1] = '\0';
-    TEST_CHECK_STRING_EQUAL(ctx.user_agent, test_ua);
+    strncpy(ctx->user_agent, test_ua, sizeof(ctx->user_agent) - 1);
+    ctx->user_agent[sizeof(ctx->user_agent) - 1] = '\0';
+    TEST_CHECK_STRING_EQUAL(ctx->user_agent, test_ua);
 
-    ctx.shutdown_timeout = 12345;
-    TEST_CHECK_UINT64_EQUAL(ctx.shutdown_timeout, 12345);
+    ctx->shutdown_timeout = 12345;
+    TEST_CHECK_UINT64_EQUAL(ctx->shutdown_timeout, 12345);
 
     // Verify fields are zero-initialized when memset to 0
-    memset(&ctx, 0, sizeof(ctx));
-    TEST_CHECK(ctx.ca_certs[0] == '\0');
-    TEST_CHECK(ctx.proxy[0] == '\0');
-    TEST_CHECK(ctx.user_agent[0] == '\0');
-    TEST_CHECK_UINT64_EQUAL(ctx.shutdown_timeout, 0);
+    memset(ctx, 0, sizeof(*ctx));
+    TEST_CHECK(ctx->ca_certs[0] == '\0');
+    TEST_CHECK(ctx->proxy[0] == '\0');
+    TEST_CHECK(ctx->user_agent[0] == '\0');
+    TEST_CHECK_UINT64_EQUAL(ctx->shutdown_timeout, 0);
+
+    sentry_free(ctx);
 #else
     SKIP_TEST();
 #endif
@@ -392,32 +397,35 @@ SENTRY_TEST(crash_context_options_propagation)
     TEST_CHECK_STRING_EQUAL(
         sentry_options_get_proxy(options), "http://myproxy:3128");
 
-    // Simulate what native_backend_startup does: copy to crash context
-    sentry_crash_context_t ctx;
-    memset(&ctx, 0, sizeof(ctx));
+    // Simulate what native_backend_startup does: copy to crash context.
+    // Heap-allocated to avoid overflowing the stack on the inline modules[].
+    sentry_crash_context_t *ctx = sentry_malloc(sizeof(*ctx));
+    TEST_ASSERT(!!ctx);
+    memset(ctx, 0, sizeof(*ctx));
 
     if (options->ca_certs) {
-        strncpy(ctx.ca_certs, options->ca_certs, sizeof(ctx.ca_certs) - 1);
-        ctx.ca_certs[sizeof(ctx.ca_certs) - 1] = '\0';
+        strncpy(ctx->ca_certs, options->ca_certs, sizeof(ctx->ca_certs) - 1);
+        ctx->ca_certs[sizeof(ctx->ca_certs) - 1] = '\0';
     }
     if (options->proxy) {
-        strncpy(ctx.proxy, options->proxy, sizeof(ctx.proxy) - 1);
-        ctx.proxy[sizeof(ctx.proxy) - 1] = '\0';
+        strncpy(ctx->proxy, options->proxy, sizeof(ctx->proxy) - 1);
+        ctx->proxy[sizeof(ctx->proxy) - 1] = '\0';
     }
     if (options->user_agent) {
         strncpy(
-            ctx.user_agent, options->user_agent, sizeof(ctx.user_agent) - 1);
-        ctx.user_agent[sizeof(ctx.user_agent) - 1] = '\0';
+            ctx->user_agent, options->user_agent, sizeof(ctx->user_agent) - 1);
+        ctx->user_agent[sizeof(ctx->user_agent) - 1] = '\0';
     }
-    ctx.shutdown_timeout = options->shutdown_timeout;
+    ctx->shutdown_timeout = options->shutdown_timeout;
 
     // Verify crash context received the values
-    TEST_CHECK_STRING_EQUAL(ctx.ca_certs, "/path/to/ca-bundle.crt");
-    TEST_CHECK_STRING_EQUAL(ctx.proxy, "http://myproxy:3128");
+    TEST_CHECK_STRING_EQUAL(ctx->ca_certs, "/path/to/ca-bundle.crt");
+    TEST_CHECK_STRING_EQUAL(ctx->proxy, "http://myproxy:3128");
     // user_agent should have the default SDK user agent
-    TEST_CHECK(ctx.user_agent[0] != '\0');
-    TEST_CHECK_UINT64_EQUAL(ctx.shutdown_timeout, 12345);
+    TEST_CHECK(ctx->user_agent[0] != '\0');
+    TEST_CHECK_UINT64_EQUAL(ctx->shutdown_timeout, 12345);
 
+    sentry_free(ctx);
     sentry_options_free(options);
 #else
     SKIP_TEST();
@@ -463,22 +471,25 @@ SENTRY_TEST(crash_context_null_options)
 #ifdef SENTRY_BACKEND_NATIVE
     SENTRY_TEST_OPTIONS_NEW(options);
 
-    // Don't set ca_certs or proxy - leave them as NULL
-    sentry_crash_context_t ctx;
-    memset(&ctx, 0, sizeof(ctx));
+    // Don't set ca_certs or proxy - leave them as NULL.
+    // Heap-allocated to avoid overflowing the stack on the inline modules[].
+    sentry_crash_context_t *ctx = sentry_malloc(sizeof(*ctx));
+    TEST_ASSERT(!!ctx);
+    memset(ctx, 0, sizeof(*ctx));
 
     // Copy like native_backend_startup does (with NULL checks)
     if (options->ca_certs) {
-        strncpy(ctx.ca_certs, options->ca_certs, sizeof(ctx.ca_certs) - 1);
+        strncpy(ctx->ca_certs, options->ca_certs, sizeof(ctx->ca_certs) - 1);
     }
     if (options->proxy) {
-        strncpy(ctx.proxy, options->proxy, sizeof(ctx.proxy) - 1);
+        strncpy(ctx->proxy, options->proxy, sizeof(ctx->proxy) - 1);
     }
 
     // All should remain empty (zero-initialized)
-    TEST_CHECK(ctx.ca_certs[0] == '\0');
-    TEST_CHECK(ctx.proxy[0] == '\0');
+    TEST_CHECK(ctx->ca_certs[0] == '\0');
+    TEST_CHECK(ctx->proxy[0] == '\0');
 
+    sentry_free(ctx);
     sentry_options_free(options);
 #else
     SKIP_TEST();


### PR DESCRIPTION
The native backend daemon captures the loaded-module list into shared memory at crash time and emits it as the minidump. Frames whose IP doesn't fall inside any captured module cannot be symbolicated server-side. They appear as `null` with just an address.

On macOS the enumeration is in dyld load order. Unity IL2CPP builds load enough Apple framework dylibs (SwiftUI/Metal/PhotoKit/CoreData transitively) that `UnityFramework` and especially `GameAssembly` arrive past the 512-module cap. You can see this 

See the resulting stack trace prior to the increase

```
  EXC_SOFTWARE / 0x00000000 / 0x11f6b0eac: Fatal Error: EXC_SOFTWARE / 0x00000000 / 0x11f6b0eac
    0x11f6b0eac  null
    0x11fb27ef4  null
    0x1214088d0  null
    0x12140a440  null
    0x121408fd0  null
    0x11f9ad290  null
    0x11f9ad1cc  null
    UnityPlayer         0x1050a625c  UNITY_TT_RunIns
    UnityPlayer         0x1050ae078  UNITY_TT_RunIns
    UnityPlayer         0x1050c4c50  UNITY_TT_RunIns
    UnityPlayer         0x104d859fc  UNITY_TT_RunIns
    UnityPlayer         0x104f323e4  UNITY_TT_RunIns
    UnityPlayer         0x104f32424  UNITY_TT_RunIns
    UnityPlayer         0x104f326f4  UNITY_TT_RunIns
    UnityPlayer         0x1052d359c  unity_operator_delete_dealloc
    UnityPlayer         0x1052d3354  unity_operator_delete_dealloc
    Foundation          0x18ee07da0  __NSFireTimer
    CoreFoundation      0x18d59dd4c  __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__
    CoreFoundation      0x18d59da44  __CFRunLoopDoTimer
    CoreFoundation      0x18d59d5bc  __CFRunLoopDoTimers
    CoreFoundation      0x18d5838c4  __CFRunLoopRun
    CoreFoundation      0x18d655bdc  _CFRunLoopRunSpecificWithOptions
    HIToolbox           0x19a35855c  RunCurrentEventLoopInMode
    HIToolbox           0x19a35b8b8  ReceiveNextEventCommon
    HIToolbox           0x19a4e5138  _BlockUntilNextEventMatchingListInMode
    AppKit              0x19205b1a0  _DPSBlockUntilNextEventMatchingListInMode
    AppKit              0x1919af080  _DPSNextEvent
    AppKit              0x192544698  -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
    AppKit              0x1925443a4  -[NSApplication(NSEventRouting) nextEventMatchingMask:untilDate:inMode:dequeue:]
    AppKit              0x1919a2138  -[NSApplication run]
    AppKit              0x19197a7ac  NSApplicationMain
    UnityPlayer         0x1052d2f10  PlayerMain
    0x18d10bda4  null
    unity-of-bugs       0x1000eff6c  _mh_execute_header
```

You can see that every frame with a low address that landed in an Apple framework (AppKit, CoreFoundation, Foundation, HIToolbox) symbolicates fine. Those modules are within the 512 cap. Every frame in `GameAssembly` is `null`. because that module's record got truncated.

Compared to a stack trace with increased module list:
```
  EXC_SOFTWARE / 0x00000000 / 0x11f4bceac: Fatal Error: EXC_SOFTWARE / 0x00000000 / 0x11f4bceac
    GameAssembly        0x11f4bceac  crash_in_c (CppPlugin.cpp:9)
    GameAssembly        0x11f933ef0  EventFunction_1_Invoke_m98A8A653E7180305E41F7CFFDDD9D32C63B96FE7_gshared_inline (EnumerableIList.cs:15)
    GameAssembly        0x11f933ef0  EventFunction_1_Invoke_m98A8A653E7180305E41F7CFFDDD9D32C63B96FE7_inline (GenericMethods__17.cpp:8877)
    GameAssembly        0x11f933ef0  ExecuteEvents_Execute_TisRuntimeObject_mDC4455B743BE4A6BA46DD741D0E0AB150FF1209A_gshared (ExecuteEvents.cs:272)
    GameAssembly        0x1212148cc  ExecuteEvents_Execute_TisIPointerClickHandler_t77341AA19DE37C26F5F619DE8BD28B70D5A2B5D8_m024FB23AA1DBB1B7A5E1935FA35A1E4FF57AC5F6 (UnityEngine.UI__3.cpp:5160)
    GameAssembly        0x1212148cc  StandaloneInputModule_ReleaseMouse_mC5C3083C356ACD5CD420A58662D99A6CACC5FAF5 (StandaloneInputModule.cs:216)
    GameAssembly        0x12121643c  StandaloneInputModule_ProcessMouseEvent_m8A8214EB9286BA31C18F515BCC3349DF740B2BBA (StandaloneInputModule.cs:578)
    GameAssembly        0x121214fcc  StandaloneInputModule_ProcessMouseEvent_mCE1BA96E47D9A4448614CB9DAF5A406754F655DD (StandaloneInputModule.cs:558)
    GameAssembly        0x121214fcc  StandaloneInputModule_Process_mBD949CC45BBCAB5A0FAF5E24F3BB4C3B22FF3E81 (StandaloneInputModule.cs:306)
    GameAssembly        0x11f7b928c  il2cpp::vm::Runtime::InvokeWithThrow (Runtime.cpp:624)
    GameAssembly        0x11f7b91c8  il2cpp::vm::Runtime::Invoke (Runtime.cpp:610)
    UnityPlayer         0x10565a25c  UNITY_TT_RunIns
    UnityPlayer         0x105662078  UNITY_TT_RunIns
    UnityPlayer         0x105678c50  UNITY_TT_RunIns
    UnityPlayer         0x1053399fc  UNITY_TT_RunIns
    UnityPlayer         0x1054e63e4  UNITY_TT_RunIns
    UnityPlayer         0x1054e6424  UNITY_TT_RunIns
    UnityPlayer         0x1054e66f4  UNITY_TT_RunIns
    UnityPlayer         0x10588759c  unity_operator_delete_dealloc
    UnityPlayer         0x105887354  unity_operator_delete_dealloc
    Foundation          0x18ee07da0  __NSFireTimer
    CoreFoundation      0x18d59dd4c  __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__
    CoreFoundation      0x18d59da44  __CFRunLoopDoTimer
    CoreFoundation      0x18d59d5bc  __CFRunLoopDoTimers
    CoreFoundation      0x18d5838c4  __CFRunLoopRun
    CoreFoundation      0x18d655bdc  _CFRunLoopRunSpecificWithOptions
    HIToolbox           0x19a35855c  RunCurrentEventLoopInMode
    HIToolbox           0x19a35b8b8  ReceiveNextEventCommon
    HIToolbox           0x19a4e5138  _BlockUntilNextEventMatchingListInMode
    AppKit              0x19205b1a0  _DPSBlockUntilNextEventMatchingListInMode
    AppKit              0x1919af080  _DPSNextEvent
    AppKit              0x192544698  -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
    AppKit              0x1925443a4  -[NSApplication(NSEventRouting) nextEventMatchingMask:untilDate:inMode:dequeue:]
    AppKit              0x1919a2138  -[NSApplication run]
    AppKit              0x19197a7ac  NSApplicationMain
    UnityPlayer         0x105886f10  PlayerMain
    0x18d10bda4  null
    unity-of-bugs       0x10039ff6c  _mh_execute_header
```

Bumping the cap to `2048` now covers observed module counts with some additional headroom. The cost comes as a  larger shared-memory reservation (`~+6 MB` on Linux/Android/macOS, `~+820 KB` on Windows).