### PR TITLE
test: stabilize test_tus_shutdown

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -1251,7 +1251,7 @@ main(int argc, char **argv)
     sentry_close();
 
     if (has_arg(argc, argv, "sleep-after-shutdown")) {
-        sleep_s(1);
+        sleep_s(5);
     }
 
     if (has_arg(argc, argv, "crash-after-shutdown")) {


### PR DESCRIPTION
The TUS shutdown integration test intentionally blocks the TUS create request during shutdown. Give the WinHTTP transport more time to process shutdown cancellation and persist pending envelopes before the example process exits.