### PR TITLE
(test) fix: rename `SIZEOF_LONG` to `SENTRY_SIZEOF_LONG`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,7 +477,7 @@ if(SENTRY_BUILD_SHARED_LIBS)
 else()
 	target_compile_definitions(sentry PUBLIC SENTRY_BUILD_STATIC)
 endif()
-target_compile_definitions(sentry PRIVATE SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
+target_compile_definitions(sentry PRIVATE SENTRY_SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
 
 # AIX needs libm for isnan used in test suite
 if(CMAKE_SYSTEM_NAME STREQUAL "AIX" OR CMAKE_SYSTEM_NAME STREQUAL "OS400")

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -373,7 +373,7 @@ static inline long
 sentry__atomic_fetch_and_add(volatile long *val, long diff)
 {
 #ifdef SENTRY_PLATFORM_WINDOWS
-#    if SIZEOF_LONG == 8
+#    if SENTRY_SIZEOF_LONG == 8
     return InterlockedExchangeAdd64((LONG64 *)val, diff);
 #    else
     return InterlockedExchangeAdd((LONG *)val, diff);
@@ -387,7 +387,7 @@ static inline long
 sentry__atomic_store(volatile long *val, long value)
 {
 #ifdef SENTRY_PLATFORM_WINDOWS
-#    if SIZEOF_LONG == 8
+#    if SENTRY_SIZEOF_LONG == 8
     return InterlockedExchange64((LONG64 *)val, value);
 #    else
     return InterlockedExchange((LONG *)val, value);
@@ -418,7 +418,7 @@ static inline bool
 sentry__atomic_compare_swap(volatile long *val, long expected, long desired)
 {
 #ifdef SENTRY_PLATFORM_WINDOWS
-#    if SIZEOF_LONG == 8
+#    if SENTRY_SIZEOF_LONG == 8
     return InterlockedCompareExchange64((LONG64 *)val, desired, expected)
         == expected;
 #    else

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -107,7 +107,7 @@ if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
 	set_property(TARGET sentry_test_unit PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-target_compile_definitions(sentry PRIVATE SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
+target_compile_definitions(sentry PRIVATE SENTRY_SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
 
 target_compile_definitions(sentry_test_unit PRIVATE SENTRY_UNITTEST)
 


### PR DESCRIPTION
Fixes #1810

#skip-changelog