### PR TITLE
fix: route libcurl debug output through SENTRY_TRACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Apply the propagation context to events that already have contexts set, so that events captured with a local scope or with event-level contexts keep their trace. ([#1843](https://github.com/getsentry/sentry-native/pull/1843))
 - Route libcurl debug output through the Sentry logger (`SENTRY_TRACE`) instead of writing to `stderr`. ([#1854](https://github.com/getsentry/sentry-native/pull/1854))
+  - NOTE: `sentry_options_set_debug(options, true)` no longer displays verbose libcurl debug output by default. To restore it, call `sentry_options_set_logger_level(options, SENTRY_LEVEL_TRACE)`.
 
 ## 0.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Fixes**:
 
 - Apply the propagation context to events that already have contexts set, so that events captured with a local scope or with event-level contexts keep their trace. ([#1843](https://github.com/getsentry/sentry-native/pull/1843))
+- Route libcurl debug output through the Sentry logger (`SENTRY_TRACE`) instead of writing to `stderr`. ([#1854](https://github.com/getsentry/sentry-native/pull/1854))
 
 ## 0.15.3
 

--- a/src/transports/sentry_http_transport_curl.c
+++ b/src/transports/sentry_http_transport_curl.c
@@ -157,6 +157,55 @@ swallow_data(
     return size * nmemb;
 }
 
+static int
+debug_callback(CURL *UNUSED(handle), curl_infotype type, char *data,
+    size_t size, void *UNUSED(userdata))
+{
+    const char *prefix;
+    switch (type) {
+    case CURLINFO_TEXT:
+        prefix = "*";
+        break;
+    case CURLINFO_HEADER_OUT:
+        prefix = ">";
+        break;
+    case CURLINFO_HEADER_IN:
+        prefix = "<";
+        break;
+    default:
+        return 0;
+    }
+    size_t start = 0;
+    for (size_t i = 0; i <= size; i++) {
+        if (i == size || data[i] == '\n') {
+            size_t end = i;
+            while (end > start && data[end - 1] == '\r') {
+                end--;
+            }
+            if (end > start) {
+                SENTRY_TRACEF(
+                    "%s %.*s", prefix, (int)(end - start), data + start);
+            }
+            start = i + 1;
+        }
+    }
+    return 0;
+}
+
+static size_t
+write_callback(char *ptr, size_t size, size_t nmemb, void *UNUSED(userdata))
+{
+    size_t total = size * nmemb;
+    size_t len = total;
+    while (len > 0 && (ptr[len - 1] == '\n' || ptr[len - 1] == '\r')) {
+        len--;
+    }
+    if (len > 0) {
+        SENTRY_TRACEF("%.*s", (int)len, ptr);
+    }
+    return total;
+}
+
 static size_t
 header_callback(char *buffer, size_t size, size_t nitems, void *userdata)
 {
@@ -238,8 +287,8 @@ curl_send_task(void *_client, sentry_prepared_http_request_t *req,
     curl_easy_reset(curl);
     if (client->debug) {
         curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, stderr);
-        // CURLOPT_WRITEFUNCTION will `fwrite` by default
+        curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, debug_callback);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     } else {
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, swallow_data);
     }


### PR DESCRIPTION
> [!NOTE]
> This is an opinionated behavior change. Previously, `sentry_options_set_debug(options, true)` also made libcurl's verbose debug output visible. With this change, that output is routed through the Sentry logger at `TRACE` level and is therefore no longer shown by default.
>
> Applications that still want the curl/transport diagnostics can opt in:
>
> ```c
> sentry_options_set_debug(options, true);
> sentry_options_set_logger_level(options, SENTRY_LEVEL_TRACE);
> ```
>
> Using the existing logger level provides explicit control over this useful but noisy output without introducing curl- or transport-specific configuration flags.

#### Problem A: Sentry logger cannot capture curl output (#887)

- Install `CURLOPT_DEBUGFUNCTION` and route curl debug logs through the Sentry logger. As a bonus, this makes curl debug output visible in sentry-daemon logs.

#### Problem B: curl debug output is overly verbose (#555)

- Use `SENTRY_TRACE` (instead of `SENTRY_DEBUG`) to avoid the verbose curl debug output being visible by default when debug logging is enabled.

#### Before
```
[sentry] DEBUG shutting down background worker thread
[sentry] DEBUG submitting task to background worker thread
< HTTP/2 200 
< server: nginx
< date: Thu, 09 Jul 2026 15:16:01 GMT
< content-type: application/json
< content-length: 2
< vary: origin, access-control-request-method, access-control-request-headers
< access-control-allow-origin: *
< access-control-expose-headers: x-sentry-error,x-sentry-rate-limits,retry-after
< cross-origin-resource-policy: cross-origin
< strict-transport-security: max-age=31536000; includeSubDomains; preload
< via: 1.1 google
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
< 
{}* Connection #0 to host o447951.ingest.us.sentry.io left intact
[sentry] DEBUG executing task on worker thread
```

#### After
```
[sentry] DEBUG shutting down background worker thread
[sentry] DEBUG submitting task to background worker thread
[sentry] TRACE < HTTP/2 200 
[sentry] TRACE < server: nginx
[sentry] TRACE < date: Thu, 09 Jul 2026 15:06:58 GMT
[sentry] TRACE < content-type: application/json
[sentry] TRACE < content-length: 2
[sentry] TRACE < vary: origin, access-control-request-method, access-control-request-headers
[sentry] TRACE < access-control-allow-origin: *
[sentry] TRACE < access-control-expose-headers: x-sentry-error,x-sentry-rate-limits,retry-after
[sentry] TRACE < cross-origin-resource-policy: cross-origin
[sentry] TRACE < strict-transport-security: max-age=31536000; includeSubDomains; preload
[sentry] TRACE < via: 1.1 google
[sentry] TRACE < alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
[sentry] TRACE {}
[sentry] TRACE * Connection #0 to host o447951.ingest.us.sentry.io left intact
[sentry] DEBUG executing task on worker thread
```

Close: #555
Close: #887
