### PR TITLE
fix(tus): remove redundant Upload-Metadata header from PATCH request

### DIFF
--- a/src/transports/sentry_http_transport.c
+++ b/src/transports/sentry_http_transport.c
@@ -21,7 +21,7 @@
 
 #define ENVELOPE_MIME "application/x-sentry-envelope"
 #define TUS_MIME "application/offset+octet-stream"
-#define TUS_MAX_HTTP_HEADERS 5
+#define TUS_MAX_HTTP_HEADERS 4
 #ifdef SENTRY_TRANSPORT_COMPRESSION
 #    define MAX_HTTP_HEADERS 4
 #else
@@ -276,8 +276,7 @@ prepare_tus_request_common(size_t upload_size, const char *attachment_type,
 
 static sentry_prepared_http_request_t *
 prepare_tus_upload_request(const char *location, const sentry_path_t *path,
-    size_t file_size, const char *attachment_type, const sentry_dsn_t *dsn,
-    const char *user_agent)
+    size_t file_size, const sentry_dsn_t *dsn, const char *user_agent)
 {
     if (!location || !path) {
         return NULL;
@@ -319,12 +318,6 @@ prepare_tus_upload_request(const char *location, const sentry_path_t *path,
     h = &req->headers[req->headers_len++];
     h->key = "upload-offset";
     h->value = sentry__string_clone("0");
-
-    if (!sentry__string_empty(attachment_type)) {
-        h = &req->headers[req->headers_len++];
-        h->key = "upload-metadata";
-        h->value = tus_build_upload_metadata(attachment_type);
-    }
 
     return req;
 }
@@ -437,8 +430,8 @@ tus_upload_file(http_transport_state_t *state, const sentry_path_t *cache_path,
         sentry__path_free(att_file);
         return RESULT_ERROR;
     }
-    req = prepare_tus_upload_request(patch_url, att_file, file_size,
-        ref->attachment_type, state->dsn, state->user_agent);
+    req = prepare_tus_upload_request(
+        patch_url, att_file, file_size, state->dsn, state->user_agent);
     sentry_free(patch_url);
     sentry__path_free(att_file);
     if (!req) {
@@ -986,9 +979,9 @@ sentry__prepare_tus_create_request(size_t file_size,
 
 sentry_prepared_http_request_t *
 sentry__prepare_tus_upload_request(const char *location,
-    const sentry_path_t *path, size_t file_size, const char *attachment_type,
-    const sentry_dsn_t *dsn, const char *user_agent)
+    const sentry_path_t *path, size_t file_size, const sentry_dsn_t *dsn,
+    const char *user_agent)
 {
     return prepare_tus_upload_request(
-        location, path, file_size, attachment_type, dsn, user_agent);
+        location, path, file_size, dsn, user_agent);
 }

--- a/src/transports/sentry_http_transport.h
+++ b/src/transports/sentry_http_transport.h
@@ -31,8 +31,7 @@ sentry_prepared_http_request_t *sentry__prepare_tus_create_request(
     const char *user_agent);
 sentry_prepared_http_request_t *sentry__prepare_tus_upload_request(
     const char *location, const sentry_path_t *path, size_t file_size,
-    const char *attachment_type, const sentry_dsn_t *dsn,
-    const char *user_agent);
+    const sentry_dsn_t *dsn, const char *user_agent);
 
 void sentry__prepared_http_request_free(sentry_prepared_http_request_t *req);
 

--- a/tests/unit/test_tus.c
+++ b/tests/unit/test_tus.c
@@ -96,7 +96,7 @@ SENTRY_TEST(tus_request_preparation)
 
     const char *location = "https://sentry.invalid/api/42/upload/abc123/";
     req = sentry__prepare_tus_upload_request(
-        location, test_file_path, 9, NULL, dsn, NULL);
+        location, test_file_path, 9, dsn, NULL);
     TEST_CHECK(!!req);
     TEST_CHECK_STRING_EQUAL(req->method, "PATCH");
     TEST_CHECK_STRING_EQUAL(req->url, location);


### PR DESCRIPTION
The TUS spec only defines Upload-Metadata on the creation request (POST), not on the upload request (PATCH). Remove the duplicate header from the PATCH path and drop the now-unused attachment_type parameter from `prepare_tus_upload_request`.

follow-up of #1795 

#skip-changelog