### PR TITLE
test: trigger crashes with correct WER exception codes

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -416,9 +416,9 @@ trigger_stack_buffer_overrun()
 static void
 trigger_fastfail_crash()
 {
-    // this bypasses WINDOWS SEH and will only be caught with the crashpad WER
-    // module enabled
-    __fastfail(77);
+    // this bypasses WINDOWS SEH and will only be caught with the
+    // crashpad/native WER module enabled
+    RaiseFailFastException(NULL, NULL, 0);
 }
 
 #endif

--- a/src/backends/native/sentry_wer.c
+++ b/src/backends/native/sentry_wer.c
@@ -146,6 +146,14 @@ process_wer_exception(
         ctx->platform.threads[0].thread_id = ctx->crashed_tid;
         ctx->platform.threads[0].context = exception_info->context;
 
+        char buf[4096];
+        snprintf(buf, sizeof(buf),
+            "### SENTRY_WER: crashed_pid=%lu crashed_tid=%llu "
+            "exception_code=0x%08X",
+            (unsigned long)ctx->crashed_pid,
+            (unsigned long long)ctx->crashed_tid, ctx->platform.exception_code);
+        OutputDebugStringA(buf);
+
         InterlockedExchange(&ctx->state, SENTRY_CRASH_STATE_CRASHED);
         if (SetEvent(event)) {
             claimed = TRUE;

--- a/src/backends/native/sentry_wer.c
+++ b/src/backends/native/sentry_wer.c
@@ -146,14 +146,6 @@ process_wer_exception(
         ctx->platform.threads[0].thread_id = ctx->crashed_tid;
         ctx->platform.threads[0].context = exception_info->context;
 
-        char buf[4096];
-        snprintf(buf, sizeof(buf),
-            "### SENTRY_WER: crashed_pid=%lu crashed_tid=%llu "
-            "exception_code=0x%08X",
-            (unsigned long)ctx->crashed_pid,
-            (unsigned long long)ctx->crashed_tid, ctx->platform.exception_code);
-        OutputDebugStringA(buf);
-
         InterlockedExchange(&ctx->state, SENTRY_CRASH_STATE_CRASHED);
         if (SetEvent(event)) {
             claimed = TRUE;

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -88,8 +88,14 @@ def test_native_capture_crash(cmake, httpserver):
     reason="WER crash tests are only available in MSVC Windows builds",
 )
 @pytest.mark.with_wer
-@pytest.mark.parametrize("crash_arg", ["fastfail", "stack-buffer-overrun"])
-def test_native_wer(cmake, httpserver, crash_arg):
+@pytest.mark.parametrize(
+    "crash_arg,exception_code",
+    [
+        pytest.param("fastfail", 0xC0000602, id="fastfail"),
+        pytest.param("stack-buffer-overrun", 0xC0000409, id="stack-buffer-overrun"),
+    ],
+)
+def test_native_wer_crash(cmake, httpserver, crash_arg, exception_code):
     """Test WER crash capture with native backend"""
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
 
@@ -106,7 +112,7 @@ def test_native_wer(cmake, httpserver, crash_arg):
 
     assert len(httpserver.log) >= 1
     envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
-    assert_native_crash(envelope, exception_code=0xC0000409)
+    assert_native_crash(envelope, exception_code=exception_code)
 
 
 @pytest.mark.skipif(not has_oom, reason="OOM test unreliable in this environment")


### PR DESCRIPTION
For stack-buffer-overruns, the example uses `RaiseFailFastException` as appropriate, but for fastfails, it used `__fastfail(77)` that makes WER deliver `STATUS_STACK_BUFFER_OVERRUN (0xC0000409)`.

- `__fastfail(77)` → kernel int `0x29` → WER always normalizes to `STATUS_STACK_BUFFER_OVERRUN (0xC0000409)`
   > User-mode fast fail requests appear as a second chance non-continuable exception with exception code `0xC0000409`

   https://learn.microsoft.com/en-us/cpp/intrinsics/fastfail

vs.

- `RaiseFailFastException(NULL, NULL, 0)` → WER preserves the original exception code `STATUS_FAIL_FAST_EXCEPTION (0xC0000602)`
   https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-raisefailfastexception

_Originally posted by @cursor[bot] in https://github.com/getsentry/sentry-native/pull/1777#discussion_r3346325493_

> ### Wrong exception code for fastfail
> 
> **Medium Severity**
> 
> <!-- DESCRIPTION START -->
> `test_native_wer_crash` is parametrized with `fastfail` and `stack-buffer-overrun`, but always asserts exception code `0xC0000409`. The `fastfail` path uses `__fastfail` and raises `STATUS_FAIL_FAST_EXCEPTION` (`0xC0000602`), so the `fastfail` case fails the assertion even when capture works.
> <!-- DESCRIPTION END -->
> 
> <!-- BUGBOT_BUG_ID: 826cd282-853c-4ab0-9889-20f3ddfab3a5 -->
> 
> <!-- LOCATIONS START
> tests/test_integration_native.py#L108-L109
> LOCATIONS END -->
> <div><a href="https://cursor.com/open?link=eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiQlVHQk9UX0ZJWF9JTl9DVVJTT1IiLCJkYXRhIjp7InJlZGlzS2V5IjoiYnVnYm90OmFjYWQ0NTI0LWE2NDUtNDAwNi1hZDJjLTliODdiNTllMTM2ZCIsImVuY3J5cHRpb25LZXkiOiJfVGllcUJFWGhTWEZoSlZVYmhRYnE4X3EzV0xjV3BueFV6SDVZY2pTc0NjIiwiYnJhbmNoIjoianBudXJtaS9mZWF0L25hdGl2ZS93ZXIiLCJyZXBvT3duZXIiOiJnZXRzZW50cnkiLCJyZXBvTmFtZSI6InNlbnRyeS1uYXRpdmUifX0" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-cursor-light.png"><img alt="Fix in Cursor" width="115" height="28" src="https://cursor.com/assets/images/fix-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?link=eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiQlVHQk9UX0ZJWF9JTl9XRUIiLCJkYXRhIjp7InJlZGlzS2V5IjoiYnVnYm90OmFjYWQ0NTI0LWE2NDUtNDAwNi1hZDJjLTliODdiNTllMTM2ZCIsImVuY3J5cHRpb25LZXkiOiJfVGllcUJFWGhTWEZoSlZVYmhRYnE4X3EzV0xjV3BueFV6SDVZY2pTc0NjIiwiYnJhbmNoIjoianBudXJtaS9mZWF0L25hdGl2ZS93ZXIiLCJyZXBvT3duZXIiOiJnZXRzZW50cnkiLCJyZXBvTmFtZSI6InNlbnRyeS1uYXRpdmUiLCJwck51bWJlciI6MTc3NywiY29tbWl0U2hhIjoiOWMzZTgyZjU1Mzk3NWExZjM2ZTVmNDEyNzY0NGI3ZmVkNWNlZWM2MiIsInByb3ZpZGVyIjoiZ2l0aHViIn19" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-web-light.png"><img alt="Fix in Web" width="99" height="28" src="https://cursor.com/assets/images/fix-in-web-dark.png"></picture></a></div>


<sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3e82f553975a1f36e5f4127644b7fed5ceec62. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

NOTE: The CI does not run WER tests. Tested locally:
```
(.venv) C:\Users\jpnurmi\Projects\sentry\sentry-native>pytest --with_wer -v tests\
================================================= test session starts =================================================
platform win32 -- Python 3.13.3, pytest-9.0.3, pluggy-1.5.0 -- C:\Python313\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\jpnurmi\Projects\sentry\sentry-native
plugins: flaky-3.8.1, pytest_httpserver-1.0.10, xdist-3.8.0
collected 1496 items

tests/test_build_static.py::test_static_lib PASSED                                                               [  0%]
...
==================================== 1460 passed, 36 skipped in 954.19s (0:15:54) =====================================
```