### PR TITLE
fix: file descriptor leak in old-run processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix division by zero when breadcrumbs are disabled. ([#1767](https://github.com/getsentry/sentry-native/pull/1767))
 - Native: escape JSON attachments. ([#1771](https://github.com/getsentry/sentry-native/pull/1771))
 - Handle memory allocation failures during JSON serialization to prevent truncated output. ([#1772](https://github.com/getsentry/sentry-native/pull/1772))
+- Free the acquired filelock before skipping the current run directory during old-run processing. ([#1792](https://github.com/getsentry/sentry-native/pull/1792))
 
 ## 0.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Fix division by zero when breadcrumbs are disabled. ([#1767](https://github.com/getsentry/sentry-native/pull/1767))
 - Native: escape JSON attachments. ([#1771](https://github.com/getsentry/sentry-native/pull/1771))
 - Handle memory allocation failures during JSON serialization to prevent truncated output. ([#1772](https://github.com/getsentry/sentry-native/pull/1772))
-- Free the acquired filelock before skipping the current run directory during old-run processing. ([#1792](https://github.com/getsentry/sentry-native/pull/1792))
+- Fix a file descriptor leak in old-run processing. ([#1792](https://github.com/getsentry/sentry-native/pull/1792))
 
 ## 0.14.2
 

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -632,6 +632,11 @@ sentry__process_old_runs(const sentry_options_t *options, uint64_t last_crash)
             continue;
         }
 
+        // our own run directory is protected by options->run->lock
+        if (sentry__path_eq(run_dir, options->run->run_path)) {
+            continue;
+        }
+
         sentry_path_t *lockfile = sentry__path_append_str(run_dir, ".lock");
         if (!lockfile) {
             continue;
@@ -643,11 +648,6 @@ sentry__process_old_runs(const sentry_options_t *options, uint64_t last_crash)
         bool did_lock = sentry__filelock_try_lock(lock);
         // the file is locked by another process
         if (!did_lock) {
-            sentry__filelock_free(lock);
-            continue;
-        }
-        // make sure we don't delete ourselves if the lock check fails
-        if (strcmp(options->run->run_path->path, run_dir->path) == 0) {
             sentry__filelock_free(lock);
             continue;
         }

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -648,6 +648,7 @@ sentry__process_old_runs(const sentry_options_t *options, uint64_t last_crash)
         }
         // make sure we don't delete ourselves if the lock check fails
         if (strcmp(options->run->run_path->path, run_dir->path) == 0) {
+            sentry__filelock_free(lock);
             continue;
         }
 


### PR DESCRIPTION
<details><summary>LOW: Filelock resource leak when matching own run path</summary>

## Details
In sentry__process_old_runs, when iterating .run directories, a filelock is acquired at line 409. At line 414, if the current directory matches the SDK's own run path, the code executes 'continue' to skip processing. However, this continue skips the sentry__filelock_free(lock) call at line 469, leaking the file descriptor associated with the lock. Each SDK initialization that encounters its own run directory leaks one file descriptor.

## Location
[src/sentry_database.c:414](https://github.com/getsentry/sentry-native/blob/master/src/sentry_database.c#L414)

## Impact
File descriptor leak accumulates over repeated SDK initializations.

## Reproduction steps
1. An application initializes and shuts down the sentry SDK repeatedly in a long-running process. Each initialization calls sentry__process_old_runs, which encounters the previous run's directory. The filelock for the matching directory is allocated but never freed due to the early continue. Over thousands of restart cycles, the accumulated file descriptor leaks can exhaust the process's file descriptor limit, causing subsequent file operations to fail.

## Recommended fix
Free the filelock before the continue statement at line 414, or restructure the code to ensure cleanup on all paths.

---
**Severity:** LOW
**Status:** Open
**Category:** Resource Leak
**Repository:** getsentry/sentry-native
**Branch:** master

</details>