### PR TITLE
fix(test): skip app hang tests if no thread stackwalk is available

### DIFF
--- a/tests/unit/test_app_hang.c
+++ b/tests/unit/test_app_hang.c
@@ -112,7 +112,7 @@ SENTRY_TEST(app_hang_monitor_fires)
     sentry__app_hang_latch_reset();
     sentry__app_hang_monitor_set_stackwalk_fn(fake_stackwalk);
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_before_send(options, capture_before_send, NULL);
     sentry_options_set_enable_app_hang_tracking(options, 1);
@@ -179,7 +179,7 @@ SENTRY_TEST(app_hang_end_to_end)
     sentry__app_hang_latch_reset();
     sentry__app_hang_monitor_set_stackwalk_fn(NULL); // use the REAL stackwalker
 
-    sentry_options_t *options = sentry_options_new();
+    SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_before_send(options, real_before_send, NULL);
     sentry_options_set_enable_app_hang_tracking(options, 1);

--- a/tests/unit/test_app_hang.c
+++ b/tests/unit/test_app_hang.c
@@ -2,6 +2,7 @@
 #include "sentry_app_hang_monitor.h"
 #include "sentry_sync.h"
 #include "sentry_testsupport.h"
+#include "sentry_thread_stackwalk.h"
 
 SENTRY_TEST(app_hang_should_capture)
 {
@@ -19,6 +20,9 @@ SENTRY_TEST(app_hang_should_capture)
 
 SENTRY_TEST(app_hang_latch)
 {
+#if !SENTRY_HAS_THREAD_STACKWALK
+    SKIP_TEST();
+#endif
     sentry__app_hang_latch_reset();
     sentry__app_hang_set_active(true);
     sentry_app_hang_latch_t l = sentry__app_hang_current_latch();
@@ -100,6 +104,9 @@ capture_before_send(sentry_value_t event, void *hint, void *data)
 
 SENTRY_TEST(app_hang_monitor_fires)
 {
+#if !SENTRY_HAS_THREAD_STACKWALK
+    SKIP_TEST();
+#endif
     g_app_hang_seen = 0;
     g_app_hang_type[0] = '\0';
     sentry__app_hang_latch_reset();
@@ -163,6 +170,9 @@ spinner(void *arg)
 
 SENTRY_TEST(app_hang_end_to_end)
 {
+#if !SENTRY_HAS_THREAD_STACKWALK
+    SKIP_TEST();
+#endif
     g_real_seen = 0;
     g_real_frames = 0;
     sentry__atomic_store(&g_keep_spinning, 1);


### PR DESCRIPTION
follow-up of #1806 (caught on main by console compat running the tests)

- skips tests if `SENTRY_HAS_THREAD_STACKWALK` is false (e.g., on Switch/PlayStation)
- replaces `sentry_options_new()` with `SENTRY_TEST_OPTIONS_NEW`

---

running `FULL_TEST` workflows in 
https://github.com/getsentry/sentry-xbox/actions/runs/28021523022
https://github.com/getsentry/sentry-switch/actions/runs/28017154955

#skip-changelog
