### PR TITLE
fix: message now as structured object when reporting app hang

### DIFF
--- a/src/sentry_app_hang_monitor.c
+++ b/src/sentry_app_hang_monitor.c
@@ -20,8 +20,11 @@ sentry__app_hang_make_event(void **ips, size_t frame_count, uint64_t freeze_ms)
 
     sentry_value_t event = sentry_value_new_event();
     sentry_value_set_by_key(event, "level", sentry_value_new_string("error"));
+
+    sentry_value_t message = sentry_value_new_object();
     sentry_value_set_by_key(
-        event, "message", sentry_value_new_string(value_buf));
+        message, "formatted", sentry_value_new_string(value_buf));
+    sentry_value_set_by_key(event, "message", message);
 
     sentry_value_t exc = sentry_value_new_exception("AppHang", value_buf);
 

--- a/tests/unit/test_app_hang.c
+++ b/tests/unit/test_app_hang.c
@@ -48,12 +48,10 @@ SENTRY_TEST(app_hang_make_event)
     void *ips[2] = { (void *)0x1000, (void *)0x2000 };
     sentry_value_t ev = sentry__app_hang_make_event(ips, 2, 5000);
 
-    // SDKs like sentry-java's serializer expect message to be an object.
     sentry_value_t message = sentry_value_get_by_key(ev, "message");
     TEST_CHECK(sentry_value_get_type(message) == SENTRY_VALUE_TYPE_OBJECT);
     TEST_CHECK_STRING_EQUAL(
-        sentry_value_as_string(
-            sentry_value_get_by_key(message, "formatted")),
+        sentry_value_as_string(sentry_value_get_by_key(message, "formatted")),
         "App hung for at least 5000 ms.");
 
     sentry_value_t exc = sentry_value_get_by_index(

--- a/tests/unit/test_app_hang.c
+++ b/tests/unit/test_app_hang.c
@@ -48,6 +48,14 @@ SENTRY_TEST(app_hang_make_event)
     void *ips[2] = { (void *)0x1000, (void *)0x2000 };
     sentry_value_t ev = sentry__app_hang_make_event(ips, 2, 5000);
 
+    // SDKs like sentry-java's serializer expect message to be an object.
+    sentry_value_t message = sentry_value_get_by_key(ev, "message");
+    TEST_CHECK(sentry_value_get_type(message) == SENTRY_VALUE_TYPE_OBJECT);
+    TEST_CHECK_STRING_EQUAL(
+        sentry_value_as_string(
+            sentry_value_get_by_key(message, "formatted")),
+        "App hung for at least 5000 ms.");
+
     sentry_value_t exc = sentry_value_get_by_index(
         sentry_value_get_by_key(
             sentry_value_get_by_key(ev, "exception"), "values"),


### PR DESCRIPTION
App-hang event message is now sent as a structured object `({"formatted": ...})` instead of a bare string.
I ran into this when I have `sentry-java` try to deserialize events.

[Sample event from macOS](https://sentry-sdks.sentry.io/issues/7555612221/?project=4511473240899584&query=is:unresolved) to confirm the structured object is not an regression in disguise.

#skip-changelog