### PR TITLE
test: update benchmarks

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -64,5 +64,5 @@ def test_benchmark_scope(test_name, backend, cmake, httpserver, gbenchmark):
         cmake,
         httpserver,
         gbenchmark,
-        f"Scope ({test_name})",
+        f"Scope {test_name} ({backend})",
     )

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -6,7 +6,7 @@ import pytest
 from . import make_dsn, run
 
 
-def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label):
+def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label, runs=1):
     tmp_path = cmake(
         ["sentry_benchmark"],
         {
@@ -19,7 +19,7 @@ def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label):
     env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
     benchmark_out = tmp_path / "benchmark.json"
 
-    for i in range(6):
+    for i in range(runs):
         # make sure we are isolated from previous runs
         shutil.rmtree(tmp_path / ".sentry-native", ignore_errors=True)
 
@@ -30,19 +30,19 @@ def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label):
             env=env,
         )
 
-        # ignore warmup run
-        if i > 0:
+        # ignore warmup run for init/startup benchmarks
+        if runs == 1 or i > 0:
             gbenchmark(benchmark_out, label)
 
 
-@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad"])
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
 def test_benchmark_init(backend, cmake, httpserver, gbenchmark):
     run_benchmark(
-        "init", backend, cmake, httpserver, gbenchmark, f"SDK init ({backend})"
+        "init", backend, cmake, httpserver, gbenchmark, f"SDK init ({backend})", 6
     )
 
 
-@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad"])
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
 def test_benchmark_backend(backend, cmake, httpserver, gbenchmark):
     run_benchmark(
         "backend",
@@ -51,4 +51,18 @@ def test_benchmark_backend(backend, cmake, httpserver, gbenchmark):
         httpserver,
         gbenchmark,
         f"Backend startup ({backend})",
+        6,
+    )
+
+
+@pytest.mark.parametrize("test_name", ["set_tag", "add_breadcrumb"])
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
+def test_benchmark_scope(test_name, backend, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        f"benchmark_scope_{test_name}",
+        backend,
+        cmake,
+        httpserver,
+        gbenchmark,
+        f"Scope ({test_name})",
     )

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(sentry_benchmark
 	${SENTRY_SOURCES}
 	benchmark_init.cpp
 	benchmark_backend.cpp
+	benchmark_scope.cpp
 )
 
 if(SENTRY_BACKEND_CRASHPAD)

--- a/tests/benchmark/benchmark_scope.cpp
+++ b/tests/benchmark/benchmark_scope.cpp
@@ -41,7 +41,9 @@ benchmark_scope_add_breadcrumb(benchmark::State &state)
 
     int i = 0;
     for (auto _ : state) {
-        sentry_add_breadcrumb(sentry_value_new_breadcrumb(NULL, "message"));
+        char msg[32];
+        snprintf(msg, sizeof(msg), "message%d", i);
+        sentry_add_breadcrumb(sentry_value_new_breadcrumb(NULL, msg));
         i++;
     }
 

--- a/tests/benchmark/benchmark_scope.cpp
+++ b/tests/benchmark/benchmark_scope.cpp
@@ -1,0 +1,53 @@
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#include "sentry_core.h"
+#include "sentry_options.h"
+#include "sentry_scope.h"
+}
+
+static void
+benchmark_scope_set_tag(benchmark::State &state)
+{
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // flush both __sentry-event and the external crash report
+    sentry_options_set_external_crash_reporter_path(options, ".");
+    sentry_options_set_debug(options, true);
+    sentry_init(options);
+
+    int i = 0;
+    for (auto _ : state) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "tag%d", i);
+        snprintf(val, sizeof(val), "value%d", i);
+        sentry_set_tag(key, val);
+        i++;
+    }
+
+    sentry_close();
+}
+
+BENCHMARK(benchmark_scope_set_tag)
+    ->Iterations(1000)
+    ->Unit(benchmark::kMillisecond);
+
+static void
+benchmark_scope_add_breadcrumb(benchmark::State &state)
+{
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    sentry_init(options);
+
+    int i = 0;
+    for (auto _ : state) {
+        sentry_add_breadcrumb(sentry_value_new_breadcrumb(NULL, "message"));
+        i++;
+    }
+
+    sentry_close();
+}
+
+BENCHMARK(benchmark_scope_add_breadcrumb)
+    ->Iterations(1000)
+    ->Unit(benchmark::kMillisecond);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,12 @@ def pytest_configure(config):
 def gbenchmark():
     def _load(json_path, label, test_name=None):
         if test_name is None:
-            test_name = os.environ.get("PYTEST_CURRENT_TEST").split(" ")[0]
+            test_name = (
+                os.environ.get("PYTEST_CURRENT_TEST")
+                .split(" ")[0]
+                .replace("[", "_")
+                .replace("]", "")
+            )
 
         with open(json_path, "r") as f:
             data = json.load(f)
@@ -168,7 +173,10 @@ def _get_benchmark(name, separator):
         f"Min {min(real_time):.3f}{unit}",
         f"Max {max(real_time):.3f}{unit}",
         f"Mean {statistics.mean(real_time):.3f}{unit}",
-        f"StdDev {statistics.stdev(real_time):.3f}{unit}",
+    ]
+    if len(real_time) > 1:
+        extra += [f"StdDev {statistics.stdev(real_time):.3f}{unit}"]
+    extra += [
         f"Median {statistics.median(real_time):.3f}{unit}",
         f"CPU {statistics.mean(cpu_time):.3f}{unit}" if sys.platform != "win32" else "",
     ]
@@ -183,7 +191,8 @@ def _get_benchmark(name, separator):
 
 def pytest_report_teststatus(report, config):
     if report.when == "call" and report.passed:
-        benchmark = _get_benchmark(report.nodeid, ", ")
+        test_name = report.nodeid.replace("[", "_").replace("]", "")
+        benchmark = _get_benchmark(test_name, ", ")
         if benchmark:
             return (
                 "passed",


### PR DESCRIPTION
1. Add `native` to the [existing benchmarks](https://getsentry.github.io/sentry-native/):
   - backend startup
   - SDK init
2. Add new benchmarks parameterized for all backends:
   - scope set tag
   - scope add breadcrumb

See also:
- #1395
- #1834