### PR TITLE
ci: Bump kcov and re-enable crash exit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,9 @@ jobs:
           sudo apt-get install binutils-dev libssl-dev libelf-dev libstdc++-14-dev libdw-dev libiberty-dev
           git clone https://github.com/SimonKagstrom/kcov.git
           cd kcov
-          # pin to a known good version with the coveralls git integration and performance bottlenecks fixed
-          git checkout b370df05ccc96facfd83a9e101e35263457b8035
+          # pin to a known good version with the coveralls git integration, performance bottlenecks,
+          # and signal exit code handling fixed
+          git checkout f65e1145b7f1c42872f37d03edcc29264fccf26a
           mkdir build
           cd build
           cmake ..

--- a/tests/test_e2e_sentry.py
+++ b/tests/test_e2e_sentry.py
@@ -30,7 +30,6 @@ from .conditions import (
     has_http,
     has_native,
     is_asan,
-    is_kcov,
 )
 
 # Skip all tests if E2E env vars not configured
@@ -357,7 +356,7 @@ def run_crash_e2e(tmp_path, exe, args, env):
     """
     Run a crash test for E2E, capturing output for test ID extraction.
 
-    Handles ASAN and kcov quirks similar to run_crash in test_integration_native.py.
+    Handles ASAN signal handling similar to run_crash in test_integration_native.py.
     """
     if is_asan:
         asan_opts = env.get("ASAN_OPTIONS", "")
@@ -371,16 +370,7 @@ def run_crash_e2e(tmp_path, exe, args, env):
             env["ASAN_OPTIONS"] = asan_signal_opts
 
     # Use check_output to capture stdout for test ID extraction
-    try:
-        output = check_output(tmp_path, exe, args, env=env, expect_failure=True)
-    except AssertionError:
-        if is_kcov:
-            # kcov may exit with 0 even on crash, try without expect_failure
-            output = check_output(tmp_path, exe, args, env=env, expect_failure=False)
-        else:
-            raise
-
-    return output
+    return check_output(tmp_path, exe, args, env=env, expect_failure=True)
 
 
 @pytest.mark.skipif(

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -38,7 +38,6 @@ from .conditions import (
     has_breakpad,
     has_native,
     has_files,
-    is_kcov,
     is_asan,
     is_qemu,
 )
@@ -299,7 +298,6 @@ def test_user_report_http(cmake, httpserver):
     assert_user_report(envelope)
 
 
-@pytest.mark.skipif(is_kcov, reason="kcov exits with 0 even when the process crashes")
 @pytest.mark.parametrize(
     "build_args",
     [
@@ -812,7 +810,6 @@ def test_discarding_before_breadcrumb_http(cmake, httpserver):
     assert_no_breadcrumbs(envelope)
 
 
-@pytest.mark.skipif(is_kcov, reason="kcov exits with 0 even when the process crashes")
 @pytest.mark.skipif(not has_native or is_qemu, reason="test needs native backend")
 def test_native_crash_http(cmake, httpserver):
     """Test native backend crash handling with HTTP transport"""
@@ -867,7 +864,7 @@ def test_native_crash_http(cmake, httpserver):
         pytest.param(
             "native",
             marks=pytest.mark.skipif(
-                not has_native or is_qemu or is_kcov,
+                not has_native or is_qemu,
                 reason="test needs native backend",
             ),
         ),

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -27,7 +27,7 @@ from .assertions import (
     wait_for_file,
     assert_user_feedback,
 )
-from .conditions import has_native, has_oom, is_kcov, is_asan, is_tsan, is_qemu
+from .conditions import has_native, has_oom, is_asan, is_tsan, is_qemu
 
 pytestmark = pytest.mark.skipif(
     not has_native or is_qemu,
@@ -41,8 +41,7 @@ SANITIZER_ARGS = ["shutdown-timeout", "10000"] if is_asan or is_tsan else []
 
 def run_crash(tmp_path, exe, args, env):
     """
-    Run a crash test, handling kcov's quirk of exiting with 0.
-    kcov intercepts signals and may exit cleanly even when the program crashes.
+    Run a crash test.
 
     When running under ASAN, we configure it to not intercept crash signals
     so that our native crash handler can run and capture the crash.
@@ -63,14 +62,7 @@ def run_crash(tmp_path, exe, args, env):
         else:
             env["ASAN_OPTIONS"] = asan_signal_opts
 
-    if is_kcov:
-        try:
-            run(tmp_path, exe, args, expect_failure=True, env=env)
-        except AssertionError:
-            # kcov may exit with 0 even on crash, that's acceptable
-            pass
-    else:
-        run(tmp_path, exe, args, expect_failure=True, env=env)
+    run(tmp_path, exe, args, expect_failure=True, env=env)
 
 
 def test_native_capture_crash(cmake, httpserver):


### PR DESCRIPTION
Pin the CI-built kcov revision to the upstream merge that preserves signal exit codes after crashes.

Remove kcov-specific crash exit fallbacks and per-test skips for paths that can run under kcov, while keeping ptrace-based Crashpad and Breakpad tests disabled.

See also:
- https://github.com/SimonKagstrom/kcov/pull/495
