### PR TITLE
test(benchmark): add missing native deps

### DIFF
--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -29,6 +29,13 @@ if(SENTRY_BACKEND_CRASHPAD)
 	endif()
 endif()
 
+if(SENTRY_BACKEND_NATIVE)
+	add_dependencies(sentry_benchmark sentry-crash)
+	if(WIN32)
+		add_dependencies(sentry_benchmark sentry-wer)
+	endif()
+endif()
+
 target_link_libraries(sentry_benchmark PRIVATE
 	${SENTRY_LINK_LIBRARIES}
 	${SENTRY_INTERFACE_LINK_LIBRARIES}


### PR DESCRIPTION
Add missing `sentry-xxx` dependencies for native SDK init & backend startup benchmarks. This should make the results more reasonable instead of hitting 10s timeouts...

Before
```
tests/benchmark.py::test_benchmark_init[native] PASSED
Min 10018.071ms, Max 10018.483ms, Mean 10018.233ms, StdDev 0.152ms, Median 10018.202ms, CPU 8.161ms [ 25%]
...
tests/benchmark.py::test_benchmark_backend[native] PASSED
Min 10011.066ms, Max 10017.057ms, Mean 10015.739ms, StdDev 2.618ms, Median 10016.892ms, CPU 6.819ms [ 50%]
```

After
```
tests/benchmark.py::test_benchmark_init[native] PASSED
Min 12.395ms, Max 12.826ms, Mean 12.609ms, StdDev 0.159ms, Median 12.625ms, CPU 8.019ms [ 25%]
...
tests/benchmark.py::test_benchmark_backend[native] PASSED
Min 11.812ms, Max 12.252ms, Mean 12.034ms, StdDev 0.191ms, Median 12.117ms, CPU 7.473ms [ 50%]
```