### PR TITLE
fix(native): refrain from widening `crashed_tid` to `uint64_t` on macOS

### DIFF
--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -2442,7 +2442,12 @@ build_native_event(const sentry_crash_context_t *ctx,
                     thread, "name", sentry_value_new_string(tctx->name));
             }
 
-            bool is_crashed = (tctx->tid == (uint64_t)ctx->crashed_tid);
+            // `crashed_tid` holds the (pid_t)-truncated id of the crashed/hung
+            // thread, while `tctx->tid` is the full 64-bit Mach thread id.
+            // macOS thread ids exceed 32 bits, so widening the truncated
+            // `crashed_tid` back to uint64 sign-extends and never matches —
+            // compare at the same 32-bit width instead.
+            bool is_crashed = ((pid_t)tctx->tid == ctx->crashed_tid);
             sentry_value_set_by_key(
                 thread, "crashed", sentry_value_new_bool(is_crashed));
             sentry_value_set_by_key(


### PR DESCRIPTION
As far as I can tell this came through this being implemented for Linux first where the thread ID genuinely is a `pid_t` (32-bit). Windows has this as a `DWORD` which is 32-bit too. 
Later on macOS got retrofit, and `thread_identifier_info.thread_id` returning a 64-bit caused the squeeze via `(pid_t)target_tid`.
But since the minidump format in the end has it as 32-bit anyway, it doesn't make sense to neither widen `crashed_tid` neither in the context nor in the comparison.

#skip-changelog