### PR TITLE
fix: add `SENTRY_BACKEND` define for native backend

### DIFF
--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -21,6 +21,8 @@
 #    define SENTRY_BACKEND "breakpad"
 #elif defined(SENTRY_BACKEND_INPROC)
 #    define SENTRY_BACKEND "inproc"
+#elif defined(SENTRY_BACKEND_NATIVE)
+#    define SENTRY_BACKEND "native"
 #endif
 
 static bool g_scope_initialized = false;

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -912,7 +912,7 @@ def test_native_external_crash_reporter(cmake, httpserver):
     # Verify it's a minidump crash report and user feedback
     envelope = Envelope.deserialize(crash)
     assert envelope.headers["cache_dir"] == str(cache_dir)
-    assert_meta(envelope)
+    assert_meta(envelope, integration="native")
     assert_breadcrumb(envelope)
 
     envelope = Envelope.deserialize(feedback)


### PR DESCRIPTION
We already defined SENTRY_BACKEND_NATIVE in our [CMakeLists.txt](https://github.com/getsentry/sentry-native/blob/master/CMakeLists.txt#L269), but weren't propagating it into the global scope through [get_client_sdk](https://github.com/getsentry/sentry-native/blob/0.15.1/src/sentry_scope.c#L59-L63) yet.

#skip-changelog