### PR TITLE
fix(crashpad): resolve correct symbol names in client-side stack traces for multi-module apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 **Fixes**:
 
 - Native/Windows: Resolve correct symbol names for crashes in multi-module apps ([#1811](https://github.com/getsentry/sentry-native/pull/1811))
-- Crashpad: Resolve correct symbol names for crashes in multi-module apps ([#1813](https://github.com/getsentry/sentry-native/pull/1813))
+- Crashpad: Resolve correct symbol names for crashes in multi-module apps ([#1813](https://github.com/getsentry/sentry-native/pull/1813), [crashpad#156](https://github.com/getsentry/crashpad/pull/156))
 
 ## 0.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Native/Windows: Resolve correct symbol names for crashes in multi-module apps ([#1811](https://github.com/getsentry/sentry-native/pull/1811))
+- Crashpad: Resolve correct symbol names for crashes in multi-module apps ([#1813](https://github.com/getsentry/sentry-native/pull/1813))
 
 ## 0.15.1
 


### PR DESCRIPTION
Bump Crashpad to latest with https://github.com/getsentry/crashpad/pull/156 that resolves https://github.com/getsentry/sentry-unreal/issues/1422 for Unreal SDK.

Related items:
- https://github.com/getsentry/sentry-native/pull/1811