### PR TITLE
chore: adapt Makefile for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: test
 
 GIT_COMMON_DIR := $(shell git rev-parse --git-common-dir)
 
+VENV_BIN = $(if $(filter Windows_NT,$(OS)),.venv/Scripts,.venv/bin)
+
 update-test-discovery:
 	@perl -ne 'print if s/SENTRY_TEST\(([^)]+)\).*/XX(\1)/' tests/unit/*.c | LC_ALL=C sort | grep -v define | uniq > tests/unit/tests.inc
 .PHONY: update-test-discovery
@@ -21,14 +23,15 @@ test-unit: update-test-discovery CMakeLists.txt
 	@mkdir -p unit-build
 	@cd unit-build; cmake \
 		-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(PWD)/unit-build \
+		-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO=$(PWD)/unit-build \
 		-DSENTRY_BACKEND=none \
 		..
-	@cmake --build unit-build --target sentry_test_unit --parallel
+	@cmake --build unit-build --target sentry_test_unit --parallel --config RelWithDebInfo
 	./unit-build/sentry_test_unit
 .PHONY: test-unit
 
 test-integration: setup-venv
-	.venv/bin/pytest tests --verbose
+	$(VENV_BIN)/pytest tests --verbose
 .PHONY: test-integration
 
 test-leaks: update-test-discovery CMakeLists.txt
@@ -46,7 +49,7 @@ test-leaks: update-test-discovery CMakeLists.txt
 .PHONY: test-leaks
 
 benchmark: setup-venv
-	.venv/bin/pytest tests/benchmark.py --verbose
+	$(VENV_BIN)/pytest tests/benchmark.py --verbose
 .PHONY: benchmark
 
 clean: build/Makefile
@@ -69,19 +72,19 @@ $(GIT_COMMON_DIR)/hooks/pre-commit:
 .venv/.stamp: Makefile tests/requirements.txt
 	@rm -rf .venv
 	python3 -m venv .venv
-	.venv/bin/pip install --upgrade --requirement tests/requirements.txt
+	$(VENV_BIN)/pip install --upgrade --requirement tests/requirements.txt
 	@touch $@
 
 format: setup-venv
 	@find examples include src tests/unit \
 		\( -name '*.c' -o -name '*.cpp' -o -name '*.h' \) -print0 \
-		| xargs -0 .venv/bin/clang-format -i
-	@.venv/bin/black tests
+		| xargs -0 $(VENV_BIN)/clang-format -i
+	@$(VENV_BIN)/black tests
 .PHONY: format
 
 style: setup-venv
-	@.venv/bin/python ./scripts/check-clang-format.py \
-		--clang-format-executable .venv/bin/clang-format \
+	@$(VENV_BIN)/python ./scripts/check-clang-format.py \
+		--clang-format-executable $(VENV_BIN)/clang-format \
 		-r examples include src tests/unit
-	@.venv/bin/black --diff --check tests
+	@$(VENV_BIN)/black --diff --check tests
 .PHONY: style


### PR DESCRIPTION
As long as one has `make` and a compiler in PATH (e.g. choco & vcvarsall.sh), the only adaptations needed for working straight from Git Bash on Windows are:
- [NT](https://github.com/python/cpython/blob/57d444612d9c8a0eab66543d5bf8539103a59b47/Lib/sysconfig/__init__.py#L98): `.venv/Scripts` vs. [POSIX](https://github.com/python/cpython/blob/57d444612d9c8a0eab66543d5bf8539103a59b47/Lib/sysconfig/__init__.py#L88): `.venv/bin`
- explicit `DCMAKE_RUNTIME_OUTPUT_DIRECTORY_<CONFIG>` and `--config` to support multi-config generators (VS).

<details><summary>make setup</summary>

```sh
jpnurmi@surface:~/Projects/sentry/sentry-native (jpnurmi/chore/makefile)$ make setup
git submodule update --init --recursive
Submodule 'external/benchmark' (https://github.com/google/benchmark.git) registered for path 'external/benchmark'
[...]
Submodule path 'external/third_party/lss': checked out 'ed31caa60f20a4f6569883b2d752ef7522de51e0'
python3 -m venv .venv
.venv/Scripts/pip install --upgrade --requirement tests/requirements.txt
[...]
Successfully installed Brotli-1.2.0 Werkzeug-3.1.8 aioquic-1.2.0 argon2-cffi-25.1.0 argon2-cffi-bindings-25.1.0 asgiref-3.11.0 attrs-26.1.0 bcrypt-5.0.0 black-26.3.1 blinker-1.9.0 certifi-2026.5.20 cffi-2.0.0 charset_normalizer-3.4.7 clang-format-20.1.5 click-8.4.1 colorama-0.4.6 cryptography-46.0.7 execnet-2.1.2 flaky-3.8.1 flask-3.1.3 h11-0.16.0 h2-4.3.0 hpack-4.1.0 hyperframe-6.1.0 idna-3.18 iniconfig-2.3.0 itsdangerous-2.2.0 jinja2-3.1.6 kaitaistruct-0.11 ldap3-2.9.1 markupsafe-3.0.3 mitmproxy-12.2.2 mitmproxy-rs-0.12.9 mitmproxy-windows-0.12.9 msgpack-1.0.8 mypy-extensions-1.1.0 packaging-26.2 pathspec-1.1.1 platformdirs-4.10.0 pluggy-1.6.0 psutil-7.1.1 publicsuffix2-2.20191221 pyOpenSSL-25.3.0 pyasn1-0.6.3 pyasn1-modules-0.4.2 pycparser-3.0 pydivert-2.1.0 pygments-2.20.0 pylsqpack-0.3.24 pyparsing-3.3.2 pyperclip-1.11.0 pytest-9.0.3 pytest-httpserver-1.0.10 pytest-xdist-3.8.0 pytokens-0.4.1 pywin32-308 requests-2.33.0 ruamel.yaml-0.19.1 service-identity-24.2.0 sortedcontainers-2.4.0 tornado-6.5.5 urllib3-2.7.0 urwid-3.0.5 wcwidth-0.7.0 wsproto-1.3.2 zstandard-0.25.0

[notice] A new release of pip is available: 25.0.1 -> 26.1.2
[notice] To update, run: C:\Users\jpnurmi\Projects\sentry\sentry-native\.venv\Scripts\python.exe -m pip install --upgrade pip
```
</details>

<details><summary>make format</summary>

```sh
jpnurmi@surface:~/Projects/sentry/sentry-native (jpnurmi/chore/makefile)$ make format
All done! ✨ 🍰 ✨
30 files left unchanged.
```
</details>

<details><summary>make build</summary>

```sh
jpnurmi@surface:~/Projects/sentry/sentry-native (jpnurmi/chore/makefile)$ make build
-- Sentry SDK version (full): 0.14.2
-- Sentry SDK version (base): 0.14.2
-- Sentry SDK version major='0' minor='14' patch='2'
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.26200.
-- SENTRY_TRANSPORT=winhttp
-- SENTRY_BACKEND=crashpad
-- SENTRY_LIBRARY_TYPE=SHARED
-- SENTRY_SDK_NAME=
-- SENTRY_HANDLER_STACK_SIZE=64
-- SENTRY_THREAD_STACK_GUARANTEE_FACTOR=10
-- SENTRY_THREAD_STACK_GUARANTEE_AUTO_INIT=ON
-- SENTRY_THREAD_STACK_GUARANTEE_VERBOSE_LOG=OFF
-- Configuring done (0.1s)
-- Generating done (0.7s)
-- Build files have been written to: C:/Users/jpnurmi/Projects/sentry/sentry-native/build
MSBuild version 17.14.40+3e7442088 for .NET Framework

  1>Checking Build System
  [...]
  crashpad_getopt.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\third_party\getopt\Debug\crashpad_getopt.lib
  crashpad_zlib.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\third_party\zlib\Debug\crashpad_zlib.lib
  crashpad_tools.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\tools\Debug\crashpad_tools.lib
  mini_chromium.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\third_party\mini_chromium\Debug\mini_chromium.lib
  crashpad_compat.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\compat\Debug\crashpad_compat.lib
  crashpad_mpack.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\third_party\mpack\Debug\crashpad_mpack.lib
  crashpad_wer.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\handler\Debug\crashpad_wer.dll
  crashpad_util.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\util\Debug\crashpad_util.lib
  crashpad_client.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\client\Debug\crashpad_client.lib
  crashpad_snapshot.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\snapshot\Debug\crashpad_snapshot.lib
  sentry_fuzz_json.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\tests\unit\Debug\sentry_fuzz_json.exe
  sentry_test_unit.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\tests\unit\Debug\sentry_test_unit.exe
  crashpad_minidump.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\minidump\Debug\crashpad_minidump.lib
  crashpad_handler_lib.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\handler\Debug\crashpad_handler_lib.lib
  crashpad_handler.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\crashpad_build\handler\Debug\crashpad_handler.exe
  Building Custom Rule C:/Users/jpnurmi/Projects/sentry/sentry-native/CMakeLists.txt
  sentry.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\Debug\sentry.dll
  sentry_crash_reporter.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\tests\fixtures\crash_reporter\Debug\sentry_crash_reporter.exe
  Building Custom Rule C:/Users/jpnurmi/Projects/sentry/sentry-native/CMakeLists.txt
  sentry_example.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\Debug\sentry_example.exe
  sentry_screenshot.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\build\tests\fixtures\screenshot\Debug\sentry_screenshot.exe
  Building Custom Rule C:/Users/jpnurmi/Projects/sentry/sentry-native/CMakeLists.txt
```
</details>

<details><summary>make test-unit</summary>

```sh
jpnurmi@surface:~/Projects/sentry/sentry-native (jpnurmi/chore/makefile)$ make test-unit
-- Sentry SDK version (full): 0.14.2
-- Sentry SDK version (base): 0.14.2
-- Sentry SDK version major='0' minor='14' patch='2'
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.26200.
-- SENTRY_TRANSPORT=winhttp
-- SENTRY_BACKEND=none
-- SENTRY_LIBRARY_TYPE=SHARED
-- SENTRY_SDK_NAME=
-- SENTRY_HANDLER_STACK_SIZE=64
-- SENTRY_THREAD_STACK_GUARANTEE_FACTOR=10
-- SENTRY_THREAD_STACK_GUARANTEE_AUTO_INIT=ON
-- SENTRY_THREAD_STACK_GUARANTEE_VERBOSE_LOG=OFF
-- Configuring done (0.0s)
-- Generating done (0.2s)
-- Build files have been written to: C:/Users/jpnurmi/Projects/sentry/sentry-native/unit-build
MSBuild version 17.14.40+3e7442088 for .NET Framework

  [...]
  sentry_test_unit.vcxproj -> C:\Users\jpnurmi\Projects\sentry\sentry-native\unit-build\sentry_test_unit.exe
./unit-build/sentry_test_unit
Test assert_sdk_name...                         [ OK ]
[...]
Test xmm_save_area_size...                      [ OK ]
SUCCESS: All unit tests have passed.
```
</details>

<details><summary>make test-integration</summary>

```sh
jpnurmi@surface:~/Projects/sentry/sentry-native (jpnurmi/chore/makefile)$ make test-integration
.venv/Scripts/pytest tests --verbose
================================================= test session starts =================================================
platform win32 -- Python 3.13.3, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\jpnurmi\Projects\sentry\sentry-native\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\jpnurmi\Projects\sentry\sentry-native
plugins: flaky-3.8.1, pytest_httpserver-1.0.10, xdist-3.8.0
collected 1496 items

tests/test_build_static.py::test_static_lib PASSED                                                               [  0%]
[...]
tests/test_unit.py::test_unit_with_test_path[xmm_save_area_size] PASSED                                          [100%]
==================================================== sccache stats ====================================================
Compile requests                   2655
Compile requests executed          2655
Cache hits                         2654
Cache hits (C/C++)                 2654
Cache misses                          1
Cache misses (C/C++)                  1
Cache hits rate                   99.96 %
Cache hits rate (C/C++)           99.96 %
Cache timeouts                        0
Cache read errors                     0
Forced recaches                       0
Cache write errors                    0
Cache errors                          0
Compilations                          1
Compilation failures                  0
Non-cacheable compilations            0
Non-cacheable calls                   0
Non-compilation calls                 0
Unsupported compiler calls            0
Average cache write               0.003 s
Average compiler                  1.195 s
Average cache read hit            0.001 s
Failed distributed compilations       0
Cache location                  Local disk: "C:\\Users\\jpnurmi\\AppData\\Local\\Mozilla\\sccache\\cache"
Base directories                (none)
Use direct/preprocessor mode?   yes
Version (client)                0.14.0
Cache size                          626 MiB
Max cache size                       10 GiB
===Flaky Test Report===

test_crashpad_dumping_crash[run_args0-build_args0] passed 1 out of the required 1 times. Success!
test_crashpad_dumping_crash[run_args1-build_args1] passed 1 out of the required 1 times. Success!
test_crashpad_dumping_crash[run_args2-build_args2] passed 1 out of the required 1 times. Success!
test_crashpad_dumping_crash[run_args3-build_args3] passed 1 out of the required 1 times. Success!
test_crashpad_dumping_crash[run_args4-build_args4] passed 1 out of the required 1 times. Success!
test_crashpad_dumping_crash[run_args5-build_args5] passed 1 out of the required 1 times. Success!
test_breakpad_dump_inflight passed 1 out of the required 1 times. Success!
test_shutdown_timeout passed 1 out of the required 1 times. Success!

===End Flaky Test Report===

==================================== 1450 passed, 46 skipped in 708.36s (0:11:48) =====================================
```
</details>

P.S. I know there's `scripts/run_tests.ps1`, but I'd prefer Bash auto-completion and the familiar Unix workflows... 🥺 