### PR TITLE
test: restart on crash

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -145,45 +145,16 @@ restart_on_crash(
 {
     (void)uctx;
 
-    int argc = 0;
-    char **argv = user_data;
-    assert(argv);
-    assert(argv[0]);
-    while (argv[argc]) {
-        argc++;
-    }
-
 #ifdef SENTRY_PLATFORM_WINDOWS
-    wchar_t module_path[MAX_PATH];
-    if (GetModuleFileNameW(NULL, module_path, MAX_PATH) > 0) {
-        int child_argc = 0;
-        wchar_t **child_argv = alloca((argc + 1) * sizeof(wchar_t *));
-        for (int i = 0; argv[i]; i++) {
-            if (strcmp(argv[i], "restart-on-crash") == 0) {
-                continue;
-            }
-            if (i == 0) {
-                child_argv[child_argc++] = module_path;
-            } else {
-                size_t len = strlen(argv[i]) + 1;
-                child_argv[child_argc] = alloca(len * sizeof(wchar_t));
-                mbstowcs(child_argv[child_argc++], argv[i], len);
-            }
-        }
-        child_argv[child_argc] = NULL;
-
-        _wspawnv(_P_NOWAIT, child_argv[0], (const wchar_t *const *)child_argv);
+    wchar_t **argv = user_data;
+    if (argv && argv[0]) {
+        _wspawnv(_P_NOWAIT, argv[0], (const wchar_t *const *)argv);
     }
 #else
-    int child_argc = 0;
-    char **child_argv = alloca((argc + 1) * sizeof(char *));
-    for (int i = 0; argv[i]; i++) {
-        if (strcmp(argv[i], "restart-on-crash") != 0) {
-            child_argv[child_argc++] = argv[i];
-        }
+    char **argv = user_data;
+    if (!argv || !argv[0]) {
+        return event;
     }
-    child_argv[child_argc] = NULL;
-
     if (fork() == 0) {
         // The crashing signal is blocked while the crash handler runs. Do not
         // let the restarted child inherit that mask.
@@ -191,12 +162,58 @@ restart_on_crash(
         sigfillset(&set);
         sigprocmask(SIG_UNBLOCK, &set, NULL);
 
-        execv(child_argv[0], child_argv);
+        execv(argv[0], argv);
         _exit(127);
     }
 #endif
 
     return event;
+}
+
+// Forward all original arguments except "restart-on-crash"
+static void *
+restart_args(int argc, char **argv)
+{
+#ifdef SENTRY_PLATFORM_WINDOWS
+    wchar_t **child_argv = calloc((size_t)argc + 1, sizeof(wchar_t *));
+    if (!child_argv) {
+        return NULL;
+    }
+
+    child_argv[0] = calloc(MAX_PATH, sizeof(wchar_t));
+    if (!child_argv[0]
+        || GetModuleFileNameW(NULL, child_argv[0], MAX_PATH) == 0) {
+        return child_argv;
+    }
+
+    int child_argc = 1;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "restart-on-crash") == 0) {
+            continue;
+        }
+
+        size_t len = strlen(argv[i]) + 1;
+        child_argv[child_argc] = calloc(len, sizeof(wchar_t));
+        if (!child_argv[child_argc]) {
+            return child_argv;
+        }
+        mbstowcs(child_argv[child_argc++], argv[i], len);
+    }
+    return child_argv;
+#else
+    char **child_argv = calloc((size_t)argc + 1, sizeof(char *));
+    if (!child_argv) {
+        return NULL;
+    }
+
+    int child_argc = 0;
+    for (int i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "restart-on-crash") != 0) {
+            child_argv[child_argc++] = argv[i];
+        }
+    }
+    return child_argv;
+#endif
 }
 
 static sentry_value_t
@@ -700,7 +717,8 @@ main(int argc, char **argv)
     }
 
     if (has_arg(argc, argv, "restart-on-crash")) {
-        sentry_options_set_on_crash(options, restart_on_crash, argv);
+        sentry_options_set_on_crash(
+            options, restart_on_crash, restart_args(argc, argv));
     }
 
     if (has_arg(argc, argv, "before-transaction")) {

--- a/examples/example.c
+++ b/examples/example.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 #ifdef NDEBUG
 #    undef NDEBUG
@@ -152,6 +153,28 @@ restart_on_crash(
         argc++;
     }
 
+#ifdef SENTRY_PLATFORM_WINDOWS
+    wchar_t module_path[MAX_PATH];
+    if (GetModuleFileNameW(NULL, module_path, MAX_PATH) > 0) {
+        int child_argc = 0;
+        wchar_t **child_argv = alloca((argc + 1) * sizeof(wchar_t *));
+        for (int i = 0; argv[i]; i++) {
+            if (strcmp(argv[i], "restart-on-crash") == 0) {
+                continue;
+            }
+            if (i == 0) {
+                child_argv[child_argc++] = module_path;
+            } else {
+                size_t len = strlen(argv[i]) + 1;
+                child_argv[child_argc] = alloca(len * sizeof(wchar_t));
+                mbstowcs(child_argv[child_argc++], argv[i], len);
+            }
+        }
+        child_argv[child_argc] = NULL;
+
+        _wspawnv(_P_NOWAIT, child_argv[0], (const wchar_t *const *)child_argv);
+    }
+#else
     int child_argc = 0;
     char **child_argv = alloca((argc + 1) * sizeof(char *));
     for (int i = 0; argv[i]; i++) {
@@ -161,9 +184,6 @@ restart_on_crash(
     }
     child_argv[child_argc] = NULL;
 
-#ifdef SENTRY_PLATFORM_WINDOWS
-    _spawnv(_P_NOWAIT, child_argv[0], (const char *const *)child_argv);
-#else
     if (fork() == 0) {
         // The crashing signal is blocked while the crash handler runs. Do not
         // let the restarted child inherit that mask.

--- a/examples/example.c
+++ b/examples/example.c
@@ -20,6 +20,7 @@
 
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include <malloc.h>
+#    include <process.h>
 #    include <synchapi.h>
 #    define sleep_s(SECONDS) Sleep((SECONDS) * 1000)
 #else
@@ -134,6 +135,47 @@ on_crash_callback(
     (void)user_data;
 
     // tell the backend to retain the event
+    return event;
+}
+
+static sentry_value_t
+restart_on_crash(
+    const sentry_ucontext_t *uctx, sentry_value_t event, void *user_data)
+{
+    (void)uctx;
+
+    int argc = 0;
+    char **argv = user_data;
+    assert(argv);
+    assert(argv[0]);
+    while (argv[argc]) {
+        argc++;
+    }
+
+    int child_argc = 0;
+    char **child_argv = alloca((argc + 1) * sizeof(char *));
+    for (int i = 0; argv[i]; i++) {
+        if (strcmp(argv[i], "restart-on-crash") != 0) {
+            child_argv[child_argc++] = argv[i];
+        }
+    }
+    child_argv[child_argc] = NULL;
+
+#ifdef SENTRY_PLATFORM_WINDOWS
+    _spawnv(_P_NOWAIT, child_argv[0], (const char *const *)child_argv);
+#else
+    if (fork() == 0) {
+        // The crashing signal is blocked while the crash handler runs. Do not
+        // let the restarted child inherit that mask.
+        sigset_t set;
+        sigfillset(&set);
+        sigprocmask(SIG_UNBLOCK, &set, NULL);
+
+        execv(child_argv[0], child_argv);
+        _exit(127);
+    }
+#endif
+
     return event;
 }
 
@@ -635,6 +677,10 @@ main(int argc, char **argv)
     if (has_arg(argc, argv, "discarding-on-crash")) {
         sentry_options_set_on_crash(
             options, discarding_on_crash_callback, NULL);
+    }
+
+    if (has_arg(argc, argv, "restart-on-crash")) {
+        sentry_options_set_on_crash(options, restart_on_crash, argv);
     }
 
     if (has_arg(argc, argv, "before-transaction")) {

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -1063,3 +1063,31 @@ def test_crashpad_cache_max_age(cmake, httpserver):
     assert len(cache_files) == 3
     for f in cache_files:
         assert time.time() - f.stat().st_mtime <= 5 * 24 * 60 * 60
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="crashpad doesn't provide SetFirstChanceExceptionHandler on macOS",
+)
+def test_crashpad_restart_on_crash(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
+
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
+    httpserver.expect_oneshot_request("/api/123456/minidump/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        # The restarted child inherits stdio, so PIPE waits for it without a sleep.
+        run(
+            tmp_path,
+            "sentry_example",
+            ["crash", "restart-on-crash"],
+            expect_failure=True,
+            env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    assert waiting.result
+    assert len(httpserver.log) == 2
+    for req in httpserver.log:
+        assert_crashpad_upload(req[0])

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import os
+import subprocess
 import time
 
 import pytest
@@ -1317,3 +1318,58 @@ def test_http_retry_session_on_network_error(cmake, httpserver, unreachable_dsn)
 
     cache_files = list(cache_dir.glob("*.envelope"))
     assert len(cache_files) == 0
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "inproc",
+        pytest.param(
+            "breakpad",
+            marks=pytest.mark.skipif(
+                not has_breakpad or is_qemu, reason="test needs breakpad backend"
+            ),
+        ),
+    ],
+)
+@pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
+def test_restart_on_crash(cmake, httpserver, backend):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": backend})
+
+    httpserver.expect_oneshot_request(
+        "/api/123456/envelope/",
+        headers={"x-sentry-auth": auth_header},
+    ).respond_with_data("OK")
+    httpserver.expect_oneshot_request(
+        "/api/123456/envelope/",
+        headers={"x-sentry-auth": auth_header},
+    ).respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        # The restarted child inherits stdio, so PIPE waits for it without a sleep.
+        run(
+            tmp_path,
+            "sentry_example",
+            ["crash", "restart-on-crash"],
+            expect_failure=True,
+            env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "no-setup"],
+            env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        )
+
+    assert waiting.result
+    assert len(httpserver.log) == 2
+    for req in httpserver.log:
+        envelope = Envelope.deserialize(req[0].get_data())
+        if backend == "inproc":
+            assert_inproc_crash(envelope)
+        elif backend == "breakpad":
+            assert_breakpad_crash(envelope)
+        else:
+            assert False

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -28,7 +28,7 @@ from .assertions import (
     wait_for_file,
     assert_user_feedback,
 )
-from .conditions import has_native, has_oom, is_asan, is_kcov, is_tsan, is_qemu
+from .conditions import has_native, has_oom, is_asan, is_tsan, is_qemu
 
 pytestmark = pytest.mark.skipif(
     not has_native or is_qemu,
@@ -63,14 +63,7 @@ def run_crash(tmp_path, exe, args, env, **kwargs):
         else:
             env["ASAN_OPTIONS"] = asan_signal_opts
 
-    if is_kcov:
-        try:
-            run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
-        except AssertionError:
-            # kcov may exit with 0 even on crash, that's acceptable
-            pass
-    else:
-        run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
+    run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
 
 
 def test_native_capture_crash(cmake, httpserver):

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -6,6 +6,7 @@ multi-thread capture, and FPU/SIMD register capture on all platforms.
 """
 
 import os
+import subprocess
 import sys
 import time
 import struct
@@ -27,7 +28,7 @@ from .assertions import (
     wait_for_file,
     assert_user_feedback,
 )
-from .conditions import has_native, has_oom, is_asan, is_tsan, is_qemu
+from .conditions import has_native, has_oom, is_asan, is_kcov, is_tsan, is_qemu
 
 pytestmark = pytest.mark.skipif(
     not has_native or is_qemu,
@@ -39,7 +40,7 @@ pytestmark = pytest.mark.skipif(
 SANITIZER_ARGS = ["shutdown-timeout", "10000"] if is_asan or is_tsan else []
 
 
-def run_crash(tmp_path, exe, args, env, wait_for_daemon=False):
+def run_crash(tmp_path, exe, args, env, **kwargs):
     """
     Run a crash test.
 
@@ -62,14 +63,14 @@ def run_crash(tmp_path, exe, args, env, wait_for_daemon=False):
         else:
             env["ASAN_OPTIONS"] = asan_signal_opts
 
-    run(
-        tmp_path,
-        exe,
-        args,
-        expect_failure=True,
-        env=env,
-        wait_for_daemon=wait_for_daemon,
-    )
+    if is_kcov:
+        try:
+            run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
+        except AssertionError:
+            # kcov may exit with 0 even on crash, that's acceptable
+            pass
+    else:
+        run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
 
 
 def test_native_capture_crash(cmake, httpserver):
@@ -1024,3 +1025,27 @@ def test_native_cache_keep(cmake, cache_keep, unreachable_dsn):
         assert cache_files[0].stem == dmp_files[0].stem
     else:
         assert len(list(cache_dir.glob("*.envelope"))) == 0
+
+
+def test_native_restart_on_crash(cmake, httpserver):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
+
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data("OK")
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data("OK")
+
+    with httpserver.wait(timeout=10) as waiting:
+        # The restarted child inherits stdio, so PIPE waits for it without a sleep.
+        run_crash(
+            tmp_path,
+            "sentry_example",
+            ["crash", "restart-on-crash"],
+            env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    assert waiting.result
+    assert len(httpserver.log) == 2
+    for req in httpserver.log:
+        envelope = Envelope.deserialize(req[0].get_data())
+        assert_native_crash(envelope)


### PR DESCRIPTION
Add "restart-on-crash" example + integration tests with all backends.

The example unblocks signals in the restarted POSIX child before `execv()`, preventing it from inheriting the crash handler’s blocked signal mask. The integration test verifies that both the original process and the restarted child report crashes.

## Why example only

The SDK should not silently rewrite an application’s signal mask as part of normal crash handling. Some applications intentionally block signals, and changing that globally would be surprising outside this restart pattern.

Handling only selected crash signals in the SDK is also fragile: the exact set depends on platform and backend behavior, and it still imposes SDK policy on process state. Keeping this in the restart example makes the requirement explicit at the point where the child process is created.

Close: #1114