### PR TITLE
test: stabilize proxy tests

### DIFF
--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -666,16 +666,21 @@ def assert_failed_proxy_auth_request(stdout):
     )
 
 
-def wait_for_file(path, timeout=10.0, poll_interval=0.1):
-    import glob
+def wait_for(condition, timeout=10.0, interval=0.1):
     import time
 
     deadline = time.time() + timeout
     while time.time() < deadline:
-        if glob.glob(str(path)):
+        if condition():
             return True
-        time.sleep(poll_interval)
+        time.sleep(interval)
     return False
+
+
+def wait_for_file(path, timeout=10.0, interval=0.1):
+    import glob
+
+    return wait_for(lambda: glob.glob(str(path)), timeout, interval)
 
 
 def wait_for_daemon(tmp_path, started_at, timeout=None):

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -709,3 +709,36 @@ def wait_for_daemon(tmp_path, started_at, timeout=None):
         time.sleep(0.1)
 
     return False
+
+
+def wait_for_stdout(process, predicate, timeout=10):
+    """Read a process's stdout in a background thread, polling until
+    *predicate(text)* is satisfied or *timeout* expires.
+
+    Returns the full stdout text collected up to that point.
+    The caller should terminate/kill the process after this returns
+    to close the pipe and let the background thread exit.
+    """
+    import threading
+
+    lines = []
+
+    def reader():
+        try:
+            for line in iter(process.stdout.readline, b""):
+                lines.append(line)
+        except ValueError:
+            pass
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+
+    def stdout_text():
+        return b"".join(lines).decode("utf-8", errors="replace")
+
+    if not wait_for(lambda: predicate(stdout_text()), timeout):
+        raise TimeoutError(
+            f"Predicate not satisfied within {timeout}s.\n"
+            f"Collected output:\n{stdout_text()}"
+        )
+    return stdout_text()

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -138,24 +138,25 @@ def proxy_test_finally(
         expected_proxy_logsize = expected_httpserver_logsize
 
     if proxy_process:
-        # Give mitmdump some time to get a response from the mock server
-        assert wait_for(
-            lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
-        )
-
-        if expected_proxy_logsize != 0:
-            # request passed through successfully
-            wait_for_stdout(
-                proxy_process,
-                lambda text: "POST" in text and "200 OK" in text,
-                timeout,
+        try:
+            # Give mitmdump some time to get a response from the mock server
+            assert wait_for(
+                lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
             )
 
+            if expected_proxy_logsize != 0:
+                # request passed through successfully
+                wait_for_stdout(
+                    proxy_process,
+                    lambda text: "POST" in text and "200 OK" in text,
+                    timeout,
+                )
+        finally:
             proxy_process.terminate()
             proxy_process.wait(timeout=timeout)
-        else:
+
+        if expected_proxy_logsize == 0:
             # don't expect any incoming requests to make it through the proxy
-            proxy_process.terminate()
             stdout_bytes, _ = proxy_process.communicate(timeout=timeout)
             stdout = stdout_bytes.decode("utf-8", errors="replace")
             proxy_log_assert(stdout)

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -138,21 +138,22 @@ def proxy_test_finally(
         expected_proxy_logsize = expected_httpserver_logsize
 
     if proxy_process:
-        # Give mitmdump some time to get a response from the mock server
-        assert wait_for(
-            lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
-        )
-
-        if expected_proxy_logsize != 0:
-            # request passed through successfully
-            assert wait_for_stdout(
-                proxy_process,
-                lambda text: "POST" in text and "200 OK" in text,
-                timeout,
+        try:
+            # Give mitmdump some time to get a response from the mock server
+            assert wait_for(
+                lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
             )
 
-        proxy_process.terminate()
-        proxy_process.wait(timeout=timeout)
+            if expected_proxy_logsize != 0:
+                # request passed through successfully
+                assert wait_for_stdout(
+                    proxy_process,
+                    lambda text: "POST" in text and "200 OK" in text,
+                    timeout,
+                )
+        finally:
+            proxy_process.terminate()
+            proxy_process.wait(timeout=timeout)
 
         if expected_proxy_logsize == 0:
             # don't expect any incoming requests to make it through the proxy

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -2,14 +2,13 @@ import contextlib
 import os
 import socket
 import subprocess
-import threading
 import time
 
 import psutil
 
 import pytest
 
-from tests.assertions import assert_no_proxy_request, wait_for
+from tests.assertions import assert_no_proxy_request, wait_for, wait_for_stdout
 
 
 @contextlib.contextmanager
@@ -139,31 +138,25 @@ def proxy_test_finally(
         expected_proxy_logsize = expected_httpserver_logsize
 
     if proxy_process:
-        stdout = []
-
-        def read_proxy_stdout():
-            if proxy_process.stdout is None:
-                return
-            for line in iter(proxy_process.stdout.readline, b""):
-                stdout.append(line.decode("utf-8", errors="replace"))
-
-        reader = threading.Thread(target=read_proxy_stdout, daemon=True)
-        reader.start()
-
         # Give mitmdump some time to get a response from the mock server
         assert wait_for(
             lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
         )
+
         if expected_proxy_logsize != 0:
             # request passed through successfully
-            assert wait_for(
-                lambda: "POST" in "".join(stdout) and "200 OK" in "".join(stdout),
+            wait_for_stdout(
+                proxy_process,
+                lambda text: "POST" in text and "200 OK" in text,
                 timeout,
             )
+
         proxy_process.terminate()
-        stdout_bytes, _ = proxy_process.communicate(timeout=timeout)
-        stdout = "".join(stdout) + stdout_bytes.decode("utf-8", errors="replace")
+        proxy_process.wait(timeout=timeout)
+
         if expected_proxy_logsize == 0:
             # don't expect any incoming requests to make it through the proxy
+            remaining = proxy_process.stdout.read()
+            stdout = remaining.decode("utf-8", errors="replace")
             proxy_log_assert(stdout)
     assert len(httpserver.log) == expected_httpserver_logsize

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -138,26 +138,25 @@ def proxy_test_finally(
         expected_proxy_logsize = expected_httpserver_logsize
 
     if proxy_process:
-        try:
-            # Give mitmdump some time to get a response from the mock server
-            assert wait_for(
-                lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
+        # Give mitmdump some time to get a response from the mock server
+        assert wait_for(
+            lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
+        )
+
+        if expected_proxy_logsize != 0:
+            # request passed through successfully
+            wait_for_stdout(
+                proxy_process,
+                lambda text: "POST" in text and "200 OK" in text,
+                timeout,
             )
 
-            if expected_proxy_logsize != 0:
-                # request passed through successfully
-                assert wait_for_stdout(
-                    proxy_process,
-                    lambda text: "POST" in text and "200 OK" in text,
-                    timeout,
-                )
-        finally:
             proxy_process.terminate()
             proxy_process.wait(timeout=timeout)
-
-        if expected_proxy_logsize == 0:
+        else:
             # don't expect any incoming requests to make it through the proxy
-            remaining = proxy_process.stdout.read()
-            stdout = remaining.decode("utf-8", errors="replace")
+            proxy_process.terminate()
+            stdout_bytes, _ = proxy_process.communicate(timeout=timeout)
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
             proxy_log_assert(stdout)
     assert len(httpserver.log) == expected_httpserver_logsize

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import socket
 import subprocess
+import threading
 import time
 
 import psutil
@@ -98,8 +99,14 @@ def start_mitmdump(
         if proxy_auth:
             proxy_command += ["-v", "--proxyauth", proxy_auth]
 
+        proxy_env = os.environ.copy()
+        proxy_env["PYTHONUNBUFFERED"] = "1"
+
         proxy_process = subprocess.Popen(
-            proxy_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            proxy_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=proxy_env,
         )
 
         try:
@@ -132,15 +139,31 @@ def proxy_test_finally(
         expected_proxy_logsize = expected_httpserver_logsize
 
     if proxy_process:
+        stdout = []
+
+        def read_proxy_stdout():
+            if proxy_process.stdout is None:
+                return
+            for line in iter(proxy_process.stdout.readline, b""):
+                stdout.append(line.decode("utf-8", errors="replace"))
+
+        reader = threading.Thread(target=read_proxy_stdout, daemon=True)
+        reader.start()
+
         # Give mitmdump some time to get a response from the mock server
-        wait_for(lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout)
+        assert wait_for(
+            lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout
+        )
+        if expected_proxy_logsize != 0:
+            # request passed through successfully
+            assert wait_for(
+                lambda: "POST" in "".join(stdout) and "200 OK" in "".join(stdout),
+                timeout,
+            )
         proxy_process.terminate()
-        stdout_bytes, _ = proxy_process.communicate()
-        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stdout_bytes, _ = proxy_process.communicate(timeout=timeout)
+        stdout = "".join(stdout) + stdout_bytes.decode("utf-8", errors="replace")
         if expected_proxy_logsize == 0:
             # don't expect any incoming requests to make it through the proxy
             proxy_log_assert(stdout)
-        else:
-            # request passed through successfully
-            assert "POST" in stdout and "200 OK" in stdout
     assert len(httpserver.log) == expected_httpserver_logsize

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -145,7 +145,7 @@ def proxy_test_finally(
 
         if expected_proxy_logsize != 0:
             # request passed through successfully
-            wait_for_stdout(
+            assert wait_for_stdout(
                 proxy_process,
                 lambda text: "POST" in text and "200 OK" in text,
                 timeout,

--- a/tests/proxy.py
+++ b/tests/proxy.py
@@ -8,7 +8,7 @@ import psutil
 
 import pytest
 
-from tests.assertions import assert_no_proxy_request
+from tests.assertions import assert_no_proxy_request, wait_for
 
 
 @contextlib.contextmanager
@@ -126,13 +126,14 @@ def proxy_test_finally(
     proxy_process,
     proxy_log_assert=assert_no_proxy_request,
     expected_proxy_logsize=None,
+    timeout=10,
 ):
     if expected_proxy_logsize is None:
         expected_proxy_logsize = expected_httpserver_logsize
 
     if proxy_process:
         # Give mitmdump some time to get a response from the mock server
-        time.sleep(0.5)
+        wait_for(lambda: len(httpserver.log) >= expected_httpserver_logsize, timeout)
         proxy_process.terminate()
         stdout_bytes, _ = proxy_process.communicate()
         stdout = stdout_bytes.decode("utf-8", errors="replace")

--- a/tests/test_dotnet_signals.py
+++ b/tests/test_dotnet_signals.py
@@ -8,6 +8,7 @@ import time
 import pytest
 
 from tests import adb
+from tests.assertions import wait_for
 from tests.conditions import is_android, is_arm32, is_tsan, is_x86, is_asan
 
 project_fixture_path = pathlib.Path("tests/fixtures/dotnet_signal")
@@ -279,15 +280,6 @@ def test_aot_signals_inproc(cmake):
 
 
 ANDROID_PACKAGE = "io.sentry.ndk.dotnet.signal.test"
-
-
-def wait_for(condition, timeout=10, interval=0.5):
-    start = time.time()
-    while time.time() - start < timeout:
-        if condition():
-            return True
-        time.sleep(interval)
-    return condition()
 
 
 def run_android(args=None, strategy=None, reinit=False, timeout=30):


### PR DESCRIPTION
Proxy-related tests have been randomly failing quite often lately. For example:
- https://github.com/getsentry/sentry-native/actions/runs/26743324579/job/78812455041
   ```
   FAILED tests/test_integration_proxy.py::test_proxy_ipv6 - AssertionError
   ```
- https://github.com/getsentry/sentry-native/actions/runs/26877926441/job/79270182718
   https://github.com/getsentry/sentry-native/actions/runs/26958276046/job/79541332538
   ```
   FAILED tests/test_integration_crashpad.py::test_crashpad_crash_proxy_env - AssertionError
   ```
- ...

Replace the hardcoded 0.5s sleep with a wait loop that gives `mitmdump` up to 10s to get a response from the mock server. This should help in busy CI environments where runners may be under load and processes can be delayed.
