### PR TITLE
fix(native): clamp module count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix a shutdown-time use-after-free window in `sentry_close()`. ([#1750](https://github.com/getsentry/sentry-native/pull/1750))
 - Native/Linux: resolve symbol names for crashed thread on Linux. ([#1764](https://github.com/getsentry/sentry-native/pull/1764))
 - Native: validate ELF header entry sizes. ([#1746](https://github.com/getsentry/sentry-native/pull/1746))
+- Native: clamp `module_count` from the shared crash context before. ([#1770](https://github.com/getsentry/sentry-native/pull/1770))
 - Prevent database cleanup from following symlinks in run and cache directories. ([#1751](https://github.com/getsentry/sentry-native/pull/1751))
 - Structured logs: respect printf argument widths when extracting log parameters to avoid stack-data disclosure and corrupted attributes on 32-bit platforms. ([#1752](https://github.com/getsentry/sentry-native/pull/1752))
 - Fix a potential out-of-bounds read when parsing non-NUL-terminated `sentry-trace` headers. ([#1749](https://github.com/getsentry/sentry-native/pull/1749))

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -605,7 +605,8 @@ static void
 enrich_frame_with_module_info(
     const sentry_crash_context_t *ctx, sentry_value_t frame, uint64_t addr)
 {
-    for (uint32_t i = 0; i < ctx->module_count; i++) {
+    uint32_t module_count = MIN(ctx->module_count, SENTRY_CRASH_MAX_MODULES);
+    for (uint32_t i = 0; i < module_count; i++) {
         const sentry_module_info_t *mod = &ctx->modules[i];
         if (addr >= mod->base_address && addr < mod->base_address + mod->size) {
             // Set package to full module path (matches minidump format)
@@ -620,7 +621,7 @@ enrich_frame_with_module_info(
     }
     // No matching module found - log for debugging
     SENTRY_DEBUGF("Frame 0x%llx NOT matched to any module (module_count=%u)",
-        (unsigned long long)addr, ctx->module_count);
+        (unsigned long long)addr, module_count);
 }
 
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
@@ -1210,7 +1211,8 @@ static void
 enrich_frame_with_symbol(
     const sentry_crash_context_t *ctx, sentry_value_t frame, uint64_t addr)
 {
-    for (uint32_t i = 0; i < ctx->module_count; i++) {
+    uint32_t module_count = MIN(ctx->module_count, SENTRY_CRASH_MAX_MODULES);
+    for (uint32_t i = 0; i < module_count; i++) {
         const sentry_module_info_t *mod = &ctx->modules[i];
         if (addr < mod->base_address || addr >= mod->base_address + mod->size) {
             continue;
@@ -2334,11 +2336,12 @@ build_native_crash_event(
     // Add debug_meta with module images from crashed process
     // (ctx->modules[] was captured in the signal handler of the crashed
     // process)
-    SENTRY_DEBUGF("Module count for debug_meta: %u", ctx->module_count);
-    if (ctx->module_count > 0) {
+    uint32_t module_count = MIN(ctx->module_count, SENTRY_CRASH_MAX_MODULES);
+    SENTRY_DEBUGF("Module count for debug_meta: %u", module_count);
+    if (module_count > 0) {
         sentry_value_t images = sentry_value_new_list();
 
-        for (uint32_t i = 0; i < ctx->module_count; i++) {
+        for (uint32_t i = 0; i < module_count; i++) {
             const sentry_module_info_t *mod = &ctx->modules[i];
             sentry_value_t image = sentry_value_new_object();
 
@@ -2456,7 +2459,7 @@ build_native_crash_event(
         sentry_value_set_by_key(debug_meta, "images", images);
         sentry_value_set_by_key(event, "debug_meta", debug_meta);
         SENTRY_DEBUGF("Added %u modules from crashed process to debug_meta",
-            ctx->module_count);
+            module_count);
     } else {
         SENTRY_WARN("No modules captured - debug_meta.images will be empty!");
     }


### PR DESCRIPTION
Clamp module_count from shared crash context before indexing the fixed module array while enriching frames and debug metadata.

<details><summary>Unvalidated module_count from shared memory causes out-of-bounds array access</summary>

## Details
In build_native_crash_event, ctx->module_count from shared memory crash context is used as a loop bound to index into ctx->modules[], a fixed-size array of SENTRY_CRASH_MAX_MODULES (512) elements. No validation ensures module_count <= 512 before the loop. The same unbounded iteration exists in enrich_frame_with_module_info at line 499. The crash context is shared memory filled by a crashing process's signal handler — memory corruption is precisely the scenario where this code runs. The developers recognized this risk and added a defensive bounds check in the minidump writer (sentry_minidump_macos.c:758-760 with comment 'Bounds check to prevent out-of-bounds access on corrupted crash context'), but did not apply the same protection to build_native_crash_event.

## Location
[src/backends/native/sentry_crash_daemon.c:2046](https://github.com/getsentry/sentry-native/blob/master/src/backends/native/sentry_crash_daemon.c#L2046)

## Impact
Crash daemon reads past fixed-size array from corrupted shared memory

## Reproduction steps
1. A process crashes due to a heap buffer overflow that corrupts the shared memory crash context, setting module_count to 0xFFFF. The crash daemon reads this corrupted value and iterates 65535 times over a 512-element array, reading adjacent shared memory. This causes either a secondary crash in the daemon (preventing crash reports from being captured) or inclusion of leaked memory contents in the crash event sent to Sentry.

## Recommended fix
module_count must be clamped to SENTRY_CRASH_MAX_MODULES before use as a loop bound, matching the defensive check already present in the minidump writer.

---
**Severity:** MEDIUM
**Status:** Open
**Category:** Buffer overflow
**Repository:** getsentry/sentry-native
**Branch:** master

</details>