### PR TITLE
fix(native): ensure event ID for fastfail crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Android: Expose app-hang detection through the NDK bindings via `NdkOptions.setEnableAppHangTracking()` and `NdkOptions.setAppHangTimeoutMillis()`. ([#1823](https://github.com/getsentry/sentry-native/pull/1823))
 
+**Fixes**:
+
+- Native/Windows: ensure valid event IDs for fast-fail crash envelopes to fix launching of the external crash reporter for fast-fail crashes. ([#1832](https://github.com/getsentry/sentry-native/pull/1832))
+
 ## 0.15.2
 
 **Fixes**:

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -2373,6 +2373,8 @@ build_native_event(const sentry_crash_context_t *ctx,
 
     if (sentry_value_is_null(event)) {
         event = sentry_value_new_event();
+    } else {
+        sentry__ensure_event_id(event, NULL);
     }
 
     apply_breadcrumbs_from_ring_files(event, run_folder, ctx);

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -447,8 +447,10 @@ def assert_inproc_crash(envelope):
 
 
 def assert_native_crash(envelope, exception_code=None):
+    assert envelope.headers["event_id"]
     event = envelope.get_event()
     assert event is not None
+    assert event["event_id"]
     assert_matches(event, {"level": "fatal"})
 
     exc = event["exception"]["values"][0]

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -84,7 +84,7 @@ def test_native_capture_crash(cmake, httpserver):
 
     assert len(httpserver.log) >= 1
     envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
-    assert_native_crash(envelope, exception_code=0xc0000005) # EXCEPTION_ACCESS_VIOLATION
+    assert_native_crash(envelope)
 
 
 @pytest.mark.skipif(

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -82,6 +82,10 @@ def test_native_capture_crash(cmake, httpserver):
         )
     assert waiting.result
 
+    assert len(httpserver.log) >= 1
+    envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
+    assert_native_crash(envelope, exception_code=0xc0000005) # EXCEPTION_ACCESS_VIOLATION
+
 
 @pytest.mark.skipif(
     sys.platform != "win32" or bool(os.environ.get("TEST_MINGW")),


### PR DESCRIPTION
This PR ensures that fast-fail crash envelopes have valid event IDs, which is required for resolving the correct envelope path when launching the external crash reporter.

For normal SEH crashes, `native_backend_except` is called, and it populates the event with a valid event ID by calling `sentry_value_new_event`. For fast-fail crashes captured via WER, however, the app callback cannot be called, and `__sentry-event` was therefore left without a valid ID. Consequently, the envelope's filename couldn't be correctly resolved when launching the external crash reporter for fast-fail crashes.

| Before | After |
|---|---|
| <img width="1332" height="891" alt="image" src="https://github.com/user-attachments/assets/8dd7363e-9d00-4508-8abf-5256fb74f1ad" /> | <img width="1332" height="891" alt="image" src="https://github.com/user-attachments/assets/162abe05-a93e-4af7-beac-d758351601ac" /> |