### PR TITLE
feat(native): add thread names on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Native: add opt-in async crash upload mode so crashed apps can exit early after crash data is captured, while the crash daemon finishes potentially large uploads in the background. ([#1739](https://github.com/getsentry/sentry-native/pull/1739))
 - Add a `transfer_timeout` option for SDK-managed HTTP transports. ([#1741](https://github.com/getsentry/sentry-native/pull/1741))
 - Apple: use `os_sync_wait_on_address` for the level-triggered waitable flag in the batcher on modern macOS(14.4+) and iOS(17.4+). ([#1765](https://github.com/getsentry/sentry-native/pull/1765))
+- Native/macOS: add thread names. ([#1766](https://github.com/getsentry/sentry-native/pull/1766))
 
 **Fixes**:
 

--- a/src/backends/native/sentry_crash_context.h
+++ b/src/backends/native/sentry_crash_context.h
@@ -187,6 +187,7 @@ typedef struct {
     _STRUCT_MCONTEXT state;
     char stack_path[SENTRY_CRASH_MAX_PATH]; // Path to saved stack memory file
     uint64_t stack_size; // Size of captured stack
+    char name[64]; // Thread name from pthread_setname_np
 } sentry_thread_context_darwin_t;
 
 /**

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -2224,6 +2224,12 @@ build_native_crash_event(
             sentry_value_set_by_key(
                 thread, "id", sentry_value_new_int32((int32_t)tctx->tid));
 
+            // Set thread name if available
+            if (tctx->name[0] != '\0') {
+                sentry_value_set_by_key(
+                    thread, "name", sentry_value_new_string(tctx->name));
+            }
+
             bool is_crashed = (tctx->tid == (uint64_t)ctx->crashed_tid);
             sentry_value_set_by_key(
                 thread, "crashed", sentry_value_new_bool(is_crashed));

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -401,6 +401,25 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
                 ctx->platform.threads[i].tid = 0;
             }
 
+            // Get thread name from THREAD_EXTENDED_INFO
+            ctx->platform.threads[i].name[0] = '\0';
+            {
+                thread_extended_info_data_t extended_info;
+                mach_msg_type_number_t ext_count = THREAD_EXTENDED_INFO_COUNT;
+                if (thread_info(threads[i], THREAD_EXTENDED_INFO,
+                        (thread_info_t)&extended_info, &ext_count)
+                    == KERN_SUCCESS) {
+                    extended_info.pth_name[sizeof(extended_info.pth_name) - 1]
+                        = '\0';
+                    memcpy(ctx->platform.threads[i].name,
+                        extended_info.pth_name,
+                        sizeof(ctx->platform.threads[i].name));
+                    ctx->platform.threads[i]
+                        .name[sizeof(ctx->platform.threads[i].name) - 1]
+                        = '\0';
+                }
+            }
+
             // For the crashing thread, use the context from the signal handler
             // For other threads, use thread_get_state()
             bool is_crashing_thread = (threads[i] == crashing_thread);

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -411,7 +411,7 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
                     == KERN_SUCCESS) {
                     extended_info.pth_name[sizeof(extended_info.pth_name) - 1]
                         = '\0';
-                    memcpy(ctx->platform.threads[i].name,
+                    signal_safe_memcpy(ctx->platform.threads[i].name,
                         extended_info.pth_name,
                         sizeof(ctx->platform.threads[i].name));
                     ctx->platform.threads[i]


### PR DESCRIPTION
Thread names are now captured via `thread_info(THREAD_EXTENDED_INFO)` in the crash handler and exposed in the native crash event JSON.

The first attempt from the daemon via `task_for_pid` failed with `KERN_FAILURE` — the API is restricted on modern macOS without a Hardened Runtime or SIP-permitted entitlement — so in-process capture avoids this entirely and matches how Crashpad handles thread names.

| Before | After |
|---|---|
| <img width="1012" height="744" alt="image" src="https://github.com/user-attachments/assets/a493d2ed-b31f-45b0-a266-f352b58d2b34" /> | <img width="1012" height="744" alt="image" src="https://github.com/user-attachments/assets/9f381c8c-e7d0-4b66-8ea7-92f8011959d5" /> |
