### PR TITLE
fix: leak in `sentry__session_from_json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix TOCTOU races in transaction/span refcounting by switching to the atomic decref return value. ([#1763](https://github.com/getsentry/sentry-native/pull/1763))
 - Fix a potential out-of-bounds read when parsing non-NUL-terminated `sentry-trace` headers. ([#1749](https://github.com/getsentry/sentry-native/pull/1749))
 - Harden ELF note parsing against overflow and OOB reads. ([#1773](https://github.com/getsentry/sentry-native/pull/1773))
+- Fix memory leak in session deserialization on malformed cached files. ([#1789](https://github.com/getsentry/sentry-native/pull/1789))
 - Fix division by zero when breadcrumbs are disabled. ([#1767](https://github.com/getsentry/sentry-native/pull/1767))
 - Native: escape JSON attachments. ([#1771](https://github.com/getsentry/sentry-native/pull/1771))
 - Handle memory allocation failures during JSON serialization to prevent truncated output. ([#1772](https://github.com/getsentry/sentry-native/pull/1772))

--- a/src/sentry_session.c
+++ b/src/sentry_session.c
@@ -151,17 +151,20 @@ sentry__session_from_json(const char *buf, size_t buflen)
 
     sentry_value_t attrs = sentry_value_get_by_key(value, "attrs");
     if (sentry_value_is_null(attrs)) {
+        sentry_value_decref(value);
         return NULL;
     }
     char *release = sentry__string_clone(
         sentry_value_as_string(sentry_value_get_by_key(attrs, "release")));
     if (!release) {
+        sentry_value_decref(value);
         return NULL;
     }
 
     sentry_session_t *rv = SENTRY_MAKE(sentry_session_t);
     if (!rv) {
         sentry_free(release);
+        sentry_value_decref(value);
         return NULL;
     }
     rv->session_id


### PR DESCRIPTION
Release parsed session JSON values on early parse failures to avoid leaking malformed cached session files.

<details><summary>LOW: Memory leak in session deserialization on malformed cached files</summary>

## Details
The function sentry__session_from_json (line 144) parses JSON from a cached session file into a refcounted sentry_value_t. If parsing succeeds but the 'attrs' key is missing (line 152-153) or the 'release' value is absent (line 157-158), the function returns NULL without calling sentry_value_decref(value), leaking the entire parsed JSON value tree. A third leak exists at line 164 if memory allocation fails. The happy path at line 190 correctly calls sentry_value_decref. Session files are read from the persistent cache directory during SDK startup via sentry__process_old_runs -> sentry__session_from_path (sentry_database.c:425). A malformed session.json file in an old run directory triggers the leak on each SDK initialization.

## Location
[src/sentry_session.c:153](https://github.com/getsentry/sentry-native/blob/master/src/sentry_session.c#L153)

## Impact
Memory leaks on each SDK initialization with crafted cache files

## Reproduction steps
1. An attacker with write access to the sentry database directory places a crafted session.json file containing valid JSON without an 'attrs' key (e.g., {"sid":"abc"}). On each SDK initialization, sentry__process_old_runs iterates old run directories, reads this file, calls sentry__session_from_json, which parses the JSON successfully but fails the attrs check at line 153 and returns NULL without freeing the parsed value tree, leaking memory.

## Recommended fix
All early-return paths in sentry__session_from_json after successful JSON parsing must call sentry_value_decref(value) before returning NULL.

---
**Severity:** LOW
**Status:** Open
**Category:** Logic error
**Repository:** getsentry/sentry-native
**Branch:** master

</details>