### PR TITLE
fix(crashpad): route client logs through sentry logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Native/macOS: resolve symbol names for crash stacktraces from Mach-O symbol tables and dSYM companions. ([#1856](https://github.com/getsentry/sentry-native/pull/1856))
 - Route libcurl debug output through the Sentry logger (`SENTRY_TRACE`) instead of writing to `stderr`. ([#1854](https://github.com/getsentry/sentry-native/pull/1854))
   - NOTE: `sentry_options_set_debug(options, true)` no longer displays verbose libcurl debug output by default. To restore it, call `sentry_options_set_logger_level(options, SENTRY_LEVEL_TRACE)`.
+- Crashpad: route client logs through the Sentry logger to make actionable handler startup errors visible. ([#1859](https://github.com/getsentry/sentry-native/pull/1859))
 - Windows: fix symlink detection used to prevent database cleanup from following symlinks in run and cache directories. ([#1857](https://github.com/getsentry/sentry-native/pull/1857))
 - Linux: avoid unsafe `copy_file_range` at crash time. ([#1868](https://github.com/getsentry/sentry-native/pull/1868))
 - Fix a lifetime issue when reading `sample_rand` from the scope propagation context. ([#1869](https://github.com/getsentry/sentry-native/pull/1869))

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -262,6 +262,46 @@ flush_external_crash_report(
     sentry_envelope_free(envelope);
 }
 
+static logging::LogSeverity
+to_crashpad_level(sentry_level_t level)
+{
+    switch (level) {
+    case SENTRY_LEVEL_TRACE:
+    case SENTRY_LEVEL_DEBUG:
+        return logging::LOG_VERBOSE;
+    case SENTRY_LEVEL_INFO:
+        return logging::LOG_INFO;
+    case SENTRY_LEVEL_WARNING:
+        return logging::LOG_WARNING;
+    case SENTRY_LEVEL_ERROR:
+        return logging::LOG_ERROR;
+    case SENTRY_LEVEL_FATAL:
+        return logging::LOG_FATAL;
+    }
+
+    return logging::LOG_VERBOSE;
+}
+
+static sentry_level_t
+to_sentry_level(logging::LogSeverity severity)
+{
+    switch (severity) {
+    case logging::LOG_VERBOSE:
+        return SENTRY_LEVEL_DEBUG;
+    case logging::LOG_INFO:
+        return SENTRY_LEVEL_INFO;
+    case logging::LOG_WARNING:
+        return SENTRY_LEVEL_WARNING;
+    case logging::LOG_ERROR:
+    case logging::LOG_ERROR_REPORT:
+        return SENTRY_LEVEL_ERROR;
+    case logging::LOG_FATAL:
+        return SENTRY_LEVEL_FATAL;
+    }
+
+    return SENTRY_LEVEL_DEBUG;
+}
+
 // This function is necessary for macOS since it has no `FirstChanceHandler`.
 // but it is also necessary on Windows if the WER handler is enabled.
 // This means we have to continuously flush the scope on
@@ -730,25 +770,6 @@ crashpad_backend_startup(
     }
 
     std::vector<std::string> arguments { "--no-rate-limit" };
-
-    // Map sentry's log level to mini_chromium's LogSeverity. They diverge at
-    // FATAL (sentry=3, mini_chromium=4); otherwise 1:1.
-    int level = static_cast<int>(options->logger.logger_level);
-    switch (options->logger.logger_level) {
-    case SENTRY_LEVEL_TRACE:
-    case SENTRY_LEVEL_DEBUG:
-        level = -1; // LOG_VERBOSE
-        break;
-    case SENTRY_LEVEL_INFO:
-    case SENTRY_LEVEL_WARNING:
-    case SENTRY_LEVEL_ERROR:
-        // LOG_INFO/WARNING/ERROR (0/1/2) match 1:1
-        break;
-    case SENTRY_LEVEL_FATAL:
-        level = 4; // LOG_FATAL
-        break;
-    }
-
     sentry_path_t *log_path
         = sentry__path_join_str(current_run_folder, "crashpad-handler.log");
     if (log_path) {
@@ -756,11 +777,24 @@ crashpad_backend_startup(
         sentry__path_free(log_path);
     }
     if (options->debug) {
+        const logging::LogSeverity level
+            = to_crashpad_level(options->logger.logger_level);
         logging::LoggingSettings settings;
-        settings.logging_dest = logging::LOG_TO_STDERR;
         settings.min_log_level = level;
         logging::InitLogging(settings);
         arguments.push_back("--log-level=" + std::to_string(level));
+
+        logging::SetLogMessageHandler(
+            [](logging::LogSeverity severity, const char *UNUSED(file),
+                int UNUSED(line), size_t start, const std::string &msg) {
+                size_t end = msg.size();
+                if (end > start && msg[end - 1] == '\n') {
+                    end--;
+                }
+                sentry__logger_log(to_sentry_level(severity), "crashpad: %.*s",
+                    static_cast<int>(end - start), msg.c_str() + start);
+                return true;
+            });
     }
 
     char report_id[37];

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -780,6 +780,7 @@ crashpad_backend_startup(
         const logging::LogSeverity level
             = to_crashpad_level(options->logger.logger_level);
         logging::LoggingSettings settings;
+        settings.logging_dest = logging::LOG_DEFAULT & ~logging::LOG_TO_STDERR;
         settings.min_log_level = level;
         logging::InitLogging(settings);
         arguments.push_back("--log-level=" + std::to_string(level));
@@ -793,7 +794,9 @@ crashpad_backend_startup(
                 }
                 sentry__logger_log(to_sentry_level(severity), "crashpad: %.*s",
                     static_cast<int>(end - start), msg.c_str() + start);
-                return true;
+                // Forward logs without consuming them so Crashpad keeps its
+                // default handling, including fatal termination.
+                return false;
             });
     }
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -786,8 +786,8 @@ crashpad_backend_startup(
         arguments.push_back("--log-level=" + std::to_string(level));
 
         logging::SetLogMessageHandler(
-            [](logging::LogSeverity severity, const char *UNUSED(file),
-                int UNUSED(line), size_t start, const std::string &msg) {
+            [](logging::LogSeverity severity, const char *, int, size_t start,
+                const std::string &msg) {
                 size_t end = msg.size();
                 if (end > start && msg[end - 1] == '\n') {
                     end--;


### PR DESCRIPTION
Forward Crashpad client log messages to the Sentry logger instead of `stderr`. This makes actionable Crashpad handler startup errors due to missing executable permissions, for example, visible in downstream SDKs that only capture Sentry logs, not `stderr`.

Before:
```
[sentry] DEBUG starting backend
[sentry] DEBUG background worker thread started
[sentry] DEBUG starting crashpad backend with handler "/Users/jpnurmi/Projects/sentry/sentry-playground/build/crashpad_handler"
[sentry] DEBUG using minidump URL <url>
[55318:16250687:20260713,103346.180970:FATAL spawn_subprocess.cc:222] posix_spawnp /Users/jpnurmi/Projects/sentry/sentry-playground/build/crashpad_handler: Permission denied (13)
[55303:16250469:20260713,103346.181480:WARNING spawn_subprocess.cc:247] intermediate process terminated by signal 5 (Trace/BPT trap: 5)
[55303:16250469:20260713,103346.181562:ERROR file_io.cc:107] ReadExactly: expected 8, observed 0
[sentry] WARN failed to start crashpad client handler
[sentry] WARN failed to initialize backend
[sentry] WARN `sentry_init` failed
```

After:
```
[sentry] DEBUG starting backend
[sentry] DEBUG background worker thread started
[sentry] DEBUG starting crashpad backend with handler "/Users/jpnurmi/Projects/sentry/sentry-playground/build/crashpad_handler"
[sentry] DEBUG using minidump URL <url>
[sentry] ERROR crashpad: failed to spawn /Users/jpnurmi/Projects/sentry/sentry-playground/build/crashpad_handler: Permission denied (13)
[sentry] ERROR crashpad: ReadExactly: expected 8, observed 0
[sentry] WARN failed to start crashpad client handler
[sentry] WARN failed to initialize backend
[sentry] WARN `sentry_init` failed
```

Note: this only applies to the Crashpad _client_ logs. Crashpad handler logs are forwarded to `<run>/crashpad-handler.log` instead.

Depends on: getsentry/crashpad#159
Resolves: #792