### PR TITLE
test(scope): disable auto-sessions in user-owned scope test

### DIFF
--- a/tests/unit/test_scope.c
+++ b/tests/unit/test_scope.c
@@ -1373,6 +1373,7 @@ SENTRY_TEST(scope_capture_user_owned)
     uint64_t called = 0;
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    sentry_options_set_auto_session_tracking(options, false);
     sentry_transport_t *transport = sentry_transport_new(send_envelope_count);
     sentry_transport_set_state(transport, &called);
     sentry_options_set_transport(options, transport);


### PR DESCRIPTION
The newly added user-owned scope test failed on Switch:
```
[ FAILED ]
  test_scope.c:1404: Check 3 == 2... failed
```
https://github.com/getsentry/sentry-switch/actions/runs/29241300898/job/86787742176

Try disabling automatic session tracking. It can emit an additional session envelope on platforms that provide release metadata during initialization.