### PR TITLE
feat: add `transfer_timeout` option for large uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**:
+
+- Add a `transfer_timeout` option for SDK-managed HTTP transports. ([#1741](https://github.com/getsentry/sentry-native/pull/1741))
+
 **Fixes**:
 
 - Native/macOS: fix module `image_size` computation, which could have caused the symbolicator to misattribute every frame to the lowest-addressed image (typically `dyld` or `libsystem`). ([#1740](https://github.com/getsentry/sentry-native/pull/1740))

--- a/examples/example.c
+++ b/examples/example.c
@@ -554,6 +554,12 @@ main(int argc, char **argv)
         sentry_options_set_shutdown_timeout(
             options, strtoull(shutdown_timeout, NULL, 10));
     }
+    const char *transfer_timeout
+        = get_arg_value(argc, argv, "transfer-timeout");
+    if (transfer_timeout) {
+        sentry_options_set_transfer_timeout(
+            options, strtoull(transfer_timeout, NULL, 10));
+    }
 
     sentry_options_set_environment(options, "development");
     // sentry defaults this to the `SENTRY_RELEASE` env variable

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1922,6 +1922,22 @@ SENTRY_API void sentry_options_set_shutdown_timeout(
 SENTRY_API uint64_t sentry_options_get_shutdown_timeout(sentry_options_t *opts);
 
 /**
+ * Sets the maximum time (in milliseconds) an HTTP request is allowed to take.
+ *
+ * This setting applies to the SDK-managed HTTP transports. It is not supported
+ * by Crashpad's crash report upload.
+ *
+ * The default value is 0, which disables the transfer timeout.
+ */
+SENTRY_API void sentry_options_set_transfer_timeout(
+    sentry_options_t *opts, uint64_t transfer_timeout);
+
+/**
+ * Gets the maximum time (in milliseconds) an HTTP request is allowed to take.
+ */
+SENTRY_API uint64_t sentry_options_get_transfer_timeout(sentry_options_t *opts);
+
+/**
  * Sets a user-defined backend.
  *
  * Since creation and destruction of backends is not exposed in the API, this

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -1922,7 +1922,11 @@ SENTRY_API void sentry_options_set_shutdown_timeout(
 SENTRY_API uint64_t sentry_options_get_shutdown_timeout(sentry_options_t *opts);
 
 /**
- * Sets the maximum time (in milliseconds) an HTTP request is allowed to take.
+ * Sets the timeout (in milliseconds) for HTTP transfer operations.
+ *
+ * On curl, this limits the total time an HTTP request is allowed to take. On
+ * WinHTTP, this is applied to send and receive operations, which WinHTTP
+ * applies to individual packets.
  *
  * This setting applies to the SDK-managed HTTP transports. It is not supported
  * by Crashpad's crash report upload.
@@ -1933,7 +1937,7 @@ SENTRY_API void sentry_options_set_transfer_timeout(
     sentry_options_t *opts, uint64_t transfer_timeout);
 
 /**
- * Gets the maximum time (in milliseconds) an HTTP request is allowed to take.
+ * Gets the timeout (in milliseconds) for HTTP transfer operations.
  */
 SENTRY_API uint64_t sentry_options_get_transfer_timeout(sentry_options_t *opts);
 

--- a/src/backends/native/sentry_crash_context.h
+++ b/src/backends/native/sentry_crash_context.h
@@ -285,6 +285,7 @@ typedef struct {
     bool enable_large_attachments;
     bool http_retry;
     uint64_t shutdown_timeout;
+    uint64_t transfer_timeout;
 
     // Atomic user consent (sentry_user_consent_t), updated whenever user
     // consent changes so the daemon can honor it at crash time.

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3361,6 +3361,7 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     options->enable_large_attachments = ipc->shmem->enable_large_attachments;
     options->http_retry = false;
     options->shutdown_timeout = ipc->shmem->shutdown_timeout;
+    options->transfer_timeout = ipc->shmem->transfer_timeout;
 
     // Set custom logger that writes to file
     if (log_file) {

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -304,6 +304,7 @@ native_backend_startup(
     ctx->enable_large_attachments = options->enable_large_attachments;
     ctx->http_retry = options->http_retry;
     ctx->shutdown_timeout = options->shutdown_timeout;
+    ctx->transfer_timeout = options->transfer_timeout;
     sentry__atomic_store(
         &ctx->user_consent, sentry__atomic_fetch(&options->run->user_consent));
 

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -87,6 +87,7 @@ sentry_options_new(void)
     opts->transport = sentry__transport_new_default();
     opts->refcount = 1;
     opts->shutdown_timeout = SENTRY_DEFAULT_SHUTDOWN_TIMEOUT;
+    opts->transfer_timeout = SENTRY_DEFAULT_TRANSFER_TIMEOUT;
     sentry_options_set_sample_rate(
         opts, sentry__getenv_double("SENTRY_SAMPLE_RATE", 1.0));
     sentry_options_set_traces_sample_rate(
@@ -640,6 +641,19 @@ uint64_t
 sentry_options_get_shutdown_timeout(sentry_options_t *opts)
 {
     return opts->shutdown_timeout;
+}
+
+void
+sentry_options_set_transfer_timeout(
+    sentry_options_t *opts, uint64_t transfer_timeout)
+{
+    opts->transfer_timeout = transfer_timeout;
+}
+
+uint64_t
+sentry_options_get_transfer_timeout(sentry_options_t *opts)
+{
+    return opts->transfer_timeout;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -12,6 +12,7 @@
 // Defaults to 2s as per
 // https://docs.sentry.io/error-reporting/configuration/?platform=native#shutdown-timeout
 #define SENTRY_DEFAULT_SHUTDOWN_TIMEOUT 2000
+#define SENTRY_DEFAULT_TRANSFER_TIMEOUT 0
 
 struct sentry_backend_s;
 
@@ -95,6 +96,7 @@ struct sentry_options_s {
 
     long refcount;
     uint64_t shutdown_timeout;
+    uint64_t transfer_timeout;
     sentry_handler_strategy_t handler_strategy;
     int minidump_mode; // 0=stack_only, 1=smart, 2=full (see
                        // sentry_crash_context.h)

--- a/src/transports/sentry_http_transport_curl.c
+++ b/src/transports/sentry_http_transport_curl.c
@@ -11,6 +11,7 @@
 
 #include <curl/curl.h>
 #include <curl/easy.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -23,6 +24,7 @@ typedef struct {
     char *proxy;
     char *ca_certs;
     bool debug;
+    uint64_t transfer_timeout;
     long shutdown;
 #ifdef SENTRY_PLATFORM_NX
     void *nx_state;
@@ -108,6 +110,7 @@ curl_client_start(void *_client, const sentry_options_t *options)
     client->ca_certs = sentry__string_clone(options->ca_certs);
     client->curl_handle = curl_easy_init();
     client->debug = options->debug;
+    client->transfer_timeout = options->transfer_timeout;
 
     if (!client->curl_handle) {
         // In this case we don't start the worker at all, which means we can
@@ -123,6 +126,12 @@ curl_client_start(void *_client, const sentry_options_t *options)
 #endif
 
     return 0;
+}
+
+static long
+curl_timeout_ms(uint64_t timeout)
+{
+    return timeout > (uint64_t)LONG_MAX ? LONG_MAX : (long)timeout;
 }
 
 static void
@@ -235,6 +244,8 @@ curl_send_task(void *_client, sentry_prepared_http_request_t *req,
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, SENTRY_SDK_USER_AGENT);
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 15000L);
+    curl_easy_setopt(
+        curl, CURLOPT_TIMEOUT_MS, curl_timeout_ms(client->transfer_timeout));
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, progress_callback);
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA, client);

--- a/src/transports/sentry_http_transport_winhttp.c
+++ b/src/transports/sentry_http_transport_winhttp.c
@@ -144,7 +144,7 @@ winhttp_client_start(void *_client, const sentry_options_t *opts)
         return 1;
     }
 
-    // 15s for resolve/connect, transfer_timeout for send/receive (0 disables)
+    // 15s for resolve/connect, transfer_timeout for send/receive per packet
     int transfer_timeout = winhttp_timeout_ms(client->transfer_timeout);
     WinHttpSetTimeouts(
         client->session, 15000, 15000, transfer_timeout, transfer_timeout);

--- a/src/transports/sentry_http_transport_winhttp.c
+++ b/src/transports/sentry_http_transport_winhttp.c
@@ -12,6 +12,7 @@
 #    include "sentry_transport_xbox.h"
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <winhttp.h>
@@ -24,6 +25,7 @@ typedef struct {
     HINTERNET connect;
     HINTERNET request;
     bool debug;
+    uint64_t transfer_timeout;
     long shutdown;
 } winhttp_client_t;
 
@@ -80,12 +82,19 @@ set_proxy_credentials(winhttp_client_t *state, const char *proxy)
 }
 
 static int
+winhttp_timeout_ms(uint64_t timeout)
+{
+    return timeout > (uint64_t)INT_MAX ? INT_MAX : (int)timeout;
+}
+
+static int
 winhttp_client_start(void *_client, const sentry_options_t *opts)
 {
     winhttp_client_t *client = _client;
 
     wchar_t *user_agent = sentry__string_to_wstr(opts->user_agent);
     client->debug = opts->debug;
+    client->transfer_timeout = opts->transfer_timeout;
 
     const char *env_proxy = opts->dsn
         ? getenv(opts->dsn->is_secure ? "https_proxy" : "http_proxy")
@@ -135,8 +144,10 @@ winhttp_client_start(void *_client, const sentry_options_t *opts)
         return 1;
     }
 
-    // 15s resolve/connect, 30s send/receive (WinHTTP defaults)
-    WinHttpSetTimeouts(client->session, 15000, 15000, 30000, 30000);
+    // 15s for resolve/connect, transfer_timeout for send/receive (0 disables)
+    int transfer_timeout = winhttp_timeout_ms(client->transfer_timeout);
+    WinHttpSetTimeouts(
+        client->session, 15000, 15000, transfer_timeout, transfer_timeout);
 
     return 0;
 }

--- a/tests/unit/test_native_backend.c
+++ b/tests/unit/test_native_backend.c
@@ -362,6 +362,8 @@ SENTRY_TEST(crash_context_transport_fields)
 
     ctx->shutdown_timeout = 12345;
     TEST_CHECK_UINT64_EQUAL(ctx->shutdown_timeout, 12345);
+    ctx->transfer_timeout = 45000;
+    TEST_CHECK_UINT64_EQUAL(ctx->transfer_timeout, 45000);
 
     // Verify fields are zero-initialized when memset to 0
     memset(ctx, 0, sizeof(*ctx));
@@ -369,6 +371,7 @@ SENTRY_TEST(crash_context_transport_fields)
     TEST_CHECK(ctx->proxy[0] == '\0');
     TEST_CHECK(ctx->user_agent[0] == '\0');
     TEST_CHECK_UINT64_EQUAL(ctx->shutdown_timeout, 0);
+    TEST_CHECK_UINT64_EQUAL(ctx->transfer_timeout, 0);
 
     sentry_free(ctx);
 #else
@@ -390,6 +393,7 @@ SENTRY_TEST(crash_context_options_propagation)
     sentry_options_set_ca_certs(options, "/path/to/ca-bundle.crt");
     sentry_options_set_proxy(options, "http://myproxy:3128");
     sentry_options_set_shutdown_timeout(options, 12345);
+    sentry_options_set_transfer_timeout(options, 45000);
 
     // Verify options were set correctly
     TEST_CHECK_STRING_EQUAL(
@@ -417,6 +421,7 @@ SENTRY_TEST(crash_context_options_propagation)
         ctx->user_agent[sizeof(ctx->user_agent) - 1] = '\0';
     }
     ctx->shutdown_timeout = options->shutdown_timeout;
+    ctx->transfer_timeout = options->transfer_timeout;
 
     // Verify crash context received the values
     TEST_CHECK_STRING_EQUAL(ctx->ca_certs, "/path/to/ca-bundle.crt");
@@ -424,6 +429,7 @@ SENTRY_TEST(crash_context_options_propagation)
     // user_agent should have the default SDK user agent
     TEST_CHECK(ctx->user_agent[0] != '\0');
     TEST_CHECK_UINT64_EQUAL(ctx->shutdown_timeout, 12345);
+    TEST_CHECK_UINT64_EQUAL(ctx->transfer_timeout, 45000);
 
     sentry_free(ctx);
     sentry_options_free(options);


### PR DESCRIPTION
Add `transfer_timeout` as a dedicated option for SDK-managed HTTP transports. The proposed default is 0 (no transfer timeout), which was the previous default for curl.

This matters most for large uploads: without server-side chunked/resumable upload support, a long/hanging transfer can occupy the single-threaded transport pipeline for a long time.

Transfer timeouts were previously inconsistent across transports: curl had no total transfer timeout, while WinHTTP was capped by the 30s OS-default send/receive timeout that is too low for large uploads. This makes the behavior explicit and configurable without overloading `shutdown_timeout`, which only controls shutdown waits. Large uploads can also happen while retrying cached envelopes on restart, so the timeout needs to apply to HTTP transfer behavior rather than shutdown waiting.

Crashpad's own crash report upload does not support this option, but it does have a hardcoded 60s limit:
- https://github.com/getsentry/crashpad/blob/ff141a8c0cc852f9c3d42e13bd9ada551351bc21/client/settings.h#L52-L58
- https://github.com/getsentry/crashpad/blob/ff141a8c0cc852f9c3d42e13bd9ada551351bc21/handler/crash_report_upload_thread.cc#L348-L349
