### PR TITLE
fix(native): prevent IPC shared memory spoofing on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix a potential out-of-bounds read when parsing non-NUL-terminated `sentry-trace` headers. ([#1749](https://github.com/getsentry/sentry-native/pull/1749))
 - Fix division by zero when breadcrumbs are disabled. ([#1767](https://github.com/getsentry/sentry-native/pull/1767))
 - Handle memory allocation failures during JSON serialization to prevent truncated output. ([#1772](https://github.com/getsentry/sentry-native/pull/1772))
+- Native/Linux: prevent IPC shared memory spoofing. ([#1774](https://github.com/getsentry/sentry-native/pull/1774))
 
 ## 0.14.2
 

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -3539,9 +3539,27 @@ daemon_file_logger(
 }
 
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
+static int
+prepare_exec_fd(int fd)
+{
+    if (fd > STDERR_FILENO) {
+        return fd;
+    }
+
+    int new_fd = fcntl(fd, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
+    if (new_fd < 0) {
+        return -1;
+    }
+
+    close(fd);
+    return new_fd;
+}
+#endif
+
+#if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
 int
-sentry__crash_daemon_main(
-    pid_t app_pid, uint64_t app_tid, int notify_eventfd, int ready_eventfd)
+sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, int notify_eventfd,
+    int ready_eventfd, int shm_fd)
 #elif defined(SENTRY_PLATFORM_MACOS)
 int
 sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, int notify_pipe_read,
@@ -3556,7 +3574,7 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     // We need this to get the database path for logging
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
     sentry_crash_ipc_t *ipc = sentry__crash_ipc_init_daemon(
-        app_pid, app_tid, notify_eventfd, ready_eventfd);
+        app_pid, app_tid, notify_eventfd, ready_eventfd, shm_fd);
 #elif defined(SENTRY_PLATFORM_MACOS)
     sentry_crash_ipc_t *ipc = sentry__crash_ipc_init_daemon(
         app_pid, app_tid, notify_pipe_read, ready_pipe_write, shm_fd);
@@ -3849,7 +3867,7 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
 pid_t
 sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, int notify_eventfd,
-    int ready_eventfd, const char *handler_path)
+    int ready_eventfd, int shm_fd, const char *handler_path)
 #elif defined(SENTRY_PLATFORM_MACOS)
 pid_t
 sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid,
@@ -3958,6 +3976,14 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
         // Child process - exec sentry-crash
         setsid();
 
+        notify_eventfd = prepare_exec_fd(notify_eventfd);
+        ready_eventfd = prepare_exec_fd(ready_eventfd);
+        shm_fd = prepare_exec_fd(shm_fd);
+        if (notify_eventfd < 0 || ready_eventfd < 0 || shm_fd < 0) {
+            perror("Failed to prepare daemon fds");
+            _exit(1);
+        }
+
         // Clear FD_CLOEXEC on notify and ready fds so they survive exec
         int notify_flags = fcntl(notify_eventfd, F_GETFD);
         if (notify_flags != -1) {
@@ -3967,16 +3993,22 @@ sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
         if (ready_flags != -1) {
             fcntl(ready_eventfd, F_SETFD, ready_flags & ~FD_CLOEXEC);
         }
+        int shm_flags = fcntl(shm_fd, F_GETFD);
+        if (shm_flags != -1) {
+            fcntl(shm_fd, F_SETFD, shm_flags & ~FD_CLOEXEC);
+        }
 
         // Convert arguments to strings for exec
-        char pid_str[32], tid_str[32], notify_str[32], ready_str[32];
+        char pid_str[32], tid_str[32], notify_str[32], ready_str[32],
+            shm_str[32];
         snprintf(pid_str, sizeof(pid_str), "%d", (int)app_pid);
         snprintf(tid_str, sizeof(tid_str), "%" PRIx64, app_tid);
         snprintf(notify_str, sizeof(notify_str), "%d", notify_eventfd);
         snprintf(ready_str, sizeof(ready_str), "%d", ready_eventfd);
+        snprintf(shm_str, sizeof(shm_str), "%d", shm_fd);
 
-        char *argv[]
-            = { "sentry-crash", pid_str, tid_str, notify_str, ready_str, NULL };
+        char *argv[] = { "sentry-crash", pid_str, tid_str, notify_str,
+            ready_str, shm_str, NULL };
 
         if (!sentry__string_empty(handler_path)) {
             execv(handler_path, argv);
@@ -4143,8 +4175,9 @@ int
 main(int argc, char **argv)
 {
     // Expected arguments:
-    //   Linux:  <app_pid> <app_tid> <notify_handle> <ready_handle>
+    //   Linux:  <app_pid> <app_tid> <notify_handle> <ready_handle> <shm_fd>
     //   macOS:  <app_pid> <app_tid> <notify_handle> <ready_handle> <shm_fd>
+    //  Windows: <app_pid> <app_tid> <event_handle> <ready_event_handle>
 #    if defined(SENTRY_PLATFORM_MACOS)
     if (argc < 6) {
         fprintf(stderr,
@@ -4152,11 +4185,18 @@ main(int argc, char **argv)
             "<ready_pipe> <shm_fd>\n");
         return 1;
     }
+#    elif defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
+    if (argc < 6) {
+        fprintf(stderr,
+            "Usage: sentry-crash <app_pid> <app_tid> <notify_handle> "
+            "<ready_handle> <shm_fd>\n");
+        return 1;
+    }
 #    else
     if (argc < 5) {
         fprintf(stderr,
-            "Usage: sentry-crash <app_pid> <app_tid> <notify_handle> "
-            "<ready_handle>\n");
+            "Usage: sentry-crash <app_pid> <app_tid> <event_handle> "
+            "<ready_event_handle>\n");
         return 1;
     }
 #    endif
@@ -4168,8 +4208,9 @@ main(int argc, char **argv)
 #    if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
     int notify_eventfd = atoi(argv[3]);
     int ready_eventfd = atoi(argv[4]);
+    int shm_fd_arg = atoi(argv[5]);
     return sentry__crash_daemon_main(
-        app_pid, app_tid, notify_eventfd, ready_eventfd);
+        app_pid, app_tid, notify_eventfd, ready_eventfd, shm_fd_arg);
 #    elif defined(SENTRY_PLATFORM_MACOS)
     int notify_pipe_read = atoi(argv[3]);
     int ready_pipe_write = atoi(argv[4]);

--- a/src/backends/native/sentry_crash_daemon.h
+++ b/src/backends/native/sentry_crash_daemon.h
@@ -26,7 +26,8 @@ struct sentry_options_s;
  */
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
 pid_t sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid,
-    int notify_eventfd, int ready_eventfd, const char *handler_path);
+    int notify_eventfd, int ready_eventfd, int shm_fd,
+    const char *handler_path);
 #elif defined(SENTRY_PLATFORM_MACOS)
 pid_t sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid,
     int notify_pipe_read, int ready_pipe_write, int shm_fd,
@@ -45,8 +46,8 @@ pid_t sentry__crash_daemon_start(pid_t app_pid, uint64_t app_tid,
  * @param ready_handle Ready signal handle to signal parent
  */
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
-int sentry__crash_daemon_main(
-    pid_t app_pid, uint64_t app_tid, int notify_eventfd, int ready_eventfd);
+int sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid,
+    int notify_eventfd, int ready_eventfd, int shm_fd);
 #elif defined(SENTRY_PLATFORM_MACOS)
 int sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid,
     int notify_pipe_read, int ready_pipe_write, int shm_fd);

--- a/src/backends/native/sentry_crash_ipc.c
+++ b/src/backends/native/sentry_crash_ipc.c
@@ -46,18 +46,18 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
 
     // Try to create shared memory. Do not reuse existing names: a pre-created
     // segment may be attacker-controlled.
-    bool shm_exists = false;
     ipc->shm_fd = -1;
     for (uint32_t attempt = 0; attempt < 8; attempt++) {
         uint32_t nonce = 0;
         if (sentry__getrandom(&nonce, sizeof(nonce)) != 0) {
             nonce = (uint32_t)(uintptr_t)&nonce ^ attempt;
         }
-        uint32_t id = (uint32_t)((getpid() ^ (tid & 0xFFFFFFFF) ^ nonce
-                                      ^ attempt)
-            & 0xFFFFFFFF);
+        uint32_t id
+            = (uint32_t)((getpid() ^ (tid & 0xFFFFFFFF) ^ nonce ^ attempt)
+                & 0xFFFFFFFF);
         snprintf(ipc->shm_name, sizeof(ipc->shm_name), "/s-%08x", id);
-        ipc->shm_fd = shm_open(ipc->shm_name, O_CREAT | O_RDWR | O_EXCL, 0600);
+        ipc->shm_fd = shm_open(
+            ipc->shm_name, O_CREAT | O_RDWR | O_EXCL | O_CLOEXEC, 0600);
         if (ipc->shm_fd >= 0) {
             ipc->shm_id = id;
             break;
@@ -76,44 +76,15 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
         return NULL;
     }
 
-    // Verify and resize shared memory (both new and existing)
-    if (shm_exists) {
-        // Check if existing shared memory has correct size
-        struct stat st;
-        if (fstat(ipc->shm_fd, &st) < 0) {
-            SENTRY_WARNF("failed to stat shared memory: %s", strerror(errno));
-            close(ipc->shm_fd);
-            if (ipc->init_sem) {
-                sem_post(ipc->init_sem);
-            }
-            sentry_free(ipc);
-            return NULL;
+    if (ftruncate(ipc->shm_fd, SENTRY_CRASH_SHM_SIZE) < 0) {
+        SENTRY_WARNF("failed to resize shared memory: %s", strerror(errno));
+        close(ipc->shm_fd);
+        shm_unlink(ipc->shm_name);
+        if (ipc->init_sem) {
+            sem_post(ipc->init_sem);
         }
-        if (st.st_size != SENTRY_CRASH_SHM_SIZE) {
-            // Existing shm has wrong size, resize it
-            if (ftruncate(ipc->shm_fd, SENTRY_CRASH_SHM_SIZE) < 0) {
-                SENTRY_WARNF("failed to resize existing shared memory: %s",
-                    strerror(errno));
-                close(ipc->shm_fd);
-                if (ipc->init_sem) {
-                    sem_post(ipc->init_sem);
-                }
-                sentry_free(ipc);
-                return NULL;
-            }
-        }
-    } else {
-        // New shared memory, set size
-        if (ftruncate(ipc->shm_fd, SENTRY_CRASH_SHM_SIZE) < 0) {
-            SENTRY_WARNF("failed to resize shared memory: %s", strerror(errno));
-            close(ipc->shm_fd);
-            shm_unlink(ipc->shm_name);
-            if (ipc->init_sem) {
-                sem_post(ipc->init_sem);
-            }
-            sentry_free(ipc);
-            return NULL;
-        }
+        sentry_free(ipc);
+        return NULL;
     }
 
     // Map shared memory
@@ -122,9 +93,7 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
     if (ipc->shmem == MAP_FAILED) {
         SENTRY_WARNF("failed to map shared memory: %s", strerror(errno));
         close(ipc->shm_fd);
-        if (!shm_exists) {
-            shm_unlink(ipc->shm_name);
-        }
+        shm_unlink(ipc->shm_name);
         if (ipc->init_sem) {
             sem_post(ipc->init_sem);
         }
@@ -138,9 +107,7 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
         SENTRY_WARNF("failed to create eventfd: %s", strerror(errno));
         munmap(ipc->shmem, SENTRY_CRASH_SHM_SIZE);
         close(ipc->shm_fd);
-        if (!shm_exists) {
-            shm_unlink(ipc->shm_name);
-        }
+        shm_unlink(ipc->shm_name);
         if (ipc->init_sem) {
             sem_post(ipc->init_sem);
         }
@@ -155,9 +122,7 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
         close(ipc->notify_fd);
         munmap(ipc->shmem, SENTRY_CRASH_SHM_SIZE);
         close(ipc->shm_fd);
-        if (!shm_exists) {
-            shm_unlink(ipc->shm_name);
-        }
+        shm_unlink(ipc->shm_name);
         if (ipc->init_sem) {
             sem_post(ipc->init_sem);
         }
@@ -165,14 +130,11 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
         return NULL;
     }
 
-    // Initialize shared memory only if newly created
-    if (!shm_exists) {
-        memset(ipc->shmem, 0, SENTRY_CRASH_SHM_SIZE);
-        ipc->shmem->magic = SENTRY_CRASH_MAGIC;
-        ipc->shmem->version = SENTRY_CRASH_VERSION;
-        sentry__atomic_store(&ipc->shmem->state, SENTRY_CRASH_STATE_READY);
-        sentry__atomic_store(&ipc->shmem->sequence, 0);
-    }
+    memset(ipc->shmem, 0, SENTRY_CRASH_SHM_SIZE);
+    ipc->shmem->magic = SENTRY_CRASH_MAGIC;
+    ipc->shmem->version = SENTRY_CRASH_VERSION;
+    sentry__atomic_store(&ipc->shmem->state, SENTRY_CRASH_STATE_READY);
+    sentry__atomic_store(&ipc->shmem->sequence, 0);
 
     // Release semaphore after initialization
     if (ipc->init_sem) {
@@ -186,21 +148,19 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
 }
 
 sentry_crash_ipc_t *
-sentry__crash_ipc_init_daemon(
-    pid_t app_pid, uint64_t app_tid, int notify_eventfd, int ready_eventfd)
+sentry__crash_ipc_init_daemon(pid_t app_pid, uint64_t app_tid,
+    int notify_eventfd, int ready_eventfd, int shm_fd)
 {
     sentry_crash_ipc_t *ipc = SENTRY_MAKE(sentry_crash_ipc_t);
     if (!ipc) {
         return NULL;
     }
     ipc->is_daemon = true;
+    (void)app_pid;
+    (void)app_tid;
 
-    // Open existing shared memory created by app (using PID and thread ID)
-    // Must match the format in sentry__crash_ipc_init_app
-    uint32_t id = (uint32_t)((app_pid ^ (app_tid & 0xFFFFFFFF)) & 0xFFFFFFFF);
-    snprintf(ipc->shm_name, sizeof(ipc->shm_name), "/s-%08x", id);
-
-    ipc->shm_fd = shm_open(ipc->shm_name, O_RDWR, 0600);
+    ipc->shm_name[0] = '\0';
+    ipc->shm_fd = shm_fd;
     if (ipc->shm_fd < 0) {
         SENTRY_WARNF(
             "daemon: failed to open shared memory: %s", strerror(errno));
@@ -232,9 +192,9 @@ sentry__crash_ipc_init_daemon(
     ipc->notify_fd = notify_eventfd;
     ipc->ready_fd = ready_eventfd;
 
-    SENTRY_DEBUGF("daemon: attached to crash IPC (shm=%s, notify_fd=%d, "
+    SENTRY_DEBUGF("daemon: attached to crash IPC (shm_fd=%d, notify_fd=%d, "
                   "ready_notify_fd=%d)",
-        ipc->shm_name, notify_eventfd, ready_eventfd);
+        ipc->shm_fd, notify_eventfd, ready_eventfd);
 
     return ipc;
 }

--- a/src/backends/native/sentry_crash_ipc.c
+++ b/src/backends/native/sentry_crash_ipc.c
@@ -2,6 +2,7 @@
 
 #include "sentry_alloc.h"
 #include "sentry_logger.h"
+#include "sentry_random.h"
 #include "sentry_sync.h"
 
 #include <stdio.h>
@@ -26,14 +27,14 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
     ipc->is_daemon = false;
     ipc->init_sem = init_sem; // Use provided semaphore (managed by backend)
 
-    // Create shared memory with unique name based on PID and thread ID
+    // Create shared memory with a random nonce mixed into PID and thread ID
     // macOS has a 31-character limit for POSIX shared memory names (PSEMNAMLEN)
     // Format: /s-{8_hex_chars} = 11 chars total (well under 31 limit)
     // We mix PID and TID to create a unique 32-bit identifier, allowing
     // multiple sentry_init() calls from different threads in the same process.
     uint64_t tid = (uint64_t)pthread_self();
-    uint32_t id = (uint32_t)((getpid() ^ (tid & 0xFFFFFFFF)) & 0xFFFFFFFF);
-    snprintf(ipc->shm_name, sizeof(ipc->shm_name), "/s-%08x", id);
+    ipc->shm_id = 0;
+    ipc->shm_name[0] = '\0';
 
     // Acquire semaphore for exclusive access during initialization
     if (ipc->init_sem && sem_wait(ipc->init_sem) < 0) {
@@ -43,13 +44,27 @@ sentry__crash_ipc_init_app(sem_t *init_sem)
         return NULL;
     }
 
-    // Try to create or open shared memory
+    // Try to create shared memory. Do not reuse existing names: a pre-created
+    // segment may be attacker-controlled.
     bool shm_exists = false;
-    ipc->shm_fd = shm_open(ipc->shm_name, O_CREAT | O_RDWR | O_EXCL, 0600);
-    if (ipc->shm_fd < 0 && errno == EEXIST) {
-        // Shared memory already exists - reuse it
-        shm_exists = true;
-        ipc->shm_fd = shm_open(ipc->shm_name, O_RDWR, 0600);
+    ipc->shm_fd = -1;
+    for (uint32_t attempt = 0; attempt < 8; attempt++) {
+        uint32_t nonce = 0;
+        if (sentry__getrandom(&nonce, sizeof(nonce)) != 0) {
+            nonce = (uint32_t)(uintptr_t)&nonce ^ attempt;
+        }
+        uint32_t id = (uint32_t)((getpid() ^ (tid & 0xFFFFFFFF) ^ nonce
+                                      ^ attempt)
+            & 0xFFFFFFFF);
+        snprintf(ipc->shm_name, sizeof(ipc->shm_name), "/s-%08x", id);
+        ipc->shm_fd = shm_open(ipc->shm_name, O_CREAT | O_RDWR | O_EXCL, 0600);
+        if (ipc->shm_fd >= 0) {
+            ipc->shm_id = id;
+            break;
+        }
+        if (errno != EEXIST) {
+            break;
+        }
     }
 
     if (ipc->shm_fd < 0) {

--- a/src/backends/native/sentry_crash_ipc.h
+++ b/src/backends/native/sentry_crash_ipc.h
@@ -86,8 +86,8 @@ sentry_crash_ipc_t *sentry__crash_ipc_init_app(void);
  * Linux, pipe fd on macOS, event on Windows)
  */
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
-sentry_crash_ipc_t *sentry__crash_ipc_init_daemon(
-    pid_t app_pid, uint64_t app_tid, int notify_eventfd, int ready_eventfd);
+sentry_crash_ipc_t *sentry__crash_ipc_init_daemon(pid_t app_pid,
+    uint64_t app_tid, int notify_eventfd, int ready_eventfd, int shm_fd);
 #elif defined(SENTRY_PLATFORM_MACOS)
 sentry_crash_ipc_t *sentry__crash_ipc_init_daemon(pid_t app_pid,
     uint64_t app_tid, int notify_pipe_read, int ready_pipe_write, int shm_fd);

--- a/src/backends/native/sentry_crash_ipc.h
+++ b/src/backends/native/sentry_crash_ipc.h
@@ -32,6 +32,7 @@ typedef struct {
     int shm_fd;
     int notify_fd; // Eventfd for crash notifications
     int ready_fd; // Eventfd for daemon ready signal
+    uint32_t shm_id;
     char shm_name[SENTRY_CRASH_IPC_NAME_SIZE];
     sem_t *init_sem; // Named semaphore for initialization synchronization
     char sem_name[SENTRY_CRASH_IPC_NAME_SIZE];

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -458,9 +458,10 @@ native_backend_startup(
     const char *daemon_handler_path
         = options->handler_path ? options->handler_path->path : NULL;
 #    if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
-    uint64_t ipc_id = (uint64_t)(state->ipc->shm_id ^ (uint32_t)getpid());
-    state->daemon_pid = sentry__crash_daemon_start(getpid(), ipc_id,
-        state->ipc->notify_fd, state->ipc->ready_fd, daemon_handler_path);
+    uint64_t tid = (uint64_t)pthread_self();
+    state->daemon_pid
+        = sentry__crash_daemon_start(getpid(), tid, state->ipc->notify_fd,
+            state->ipc->ready_fd, state->ipc->shm_fd, daemon_handler_path);
 #    elif defined(SENTRY_PLATFORM_MACOS)
     uint64_t tid = (uint64_t)pthread_self();
     state->daemon_pid
@@ -498,6 +499,8 @@ native_backend_startup(
 #    endif
 
 #    if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
+    sentry__crash_ipc_unlink(state->ipc);
+
     // Close unused eventfd ends in parent process
     // (eventfds are bidirectional, but we only use one direction per fd)
     // Parent writes to notify_fd, daemon reads from it - parent can close for

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -458,8 +458,8 @@ native_backend_startup(
     const char *daemon_handler_path
         = options->handler_path ? options->handler_path->path : NULL;
 #    if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
-    uint64_t tid = (uint64_t)pthread_self();
-    state->daemon_pid = sentry__crash_daemon_start(getpid(), tid,
+    uint64_t ipc_id = (uint64_t)(state->ipc->shm_id ^ (uint32_t)getpid());
+    state->daemon_pid = sentry__crash_daemon_start(getpid(), ipc_id,
         state->ipc->notify_fd, state->ipc->ready_fd, daemon_handler_path);
 #    elif defined(SENTRY_PLATFORM_MACOS)
     uint64_t tid = (uint64_t)pthread_self();


### PR DESCRIPTION
Create Linux crash IPC shared memory with a random nonce and avoid reusing pre-existing segments.

<details><summary>Shared memory name prediction enables same-user IPC spoofing</summary>

## Details
The shared memory segment name is derived from `getpid() ^ pthread_self()` at line 36, formatted as `/s-%08x`. The PID is observable via /proc and pthread_self() is often deterministic for the main thread. When `shm_open` with O_EXCL fails (EEXIST) at lines 48-53, the code falls back to opening the existing segment with no ownership verification (no fstat uid check). The daemon reads unvalidated DSN, proxy URL, database_path, and external_reporter_path from this shared memory. A same-user attacker can pre-create the segment with controlled content. Although the app overwrites the segment after opening, the attacker retains a writable mapping and can race to overwrite values between the app's writes and the daemon's reads.

## Location
[src/backends/native/sentry_crash_ipc.c:36](https://github.com/getsentry/sentry-native/blob/master/src/backends/native/sentry_crash_ipc.c#L36)

## Impact
Same-user attacker redirects crash data to attacker-controlled server or executes arbitrary binary.

## Reproduction steps
1. A same-user attacker observes the target process PID via /proc, predicts the shared memory name, and pre-creates `/dev/shm/s-XXXXXXXX` with attacker-controlled content including a malicious DSN pointing to attacker's server and an external_reporter_path pointing to attacker's binary. When the target application initializes Sentry and hits the EEXIST fallback, it opens the attacker's segment. The attacker races to overwrite the configuration after the app writes it but before the daemon reads it, redirecting crash reports (potentially containing sensitive stack data) to the attacker's server.

## Recommended fix
The EEXIST fallback must verify ownership (fstat st_uid) of the existing segment before using it, and the shared memory name should include additional entropy beyond PID and TID.

---
**Severity:** LOW
**Status:** Open
**Category:** Race-condition
**Repository:** getsentry/sentry-native
**Branch:** master

</details>