### PR TITLE
test(ndk): cover Android debug image loading with instrumentation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,7 @@ jobs:
             adb shell cmd alarm set-time $(date +%s000) || adb shell su root date $(date -u +%m%d%H%M%Y.%S)
             pip install --upgrade --requirement tests/requirements.txt
             pytest --capture=no --verbose tests
+            (cd ndk && ./gradlew :sentry-native-ndk:connectedDebugAndroidTest --stacktrace)
 
       - name: Test
         if: ${{ !env['ANDROID_API'] }}

--- a/ndk/lib/src/androidTest/java/io/sentry/ndk/NdkTestHelper.java
+++ b/ndk/lib/src/androidTest/java/io/sentry/ndk/NdkTestHelper.java
@@ -8,4 +8,6 @@ public class NdkTestHelper {
   public static native void message();
 
   public static native void transaction();
+
+  public static native long sentryGetModulesListAddress();
 }

--- a/ndk/lib/src/androidTest/java/io/sentry/ndk/SentryNdkTest.java
+++ b/ndk/lib/src/androidTest/java/io/sentry/ndk/SentryNdkTest.java
@@ -6,10 +6,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
+import java.io.InputStreamReader;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -29,25 +31,66 @@ public class SentryNdkTest {
     }
   }
 
+  private static int compareUnsignedLong(final long left, final long right) {
+    final long biasedLeft = left ^ Long.MIN_VALUE;
+    final long biasedRight = right ^ Long.MIN_VALUE;
+    if (biasedLeft == biasedRight) {
+      return 0;
+    }
+    return biasedLeft < biasedRight ? -1 : 1;
+  }
+
+  private static long parseHexLong(final String hex) {
+    long result = 0;
+    for (int i = 0; i < hex.length(); i++) {
+      final int digit = Character.digit(hex.charAt(i), 16);
+      if (digit < 0) {
+        throw new NumberFormatException(hex);
+      }
+      result = (result << 4) | digit;
+    }
+    return result;
+  }
+
   private static boolean containsAddress(final long address, final long start, final long end) {
-    return Long.compareUnsigned(address, start) >= 0
-        && Long.compareUnsigned(address, end) < 0;
+    return compareUnsignedLong(address, start) >= 0 && compareUnsignedLong(address, end) < 0;
+  }
+
+  private static String readFile(final File file) throws IOException {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final byte[] buf = new byte[4096];
+    final FileInputStream in = new FileInputStream(file);
+    try {
+      int read;
+      while ((read = in.read(buf)) != -1) {
+        out.write(buf, 0, read);
+      }
+    } finally {
+      in.close();
+    }
+    return out.toString("UTF-8");
   }
 
   private static ProcMapEntry findProcMapEntryContaining(final long address) throws IOException {
-    for (String line : Files.readAllLines(new File("/proc/self/maps").toPath())) {
-      final int dash = line.indexOf('-');
-      final int space = line.indexOf(' ', dash + 1);
-      if (dash < 1 || space < 0) {
-        continue;
-      }
+    final BufferedReader reader =
+        new BufferedReader(new InputStreamReader(new FileInputStream("/proc/self/maps"), "UTF-8"));
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        final int dash = line.indexOf('-');
+        final int space = line.indexOf(' ', dash + 1);
+        if (dash < 1 || space < 0) {
+          continue;
+        }
 
-      final long start = Long.parseUnsignedLong(line.substring(0, dash), 16);
-      final long end =
-          Long.parseUnsignedLong(line.substring(dash + 1, space), 16);
-      if (containsAddress(address, start, end)) {
-        return new ProcMapEntry(start, end, line);
+        final long start = parseHexLong(line.substring(0, dash));
+        final long end = parseHexLong(line.substring(dash + 1, space));
+        if (containsAddress(address, start, end)) {
+          return new ProcMapEntry(start, end, line);
+        }
       }
+    } finally {
+      reader.close();
     }
     return null;
   }
@@ -158,7 +201,7 @@ public class SentryNdkTest {
     assertNotNull(files);
     assertEquals(1, files.length);
     File firstFile = files[0];
-    String content = new String(Files.readAllBytes(firstFile.toPath()), StandardCharsets.UTF_8);
+    String content = readFile(firstFile);
     assertTrue(content.contains("It works!")); // expected message content from
     // Java_io_sentry_ndk_NdkTestHelper_message(..) in ndk-test.cpp
 
@@ -196,7 +239,7 @@ public class SentryNdkTest {
       if (imageAddr == null || imageSize == null || imageSize <= 0) {
         continue;
       }
-      final long start = Long.parseUnsignedLong(imageAddr.replace("0x", ""), 16);
+      final long start = parseHexLong(imageAddr.replace("0x", ""));
       final long end = start + imageSize;
       if (containsAddress(sentryAddress, start, end)) {
         sentryImage = image;
@@ -213,8 +256,8 @@ public class SentryNdkTest {
     assertNotNull(sentryImage.getCodeFile());
     assertNotNull(sentryImage.getDebugId());
     assertNotNull(sentryImage.getCodeId());
-    assertTrue(Long.compareUnsigned(sentryImageStart, sentryProcMapEntry.start) <= 0);
-    assertTrue(Long.compareUnsigned(sentryImageEnd, sentryProcMapEntry.end) >= 0);
+    assertTrue(compareUnsignedLong(sentryImageStart, sentryProcMapEntry.start) <= 0);
+    assertTrue(compareUnsignedLong(sentryImageEnd, sentryProcMapEntry.end) >= 0);
   }
 
   @Test
@@ -247,7 +290,7 @@ public class SentryNdkTest {
     assertNotNull(files);
     assertEquals(1, files.length);
     File firstFile = files[0];
-    String content = new String(Files.readAllBytes(firstFile.toPath()), StandardCharsets.UTF_8);
+    String content = readFile(firstFile);
     assertTrue(content.contains("\"type\":\"transaction\""));
   }
 

--- a/ndk/lib/src/androidTest/java/io/sentry/ndk/SentryNdkTest.java
+++ b/ndk/lib/src/androidTest/java/io/sentry/ndk/SentryNdkTest.java
@@ -17,6 +17,41 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class SentryNdkTest {
 
+  private static final class ProcMapEntry {
+    private final long start;
+    private final long end;
+    private final String line;
+
+    private ProcMapEntry(final long start, final long end, final String line) {
+      this.start = start;
+      this.end = end;
+      this.line = line;
+    }
+  }
+
+  private static boolean containsAddress(final long address, final long start, final long end) {
+    return Long.compareUnsigned(address, start) >= 0
+        && Long.compareUnsigned(address, end) < 0;
+  }
+
+  private static ProcMapEntry findProcMapEntryContaining(final long address) throws IOException {
+    for (String line : Files.readAllLines(new File("/proc/self/maps").toPath())) {
+      final int dash = line.indexOf('-');
+      final int space = line.indexOf(' ', dash + 1);
+      if (dash < 1 || space < 0) {
+        continue;
+      }
+
+      final long start = Long.parseUnsignedLong(line.substring(0, dash), 16);
+      final long end =
+          Long.parseUnsignedLong(line.substring(dash + 1, space), 16);
+      if (containsAddress(address, start, end)) {
+        return new ProcMapEntry(start, end, line);
+      }
+    }
+    return null;
+  }
+
   @Test
   public void initDoesNotFail() throws IOException {
     final TemporaryFolder temporaryFolder = TemporaryFolder.builder().build();
@@ -130,6 +165,56 @@ public class SentryNdkTest {
     // and the breadcrumb data is well formed.
     assertTrue(content.contains("\"some_key\":\"some_value\""));
     assertFalse(content.contains("\"data\":\"{"));
+
+    // and native events carry module debug images.
+    assertTrue(content.contains("\"debug_meta\""));
+    assertTrue(content.contains("\"images\":[{"));
+  }
+
+  @Test
+  public void nativeModuleListLoadsDebugImages() throws IOException {
+    SentryNdk.loadNativeLibraries();
+
+    final long sentryAddress = NdkTestHelper.sentryGetModulesListAddress();
+    final ProcMapEntry sentryProcMapEntry = findProcMapEntryContaining(sentryAddress);
+    assertNotNull("/proc/self/maps should contain the loaded libsentry symbol", sentryProcMapEntry);
+
+    final NativeModuleListLoader loader = new NativeModuleListLoader();
+    loader.clearModuleList();
+
+    final DebugImage[] images = loader.loadModuleList();
+
+    assertNotNull(images);
+    assertTrue(images.length > 0);
+
+    DebugImage sentryImage = null;
+    long sentryImageStart = 0;
+    long sentryImageEnd = 0;
+    for (DebugImage image : images) {
+      final String imageAddr = image.getImageAddr();
+      final Long imageSize = image.getImageSize();
+      if (imageAddr == null || imageSize == null || imageSize <= 0) {
+        continue;
+      }
+      final long start = Long.parseUnsignedLong(imageAddr.replace("0x", ""), 16);
+      final long end = start + imageSize;
+      if (containsAddress(sentryAddress, start, end)) {
+        sentryImage = image;
+        sentryImageStart = start;
+        sentryImageEnd = end;
+        break;
+      }
+    }
+
+    assertNotNull(
+        "module list should contain the loaded libsentry image from " + sentryProcMapEntry.line,
+        sentryImage);
+    assertEquals("elf", sentryImage.getType());
+    assertNotNull(sentryImage.getCodeFile());
+    assertNotNull(sentryImage.getDebugId());
+    assertNotNull(sentryImage.getCodeId());
+    assertTrue(Long.compareUnsigned(sentryImageStart, sentryProcMapEntry.start) <= 0);
+    assertTrue(Long.compareUnsigned(sentryImageEnd, sentryProcMapEntry.end) >= 0);
   }
 
   @Test

--- a/ndk/lib/src/androidTest/jni/ndk-test.cpp
+++ b/ndk/lib/src/androidTest/jni/ndk-test.cpp
@@ -1,6 +1,7 @@
 #include <jni.h>
 #include <android/log.h>
 #include <sentry.h>
+#include <stdint.h>
 
 #define TAG "ndk-test"
 
@@ -14,6 +15,15 @@ JNIEXPORT void JNICALL Java_io_sentry_ndk_NdkTestHelper_message(JNIEnv *env, jcl
             /* message */ "It works!"
     );
     sentry_capture_event(event);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_sentry_ndk_NdkTestHelper_sentryGetModulesListAddress(
+        JNIEnv *env, jclass cls) {
+    (void)env;
+    (void)cls;
+    return static_cast<jlong>(
+            reinterpret_cast<uintptr_t>(&sentry_get_modules_list));
 }
 
 JNIEXPORT void JNICALL Java_io_sentry_ndk_NdkTestHelper_transaction(JNIEnv *env, jclass cls) {

--- a/ndk/lib/src/main/java/io/sentry/ndk/SentryNdk.java
+++ b/ndk/lib/src/main/java/io/sentry/ndk/SentryNdk.java
@@ -23,17 +23,15 @@ public final class SentryNdk {
   private static native void shutdown();
 
   /**
-   * Preloads sentry-native into the process signal chain before full
-   * initialization.
+   * Preloads sentry-native into the process signal chain before full initialization.
    *
-   * <p>Intended for downstream SDK/runtime integrations on Android. This does
-   * not initialize sentry-native, configure a database path, or start the
-   * inproc handler thread; it only establishes signal-handler ordering ahead of
-   * the managed runtime.
+   * <p>Intended for downstream SDK/runtime integrations on Android. This does not initialize
+   * sentry-native, configure a database path, or start the inproc handler thread; it only
+   * establishes signal-handler ordering ahead of the managed runtime.
    *
-   * <p>This is intended to be used by downstream integrations that gate the
-   * preload flow to supported runtimes and then call {@link #init(NdkOptions)}
-   * with the normal DEFAULT handler strategy.
+   * <p>This is intended to be used by downstream integrations that gate the preload flow to
+   * supported runtimes and then call {@link #init(NdkOptions)} with the normal DEFAULT handler
+   * strategy.
    */
   public static void preload() {
     loadNativeLibraries();

--- a/ndk/lib/src/main/java/io/sentry/ndk/SentryNdkPreloadProvider.java
+++ b/ndk/lib/src/main/java/io/sentry/ndk/SentryNdkPreloadProvider.java
@@ -14,18 +14,17 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Preloads the NDK integration before the .NET runtime provider on Android.
  *
- * <p>This is intended for downstream SDK integrations that run with CoreCLR on
- * Android. By installing sentry-native before the managed runtime registers
- * its own signal handlers, native crash signals can chain from the runtime
- * back to the Native SDK, while runtime-generated fault signals can still be
- * consumed by the runtime for managed exception handling.
+ * <p>This is intended for downstream SDK integrations that run with CoreCLR on Android. By
+ * installing sentry-native before the managed runtime registers its own signal handlers, native
+ * crash signals can chain from the runtime back to the Native SDK, while runtime-generated fault
+ * signals can still be consumed by the runtime for managed exception handling.
  *
- * <p>This is the preload alternative to CHAIN_AT_START. Mono on Android
- * continues to use CHAIN_AT_START.
+ * <p>This is the preload alternative to CHAIN_AT_START. Mono on Android continues to use
+ * CHAIN_AT_START.
  *
- * <p>Enabled by setting {@code io.sentry.ndk.preload} to {@code true} in the
- * app manifest metadata. The high {@code initOrder} ensures this runs before
- * the runtime provider emitted by dotnet/android.
+ * <p>Enabled by setting {@code io.sentry.ndk.preload} to {@code true} in the app manifest metadata.
+ * The high {@code initOrder} ensures this runs before the runtime provider emitted by
+ * dotnet/android.
  */
 public final class SentryNdkPreloadProvider extends ContentProvider {
 
@@ -73,7 +72,8 @@ public final class SentryNdkPreloadProvider extends ContentProvider {
   }
 
   @Override
-  public int delete(@NotNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+  public int delete(
+      @NotNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
     return 0;
   }
 


### PR DESCRIPTION
Recently, @buenaflor reminded (indirectly) on Slack, that it would be great to have at least basic smoky instrumentation tests for `sentry-native-ndk`.

While we already test most of these exposed features with unit and integration tests, having Android instrumentation tests run not only on the emulator but also from inside ART, stressing the JNI layer and any other translation mappings that our other tests do not cover.

This PR in particular adds Android NDK instrumentation coverage for debug image loading, testing that:

- native events written through the NDK transport contain `debug_meta.images`
- `NativeModuleListLoader` returns debug images on-device
- the returned image list covers the actual loaded `libsentry` address, cross-checked against `/proc/self/maps`

This gives us a regression guard against changes to the Linux/Android module finder, the JNI module-list bridge, Android native packaging, and scope/envelope debug-meta wiring.

The instrumentation test is also wired into the existing Android emulator CI step via `connectedDebugAndroidTest`, so it can be conveniently extended if needed.

#skip-changelog