### PR TITLE
fix: app hang option name convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Features**:
 
-- Added an in-process app-hang detection. When enabled via `sentry_options_set_enable_app_hang_tracking`, a background thread monitors the application and captures an app-hang event if no heartbeat is received within `app_hang_timeout_ms` (default `5000` ms). Call `sentry_app_hang_heartbeat()` regularly from the thread you want monitored. ([#1806](https://github.com/getsentry/sentry-native/pull/1806))
+- Added an in-process app-hang detection. When enabled via `sentry_options_set_enable_app_hang_tracking`, a background thread monitors the application and captures an app-hang event if no heartbeat is received within `app_hang_timeout` (default `5000` ms). Call `sentry_app_hang_heartbeat()` regularly from the thread you want monitored. ([#1806](https://github.com/getsentry/sentry-native/pull/1806))
 
 ## 0.15.1
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -662,7 +662,7 @@ main(int argc, char **argv)
 
     if (has_arg(argc, argv, "app-hang")) {
         sentry_options_set_enable_app_hang_tracking(options, 1);
-        sentry_options_set_app_hang_timeout_ms(options, 1000);
+        sentry_options_set_app_hang_timeout(options, 1000);
     }
 
     if (has_arg(argc, argv, "stdout")) {

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -2666,16 +2666,16 @@ SENTRY_EXPERIMENTAL_API int sentry_options_get_enable_app_hang_tracking(
     const sentry_options_t *opts);
 
 /**
- * Sets the app-hang detection timeout in milliseconds. Defaults to 5000 ms.
+ * Sets the app-hang detection timeout (in milliseconds). Defaults to 5000 ms.
  * If `enable_app_hang_tracking` is true and no heartbeat is received within
  * this window, an app-hang event is captured.
  *
  * Setting this to 0 while `enable_app_hang_tracking` is true is a
  * configuration error: the watchdog will log a warning and skip detection.
  */
-SENTRY_EXPERIMENTAL_API void sentry_options_set_app_hang_timeout_ms(
-    sentry_options_t *opts, uint64_t millis);
-SENTRY_EXPERIMENTAL_API uint64_t sentry_options_get_app_hang_timeout_ms(
+SENTRY_EXPERIMENTAL_API void sentry_options_set_app_hang_timeout(
+    sentry_options_t *opts, uint64_t app_hang_timeout);
+SENTRY_EXPERIMENTAL_API uint64_t sentry_options_get_app_hang_timeout(
     const sentry_options_t *opts);
 
 /**

--- a/src/sentry_app_hang_monitor.c
+++ b/src/sentry_app_hang_monitor.c
@@ -123,9 +123,9 @@ sentry__app_hang_monitor_start(const sentry_options_t *options)
         return 0;
     }
 
-    g_timeout_ms = options->app_hang_timeout_ms;
+    g_timeout_ms = options->app_hang_timeout;
     if (g_timeout_ms == 0) {
-        SENTRY_WARN("app-hang: `app_hang_timeout_ms` is 0, hang detection is "
+        SENTRY_WARN("app-hang: `app_hang_timeout` is 0, hang detection is "
                     "disabled");
     }
     sentry__atomic_store(&g_stop, 0);

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -114,7 +114,7 @@ sentry_options_new(void)
                                                             // both worlds
     opts->crash_upload_mode = SENTRY_CRASH_UPLOAD_MODE_SYNC;
     opts->enable_app_hang_tracking = false;
-    opts->app_hang_timeout_ms = 5000;
+    opts->app_hang_timeout = 5000;
     opts->http_retry = false;
     opts->send_client_reports = true;
     opts->enable_large_attachments = false;
@@ -979,15 +979,16 @@ sentry_options_get_enable_app_hang_tracking(const sentry_options_t *opts)
 }
 
 void
-sentry_options_set_app_hang_timeout_ms(sentry_options_t *opts, uint64_t millis)
+sentry_options_set_app_hang_timeout(
+    sentry_options_t *opts, uint64_t app_hang_timeout)
 {
-    opts->app_hang_timeout_ms = millis;
+    opts->app_hang_timeout = app_hang_timeout;
 }
 
 uint64_t
-sentry_options_get_app_hang_timeout_ms(const sentry_options_t *opts)
+sentry_options_get_app_hang_timeout(const sentry_options_t *opts)
 {
-    return opts->app_hang_timeout_ms;
+    return opts->app_hang_timeout;
 }
 
 void

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -86,7 +86,7 @@ struct sentry_options_s {
     sentry_before_send_metric_function_t before_send_metric_func;
     void *before_send_metric_data;
     bool enable_app_hang_tracking;
-    uint64_t app_hang_timeout_ms;
+    uint64_t app_hang_timeout;
     bool http_retry;
     bool send_client_reports;
     bool enable_large_attachments;

--- a/tests/unit/test_app_hang.c
+++ b/tests/unit/test_app_hang.c
@@ -109,7 +109,7 @@ SENTRY_TEST(app_hang_monitor_fires)
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_before_send(options, capture_before_send, NULL);
     sentry_options_set_enable_app_hang_tracking(options, 1);
-    sentry_options_set_app_hang_timeout_ms(options, 50);
+    sentry_options_set_app_hang_timeout(options, 50);
     sentry_init(options);
 
     sentry_app_hang_heartbeat();
@@ -173,7 +173,7 @@ SENTRY_TEST(app_hang_end_to_end)
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_before_send(options, real_before_send, NULL);
     sentry_options_set_enable_app_hang_tracking(options, 1);
-    sentry_options_set_app_hang_timeout_ms(options, 50);
+    sentry_options_set_app_hang_timeout(options, 50);
     sentry_init(options);
 
     sentry_threadid_t t;


### PR DESCRIPTION
Aligned name with the rest of the `_timeout` options.

#skip-changelog