### PR TITLE
fix(curl): free duplicate headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Native/macOS: honor the `system_crash_reporter_enabled` option. ([#1743](https://github.com/getsentry/sentry-native/pull/1743))
 - Cap rate-limit retry-after values at 24 hours to prevent a MITM-provided response from disabling event delivery for the process lifetime. ([#1744](https://github.com/getsentry/sentry-native/pull/1744))
 - Fix a shutdown-time use-after-free window in `sentry_close()`. ([#1750](https://github.com/getsentry/sentry-native/pull/1750))
+- curl: free duplicate HTTP response headers to avoid potential leaks. ([#1791](https://github.com/getsentry/sentry-native/pull/1791))
 - Native: validate ELF header entry sizes. ([#1746](https://github.com/getsentry/sentry-native/pull/1746))
 - Native: clamp `module_count` from the shared crash context. ([#1770](https://github.com/getsentry/sentry-native/pull/1770))
 - Prevent database cleanup from following symlinks in run and cache directories. ([#1751](https://github.com/getsentry/sentry-native/pull/1751))

--- a/src/transports/sentry_http_transport_curl.c
+++ b/src/transports/sentry_http_transport_curl.c
@@ -174,10 +174,13 @@ header_callback(char *buffer, size_t size, size_t nitems, void *userdata)
         sentry_slice_t value
             = sentry__slice_trim(sentry__slice_from_str(sep + 1));
         if (sentry__string_eq(header, "retry-after")) {
+            sentry_free(info->retry_after);
             info->retry_after = sentry__slice_to_owned(value);
         } else if (sentry__string_eq(header, "x-sentry-rate-limits")) {
+            sentry_free(info->x_sentry_rate_limits);
             info->x_sentry_rate_limits = sentry__slice_to_owned(value);
         } else if (sentry__string_eq(header, "location")) {
+            sentry_free(info->location);
             info->location = sentry__slice_to_owned(value);
         }
     }


### PR DESCRIPTION
Free previous header values before replacing them with later potentially duplicate response headers.

<details><summary>LOW: Memory leak from duplicate HTTP response headers in curl transport</summary>

## Details
In `header_callback` (lines 158-161), when a duplicate `retry-after` or `x-sentry-rate-limits` header is received, the code overwrites `info->retry_after` or `info->x_sentry_rate_limits` with a new `sentry__string_clone` allocation without first freeing the previous value. Each duplicate header leaks the previous allocation. While curl has some limits on total response header size, a malicious server can include many duplicate headers up to that limit.

## Location
[src/transports/sentry_http_transport_curl.c:159](https://github.com/getsentry/sentry-native/blob/master/src/transports/sentry_http_transport_curl.c#L159)

## Impact
Malicious server sending duplicate headers causes unbounded memory leak per request.

## Reproduction steps
1. A MITM attacker on an HTTP (non-TLS) connection, or a compromised Sentry server, sends HTTP responses with hundreds of duplicate `retry-after` headers. Each response leaks memory proportional to the number of duplicates. In a long-running application that sends frequent events, repeated requests accumulate leaked memory, eventually causing memory pressure.

## Recommended fix
Free the existing allocation before assigning the new value: `sentry_free(info->retry_after)` before the clone, ensuring only one allocation is held at a time.

---
**Severity:** LOW
**Status:** Open
**Category:** Memory Leak
**Repository:** getsentry/sentry-native
**Branch:** master

</details>