### PR TITLE
feat(consoles): allow Xbox to override sentry_init for custom device context

### DIFF
--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -100,7 +100,8 @@ generate_propagation_context(sentry_value_t propagation_context)
         sentry_value_get_by_key(propagation_context, "trace"));
 }
 
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)                 \
+    || defined(SENTRY_PLATFORM_XBOX)
 int
 sentry__native_init(sentry_options_t *options)
 #else

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -149,7 +149,8 @@ bool sentry__should_send_transaction(
     sentry_value_t tx_ctx, sentry_sampling_context_t *sampling_ctx);
 #endif
 
-#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)
+#if defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)                 \
+    || defined(SENTRY_PLATFORM_XBOX)
 int sentry__native_init(sentry_options_t *options);
 #endif
 


### PR DESCRIPTION
Add SENTRY_PLATFORM_XBOX to the preprocessor guard that exposes sentry__native_init, enabling the Xbox console SDK to provide its own sentry_init with device model detection.

Related to https://github.com/getsentry/sentry-xbox/issues/149 and https://github.com/getsentry/sentry-xbox/issues/151

#skip-changelog