### PR TITLE
fix: clamp app hang timeout

### DIFF
--- a/include/sentry.h
+++ b/include/sentry.h
@@ -2668,10 +2668,12 @@ SENTRY_EXPERIMENTAL_API int sentry_options_get_enable_app_hang_tracking(
 /**
  * Sets the app-hang detection timeout (in milliseconds). Defaults to 5000 ms.
  * If `enable_app_hang_tracking` is true and no heartbeat is received within
- * this window, an app-hang event is captured.
+ * this window, an app-hang event is captured. Detection is enabled/disabled via
+ * `enable_app_hang_tracking`, not via this timeout.
  *
- * Setting this to 0 while `enable_app_hang_tracking` is true is a
- * configuration error: the watchdog will log a warning and skip detection.
+ * The watchdog samples the heartbeat on a fixed internal interval, so timeouts
+ * shorter than 1000 ms cannot be resolved reliably. Values below that minimum
+ * are clamped up to it (with a warning).
  */
 SENTRY_EXPERIMENTAL_API void sentry_options_set_app_hang_timeout(
     sentry_options_t *opts, uint64_t app_hang_timeout);

--- a/src/sentry_app_hang_monitor.c
+++ b/src/sentry_app_hang_monitor.c
@@ -59,8 +59,6 @@ static sentry_mutex_t g_wait_mutex = SENTRY__MUTEX_INIT;
 static sentry_cond_t g_wait_cond;
 static uint64_t g_timeout_ms = 0;
 
-#    define SENTRY_APP_HANG_POLL_MS 500
-
 static size_t
 stackwalk_thread(uint64_t tid, void **ips, size_t max)
 {
@@ -127,10 +125,6 @@ sentry__app_hang_monitor_start(const sentry_options_t *options)
     }
 
     g_timeout_ms = options->app_hang_timeout;
-    if (g_timeout_ms == 0) {
-        SENTRY_WARN("app-hang: `app_hang_timeout` is 0, hang detection is "
-                    "disabled");
-    }
     sentry__cond_init(&g_wait_cond);
     // Arm before spawning: the worker uses is_active() as its run condition, so
     // it must already be true when the new thread first evaluates the loop.

--- a/src/sentry_app_hang_monitor.h
+++ b/src/sentry_app_hang_monitor.h
@@ -8,6 +8,17 @@
 
 struct sentry_options_s;
 
+// Interval at which the watchdog samples the heartbeat.
+#define SENTRY_APP_HANG_POLL_MS 500
+
+// Smallest timeout the watchdog can resolve meaningfully. A genuine hang fires
+// somewhere in [timeout, timeout + POLL_MS) depending on the phase between the
+// freeze and the next sample, so we require the timeout to be at least twice
+// the poll interval to keep that sampling jitter a minority of the configured
+// timeout. `sentry_options_set_app_hang_timeout` clamps non-zero values up to
+// this minimum.
+#define SENTRY_APP_HANG_MIN_TIMEOUT_MS (2 * SENTRY_APP_HANG_POLL_MS)
+
 int sentry__app_hang_monitor_start(const struct sentry_options_s *options);
 void sentry__app_hang_monitor_stop(void);
 

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -1,5 +1,6 @@
 #include "sentry_options.h"
 #include "sentry_alloc.h"
+#include "sentry_app_hang_monitor.h"
 #include "sentry_attachment.h"
 #include "sentry_backend.h"
 #include "sentry_database.h"
@@ -982,6 +983,14 @@ void
 sentry_options_set_app_hang_timeout(
     sentry_options_t *opts, uint64_t app_hang_timeout)
 {
+    // Clamp up to the smallest timeout the watchdog can resolve (see
+    // SENTRY_APP_HANG_MIN_TIMEOUT_MS).
+    if (app_hang_timeout < SENTRY_APP_HANG_MIN_TIMEOUT_MS) {
+        SENTRY_WARNF("app-hang: `app_hang_timeout` of %" PRIu64
+                     "ms is below the minimum of %dms, clamping",
+            app_hang_timeout, SENTRY_APP_HANG_MIN_TIMEOUT_MS);
+        app_hang_timeout = SENTRY_APP_HANG_MIN_TIMEOUT_MS;
+    }
     opts->app_hang_timeout = app_hang_timeout;
 }
 


### PR DESCRIPTION
To prevent a possible footgun of setting the timeout smaller than the SDK can resolve.

#skip-changelog