### PR TITLE
fix: image size computation on Apple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Fixes**:
 
-- Native/macOS: fix module `image_size` computation, which could have caused the symbolicator to misattribute every frame to the lowest-addressed image (typically `dyld` or `libsystem`). ([#1741](https://github.com/getsentry/sentry-native/pull/1740))
+- Native/macOS: fix module `image_size` computation, which could have caused the symbolicator to misattribute every frame to the lowest-addressed image (typically `dyld` or `libsystem`). ([#1740](https://github.com/getsentry/sentry-native/pull/1740))
 - Reject overly deep msgpack payloads during deserialization. ([#1727](https://github.com/getsentry/sentry-native/pull/1727))
 - Read lengths for variadic fingerprints. ([#1730](https://github.com/getsentry/sentry-native/pull/1730))
 - Guard against JSON token allocation overflow on 32-bit platforms. ([#1733](https://github.com/getsentry/sentry-native/pull/1733))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Fixes**:
 
+- Native/macOS: fix module `image_size` computation, which could have caused the symbolicator to misattribute every frame to the lowest-addressed image (typically `dyld` or `libsystem`). ([#1741](https://github.com/getsentry/sentry-native/pull/1740))
 - Reject overly deep msgpack payloads during deserialization. ([#1727](https://github.com/getsentry/sentry-native/pull/1727))
 - Read lengths for variadic fingerprints. ([#1730](https://github.com/getsentry/sentry-native/pull/1730))
 - Guard against JSON token allocation overflow on 32-bit platforms. ([#1733](https://github.com/getsentry/sentry-native/pull/1733))

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -571,19 +571,10 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
                     const struct segment_command_64 *seg
                         = (const struct segment_command_64 *)cmd;
                     // Image size on macOS is canonically the __TEXT segment's
-                    // vmsize — see src/modulefinder/sentry_modulefinder_apple.c.
-                    // Using max(seg->vmaddr + seg->vmsize) breaks for shared-
-                    // cache libraries on arm64 where vmaddrs are shared-cache
-                    // absolute addresses; the result is reported as a multi-GB
-                    // image size that overlaps every other system module, so
-                    // Sentry's symbolicator mis-attributes frames to whichever
-                    // image has the lowest image_addr.
-                    if (seg->segname[0] == '_'
-                        && seg->segname[1] == '_'
-                        && seg->segname[2] == 'T'
-                        && seg->segname[3] == 'E'
-                        && seg->segname[4] == 'X'
-                        && seg->segname[5] == 'T'
+                    // vmsize, see src/modulefinder/sentry_modulefinder_apple.c.
+                    if (seg->segname[0] == '_' && seg->segname[1] == '_'
+                        && seg->segname[2] == 'T' && seg->segname[3] == 'E'
+                        && seg->segname[4] == 'X' && seg->segname[5] == 'T'
                         && seg->segname[6] == '\0') {
                         size = seg->vmsize;
                     }

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -570,17 +570,22 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
                 if (cmd->cmd == LC_SEGMENT_64) {
                     const struct segment_command_64 *seg
                         = (const struct segment_command_64 *)cmd;
-                    // Skip __PAGEZERO which has vmsize=4GB on 64-bit and
-                    // would vastly inflate the module size
-                    if (seg->initprot == 0 && seg->maxprot == 0) {
-                        cmds += cmd->cmdsize;
-                        if (cmd->cmdsize == 0)
-                            break;
-                        continue;
-                    }
-                    uint64_t seg_end = seg->vmaddr + seg->vmsize;
-                    if (seg_end > size) {
-                        size = seg_end;
+                    // Image size on macOS is canonically the __TEXT segment's
+                    // vmsize — see src/modulefinder/sentry_modulefinder_apple.c.
+                    // Using max(seg->vmaddr + seg->vmsize) breaks for shared-
+                    // cache libraries on arm64 where vmaddrs are shared-cache
+                    // absolute addresses; the result is reported as a multi-GB
+                    // image size that overlaps every other system module, so
+                    // Sentry's symbolicator mis-attributes frames to whichever
+                    // image has the lowest image_addr.
+                    if (seg->segname[0] == '_'
+                        && seg->segname[1] == '_'
+                        && seg->segname[2] == 'T'
+                        && seg->segname[3] == 'E'
+                        && seg->segname[4] == 'X'
+                        && seg->segname[5] == 'T'
+                        && seg->segname[6] == '\0') {
+                        size = seg->vmsize;
                     }
                 } else if (cmd->cmd == LC_UUID) {
                     // Extract UUID for symbolication

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -562,8 +562,12 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
             const struct mach_header_64 *header64
                 = (const struct mach_header_64 *)header;
             const uint8_t *cmds = (const uint8_t *)(header64 + 1);
+            bool has_size = false;
+            bool has_uuid = false;
 
-            for (uint32_t j = 0; j < header64->ncmds && j < 256; j++) {
+            for (uint32_t j = 0;
+                j < header64->ncmds && j < 256 && (!has_size || !has_uuid);
+                j++) {
                 const struct load_command *cmd
                     = (const struct load_command *)cmds;
 
@@ -572,17 +576,16 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
                         = (const struct segment_command_64 *)cmd;
                     // Image size on macOS is canonically the __TEXT segment's
                     // vmsize, see src/modulefinder/sentry_modulefinder_apple.c.
-                    if (seg->segname[0] == '_' && seg->segname[1] == '_'
-                        && seg->segname[2] == 'T' && seg->segname[3] == 'E'
-                        && seg->segname[4] == 'X' && seg->segname[5] == 'T'
-                        && seg->segname[6] == '\0') {
+                    if (memcmp(seg->segname, "__TEXT", 7) == 0) {
                         size = seg->vmsize;
+                        has_size = true;
                     }
                 } else if (cmd->cmd == LC_UUID) {
                     // Extract UUID for symbolication
                     const struct uuid_command *uuid_cmd
                         = (const struct uuid_command *)cmd;
                     signal_safe_memcpy(module->uuid, uuid_cmd->uuid, 16);
+                    has_uuid = true;
                 }
 
                 cmds += cmd->cmdsize;

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -574,8 +574,8 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
                 if (cmd->cmd == LC_SEGMENT_64) {
                     const struct segment_command_64 *seg
                         = (const struct segment_command_64 *)cmd;
-                    // Image size on macOS is canonically the __TEXT segment's
-                    // vmsize, see src/modulefinder/sentry_modulefinder_apple.c.
+                    // image_size on macOS is the __TEXT segment's vmsize:
+                    // https://github.com/getsentry/sentry-native/blob/82dec4b8518de32586c4a761a3a9df4aed9d7b8d/src/modulefinder/sentry_modulefinder_apple.c#L65-L69
                     if (memcmp(seg->segname, "__TEXT", 7) == 0) {
                         size = seg->vmsize;
                         has_size = true;

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -182,10 +182,7 @@ def assert_event_meta(
         )
 
 
-# Largest image_size we accept for any single Mach-O / ELF / PE module.
-# In practice modules are at most a few hundred MB; anything past 1 GiB is a
-# computation bug. Picked generously so a legitimate-but-large module never
-# trips this, but small enough to flag the shared-cache inflation regression.
+# 1 GiB as largest image_size we accept for any single Mach-O / ELF / PE module.
 _MAX_IMAGE_SIZE_BYTES = 1 << 30
 
 
@@ -195,14 +192,6 @@ def assert_debug_meta_images_sane(event):
     Each image must have a plausible ``image_size`` and the half-open ranges
     ``[image_addr, image_addr + image_size)`` must not overlap.
 
-    Regression test for macOS arm64: the native crash handler used to compute
-    module size as ``max(seg->vmaddr + seg->vmsize)`` across all
-    ``LC_SEGMENT_64`` commands. For dyld-shared-cache libraries the segment
-    ``vmaddr`` is a shared-cache-absolute address, so the result was multi-GB
-    and every system image's range overlapped every other. The symbolicator
-    then misattributed every frame to whichever image had the lowest
-    ``image_addr``. The fix uses ``__TEXT.vmsize`` -- matching the non-crash
-    path in ``sentry_modulefinder_apple.c``.
     """
     images = event["debug_meta"]["images"]
     assert len(images) > 0, "debug_meta should contain at least one image"

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -198,9 +198,7 @@ def assert_debug_meta_images_do_not_overlap(event):
         ranges.append((addr, addr + image["image_size"], name))
 
     ranges.sort()
-    for (a_start, a_end, a_name), (b_start, b_end, b_name) in zip(
-        ranges, ranges[1:]
-    ):
+    for (a_start, a_end, a_name), (b_start, b_end, b_name) in zip(ranges, ranges[1:]):
         assert a_end <= b_start, (
             f"image ranges overlap: {a_name} [{a_start:#x}, {a_end:#x}) "
             f"vs {b_name} [{b_start:#x}, {b_end:#x})"

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -182,7 +182,7 @@ def assert_event_meta(
         )
 
 
-def assert_debug_meta_images_sane(event):
+def assert_debug_meta_images_do_not_overlap(event):
     """Validate ``event["debug_meta"]["images"]`` shape.
 
     The half-open ranges ``[image_addr, image_addr + image_size)`` must not

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -182,29 +182,20 @@ def assert_event_meta(
         )
 
 
-# 1 GiB as largest image_size we accept for any single Mach-O / ELF / PE module.
-_MAX_IMAGE_SIZE_BYTES = 1 << 30
-
-
 def assert_debug_meta_images_sane(event):
     """Validate ``event["debug_meta"]["images"]`` shape.
 
-    Each image must have a plausible ``image_size`` and the half-open ranges
-    ``[image_addr, image_addr + image_size)`` must not overlap.
-
+    The half-open ranges ``[image_addr, image_addr + image_size)`` must not
+    overlap -- the symbolicator relies on this to attribute frames to images.
     """
     images = event["debug_meta"]["images"]
     assert len(images) > 0, "debug_meta should contain at least one image"
 
     ranges = []
     for image in images:
-        size = image["image_size"]
         name = image.get("code_file") or image.get("debug_file") or "<unknown>"
-        assert isinstance(size, int) and 0 < size < _MAX_IMAGE_SIZE_BYTES, (
-            f"implausible image_size {size} for {name!r}"
-        )
         addr = int(image["image_addr"], 16)
-        ranges.append((addr, addr + size, name))
+        ranges.append((addr, addr + image["image_size"], name))
 
     ranges.sort()
     for (a_start, a_end, a_name), (b_start, b_end, b_name) in zip(

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -182,6 +182,51 @@ def assert_event_meta(
         )
 
 
+# Largest image_size we accept for any single Mach-O / ELF / PE module.
+# In practice modules are at most a few hundred MB; anything past 1 GiB is a
+# computation bug. Picked generously so a legitimate-but-large module never
+# trips this, but small enough to flag the shared-cache inflation regression.
+_MAX_IMAGE_SIZE_BYTES = 1 << 30
+
+
+def assert_debug_meta_images_sane(event):
+    """Validate ``event["debug_meta"]["images"]`` shape.
+
+    Each image must have a plausible ``image_size`` and the half-open ranges
+    ``[image_addr, image_addr + image_size)`` must not overlap.
+
+    Regression test for macOS arm64: the native crash handler used to compute
+    module size as ``max(seg->vmaddr + seg->vmsize)`` across all
+    ``LC_SEGMENT_64`` commands. For dyld-shared-cache libraries the segment
+    ``vmaddr`` is a shared-cache-absolute address, so the result was multi-GB
+    and every system image's range overlapped every other. The symbolicator
+    then misattributed every frame to whichever image had the lowest
+    ``image_addr``. The fix uses ``__TEXT.vmsize`` -- matching the non-crash
+    path in ``sentry_modulefinder_apple.c``.
+    """
+    images = event["debug_meta"]["images"]
+    assert len(images) > 0, "debug_meta should contain at least one image"
+
+    ranges = []
+    for image in images:
+        size = image["image_size"]
+        name = image.get("code_file") or image.get("debug_file") or "<unknown>"
+        assert isinstance(size, int) and 0 < size < _MAX_IMAGE_SIZE_BYTES, (
+            f"implausible image_size {size} for {name!r}"
+        )
+        addr = int(image["image_addr"], 16)
+        ranges.append((addr, addr + size, name))
+
+    ranges.sort()
+    for (a_start, a_end, a_name), (b_start, b_end, b_name) in zip(
+        ranges, ranges[1:]
+    ):
+        assert a_end <= b_start, (
+            f"image ranges overlap: {a_name} [{a_start:#x}, {a_end:#x}) "
+            f"vs {b_name} [{b_start:#x}, {b_end:#x})"
+        )
+
+
 def is_valid_hex(s):
     if not s.lower().startswith("0x"):
         return False

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -555,7 +555,8 @@ def test_crash_mode_native_only(cmake, httpserver):
     # Should have debug_meta
     assert "debug_meta" in event
     assert len(event["debug_meta"]["images"]) > 0
-    assert_debug_meta_images_do_not_overlap(event)
+    if sys.platform == "darwin":
+        assert_debug_meta_images_do_not_overlap(event)
 
 
 def test_crash_mode_native_with_minidump(cmake, httpserver):
@@ -600,7 +601,8 @@ def test_crash_mode_native_with_minidump(cmake, httpserver):
 
     # Should have debug_meta
     assert "debug_meta" in event
-    assert_debug_meta_images_do_not_overlap(event)
+    if sys.platform == "darwin":
+        assert_debug_meta_images_do_not_overlap(event)
 
 
 def test_native_cache_consent(cmake, httpserver):

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -20,6 +20,7 @@ from . import (
 )
 from .assertions import (
     assert_breadcrumb,
+    assert_debug_meta_images_sane,
     assert_meta,
     assert_native_crash,
     assert_session,
@@ -554,6 +555,9 @@ def test_crash_mode_native_only(cmake, httpserver):
     # Should have debug_meta
     assert "debug_meta" in event
     assert len(event["debug_meta"]["images"]) > 0
+    # Regression: macOS arm64 used to report multi-GB image_size for
+    # shared-cache libraries, causing symbolicator mis-attribution.
+    assert_debug_meta_images_sane(event)
 
 
 def test_crash_mode_native_with_minidump(cmake, httpserver):
@@ -598,6 +602,7 @@ def test_crash_mode_native_with_minidump(cmake, httpserver):
 
     # Should have debug_meta
     assert "debug_meta" in event
+    assert_debug_meta_images_sane(event)
 
 
 def test_native_cache_consent(cmake, httpserver):

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -555,8 +555,6 @@ def test_crash_mode_native_only(cmake, httpserver):
     # Should have debug_meta
     assert "debug_meta" in event
     assert len(event["debug_meta"]["images"]) > 0
-    # Regression: macOS arm64 used to report multi-GB image_size for
-    # shared-cache libraries, causing symbolicator mis-attribution.
     assert_debug_meta_images_sane(event)
 
 

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -20,7 +20,7 @@ from . import (
 )
 from .assertions import (
     assert_breadcrumb,
-    assert_debug_meta_images_sane,
+    assert_debug_meta_images_do_not_overlap,
     assert_meta,
     assert_native_crash,
     assert_session,
@@ -555,7 +555,7 @@ def test_crash_mode_native_only(cmake, httpserver):
     # Should have debug_meta
     assert "debug_meta" in event
     assert len(event["debug_meta"]["images"]) > 0
-    assert_debug_meta_images_sane(event)
+    assert_debug_meta_images_do_not_overlap(event)
 
 
 def test_crash_mode_native_with_minidump(cmake, httpserver):
@@ -600,7 +600,7 @@ def test_crash_mode_native_with_minidump(cmake, httpserver):
 
     # Should have debug_meta
     assert "debug_meta" in event
-    assert_debug_meta_images_sane(event)
+    assert_debug_meta_images_do_not_overlap(event)
 
 
 def test_native_cache_consent(cmake, httpserver):


### PR DESCRIPTION
On macOS arm64 the native crash handler computed each module's image_size as `max(seg->vmaddr + seg->vmsize)` across all `LC_SEGMENT_64` commands. For dyld-shared-cache libraries `seg->vmaddr` is a shared-cache-absolute address, not relative to the image base, so the result lands in the multi-GB range. Every system image's half-open range `[image_addr, image_addr + image_size)` then overlaps every other. This caused the symbolicator to attribute every frame to whichever image has the lowest `image_addr`.  Turns out that typically is dyld or the first libsystem module.
 
See misattribution:
```
EXC_SOFTWARE / 0x00000000 / 0x1206cceac: Fatal Error: EXC_SOFTWARE / 0x00000000 / 0x1206cceac
  GameAssembly        0x1206cceac  crash_in_c (CppPlugin.cpp:9)
  GameAssembly        0x1220a72a0  UnityAction_Invoke_m5CB9EE17CCDF64D00DE5D96DF3553CDB20D66F70_inline (UnityEngine.CoreModule__2.cpp:41033)
  GameAssembly        0x1220a72a0  InvokableCall_Invoke_m6F4828FD2B3E3BBB7AA6EECC2C37FB08538363F4 (UnityEngine.CoreModule__2.cpp:23612)
  GameAssembly        0x1220a72a0  UnityEvent_Invoke_mFBF80D59B03C30C5FE6A06F897D954ACADE061D2 (UnityEngine.CoreModule__2.cpp)
  GameAssembly        0x120b43ef0  EventFunction_1_Invoke_m98A8A653E7180305E41F7CFFDDD9D32C63B96FE7_gshared_inline (EnumerableIList.cs:15)
  GameAssembly        0x120b43ef0  EventFunction_1_Invoke_m98A8A653E7180305E41F7CFFDDD9D32C63B96FE7_inline (GenericMethods__17.cpp:8877)
  GameAssembly        0x120b43ef0  ExecuteEvents_Execute_TisRuntimeObject_mDC4455B743BE4A6BA46DD741D0E0AB150FF1209A_gshared (ExecuteEvents.cs:272)
  GameAssembly        0x1224248cc  ExecuteEvents_Execute_TisIPointerClickHandler_t77341AA19DE37C26F5F619DE8BD28B70D5A2B5D8_m024FB23AA1DBB1B7A5E1935FA35A1E4FF57AC5F6 (UnityEngine.UI__3.cpp:5160)
  GameAssembly        0x1224248cc  StandaloneInputModule_ReleaseMouse_mC5C3083C356ACD5CD420A58662D99A6CACC5FAF5 (StandaloneInputModule.cs:216)
  GameAssembly        0x12242643c  StandaloneInputModule_ProcessMouseEvent_m8A8214EB9286BA31C18F515BCC3349DF740B2BBA (StandaloneInputModule.cs:578)
  GameAssembly        0x122424fcc  StandaloneInputModule_ProcessMouseEvent_mCE1BA96E47D9A4448614CB9DAF5A406754F655DD (StandaloneInputModule.cs:558)
  GameAssembly        0x122424fcc  StandaloneInputModule_Process_mBD949CC45BBCAB5A0FAF5E24F3BB4C3B22FF3E81 (StandaloneInputModule.cs:306)
  GameAssembly        0x1209c928c  il2cpp::vm::Runtime::InvokeWithThrow (Runtime.cpp:624)
  GameAssembly        0x1209c91c8  il2cpp::vm::Runtime::Invoke (Runtime.cpp:610)
  UnityPlayer         0x1060be25c  UNITY_TT_RunIns
  UnityPlayer         0x1060c6078  UNITY_TT_RunIns
  UnityPlayer         0x1060dcc50  UNITY_TT_RunIns
  UnityPlayer         0x105d9d9fc  UNITY_TT_RunIns
  UnityPlayer         0x105f4a3e4  UNITY_TT_RunIns
  UnityPlayer         0x105f4a424  UNITY_TT_RunIns
  UnityPlayer         0x105f4a6f4  UNITY_TT_RunIns
  UnityPlayer         0x1062eb59c  unity_operator_delete_dealloc
  UnityPlayer         0x1062eb354  unity_operator_delete_dealloc
  libobjc.A           0x18ee07da0  startWeakTableScan
  libobjc.A           0x18d59dd4c  startWeakTableScan
  libobjc.A           0x18d59da44  startWeakTableScan
  libobjc.A           0x18d59d5bc  startWeakTableScan
  libobjc.A           0x18d5838c4  startWeakTableScan
  libobjc.A           0x18d655bdc  startWeakTableScan
  libobjc.A           0x19a35855c  startWeakTableScan
  libobjc.A           0x19a35b8b8  startWeakTableScan
  libobjc.A           0x19a4e5138  startWeakTableScan
  libobjc.A           0x19205b1a0  startWeakTableScan
  libobjc.A           0x1919af080  startWeakTableScan
  libobjc.A           0x192544698  startWeakTableScan
  libobjc.A           0x1925443a4  startWeakTableScan
  libobjc.A           0x1919a2138  startWeakTableScan
  libobjc.A           0x19197a7ac  startWeakTableScan
  UnityPlayer         0x1062eaf10  PlayerMain
  libobjc.A           0x18d10bda0  startWeakTableScan
  libobjc.A           0x18d0ebffc  startWeakTableScan
  unity-of-bugs       0x100f8ff6c  _mh_execute_header
  libobjc.A           0x18d10bffc  startWeakTableScan
```

We already use `__TEXT` in `sentry_modulefinder_apple.c` https://github.com/getsentry/sentry-native/blob/82dec4b8518de32586c4a761a3a9df4aed9d7b8d/src/modulefinder/sentry_modulefinder_apple.c#L65-L67
 to get to the correct per-image extent.

So now it looks like

```
EXC_SOFTWARE / 0x00000000 / 0x11f4bceac: Fatal Error: EXC_SOFTWARE / 0x00000000 / 0x11f4bceac
  GameAssembly        0x11f4bceac  crash_in_c (CppPlugin.cpp:9)
  GameAssembly        0x11f933ef0  EventFunction_1_Invoke_m98A8A653E7180305E41F7CFFDDD9D32C63B96FE7_gshared_inline (EnumerableIList.cs:15)
  GameAssembly        0x11f933ef0  EventFunction_1_Invoke_m98A8A653E7180305E41F7CFFDDD9D32C63B96FE7_inline (GenericMethods__17.cpp:8877)
  GameAssembly        0x11f933ef0  ExecuteEvents_Execute_TisRuntimeObject_mDC4455B743BE4A6BA46DD741D0E0AB150FF1209A_gshared (ExecuteEvents.cs:272)
  GameAssembly        0x1212148cc  ExecuteEvents_Execute_TisIPointerClickHandler_t77341AA19DE37C26F5F619DE8BD28B70D5A2B5D8_m024FB23AA1DBB1B7A5E1935FA35A1E4FF57AC5F6 (UnityEngine.UI__3.cpp:5160)
  GameAssembly        0x1212148cc  StandaloneInputModule_ReleaseMouse_mC5C3083C356ACD5CD420A58662D99A6CACC5FAF5 (StandaloneInputModule.cs:216)
  GameAssembly        0x12121643c  StandaloneInputModule_ProcessMouseEvent_m8A8214EB9286BA31C18F515BCC3349DF740B2BBA (StandaloneInputModule.cs:578)
  GameAssembly        0x121214fcc  StandaloneInputModule_ProcessMouseEvent_mCE1BA96E47D9A4448614CB9DAF5A406754F655DD (StandaloneInputModule.cs:558)
  GameAssembly        0x121214fcc  StandaloneInputModule_Process_mBD949CC45BBCAB5A0FAF5E24F3BB4C3B22FF3E81 (StandaloneInputModule.cs:306)
  GameAssembly        0x11f7b928c  il2cpp::vm::Runtime::InvokeWithThrow (Runtime.cpp:624)
  GameAssembly        0x11f7b91c8  il2cpp::vm::Runtime::Invoke (Runtime.cpp:610)
  UnityPlayer         0x10565a25c  UNITY_TT_RunIns
  UnityPlayer         0x105662078  UNITY_TT_RunIns
  UnityPlayer         0x105678c50  UNITY_TT_RunIns
  UnityPlayer         0x1053399fc  UNITY_TT_RunIns
  UnityPlayer         0x1054e63e4  UNITY_TT_RunIns
  UnityPlayer         0x1054e6424  UNITY_TT_RunIns
  UnityPlayer         0x1054e66f4  UNITY_TT_RunIns
  UnityPlayer         0x10588759c  unity_operator_delete_dealloc
  UnityPlayer         0x105887354  unity_operator_delete_dealloc
  Foundation          0x18ee07da0  __NSFireTimer
  CoreFoundation      0x18d59dd4c  __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__
  CoreFoundation      0x18d59da44  __CFRunLoopDoTimer
  CoreFoundation      0x18d59d5bc  __CFRunLoopDoTimers
  CoreFoundation      0x18d5838c4  __CFRunLoopRun
  CoreFoundation      0x18d655bdc  _CFRunLoopRunSpecificWithOptions
  HIToolbox           0x19a35855c  RunCurrentEventLoopInMode
  HIToolbox           0x19a35b8b8  ReceiveNextEventCommon
  HIToolbox           0x19a4e5138  _BlockUntilNextEventMatchingListInMode
  AppKit              0x19205b1a0  _DPSBlockUntilNextEventMatchingListInMode
  AppKit              0x1919af080  _DPSNextEvent
  AppKit              0x192544698  -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
  AppKit              0x1925443a4  -[NSApplication(NSEventRouting) nextEventMatchingMask:untilDate:inMode:dequeue:]
  AppKit              0x1919a2138  -[NSApplication run]
  AppKit              0x19197a7ac  NSApplicationMain
  UnityPlayer         0x105886f10  PlayerMain
  0x18d10bda4  null
  unity-of-bugs       0x10039ff6c  _mh_execute_header
```