### PR TITLE
chore: modernize test-leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ test-leaks: update-test-discovery CMakeLists.txt
 		-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(PWD)/leak-build \
 		-DSENTRY_BACKEND=none \
 		-DWITH_ASAN_OPTION=ON \
-		-DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
-		-DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
-		-DCMAKE_LINKER=/usr/local/opt/llvm/bin/clang \
+		-DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
+		-DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+		-DCMAKE_LINKER=/opt/homebrew/opt/llvm/bin/clang \
 		..
 	@cmake --build leak-build --target sentry_test_unit --parallel
-	@ASAN_OPTIONS=detect_leaks=1 ./leak-build/sentry_test_unit
+	@LSAN_OPTIONS=suppressions=$(PWD)/tests/leaks.txt:print_suppressions=0 ASAN_OPTIONS=detect_leaks=1 ./leak-build/sentry_test_unit
 .PHONY: test-leaks
 
 benchmark: setup-venv

--- a/tests/leaks.txt
+++ b/tests/leaks.txt
@@ -13,3 +13,15 @@ leak:SCDynamicStoreCopyProxiesWithOptions
 leak:realizeClassWithoutSwift
 
 leak:Curl_getaddrinfo_ex
+
+# macOS notify framework false positives from fork() during tests.
+# The notify framework re-allocates internal data structures in the child
+# process after fork(), which LSan reports as leaks since the parent's
+# pointers are gone. Upstream: https://github.com/google/sanitizers/issues/764
+leak:os_set_*_ptr_init
+leak:os_map_*_init
+
+# macOS Objective-C runtime false positive from _fetchInitializingClassList.
+# Triggered during lazy class initialization in CoreFoundation/CFNumber.
+# Upstream: https://github.com/google/sanitizers/issues/1781
+leak:_fetchInitializingClassList


### PR DESCRIPTION
Change the old Homebrew LLVM path for Apple Intel (`/usr/local/opt`) to the new one for Apple Silicon (`/opt/homebrew`), and update LSan suppressions for known macOS system-library leaks.