### PR TITLE
fix(linux): avoid unsafe `copy_file_range` at crash time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
             os: ubuntu-24.04
             CC: gcc-14
             CXX: g++-14
+          - name: Linux (GCC 15)
+            os: ubuntu-26.04
+            CC: gcc-15
+            CXX: g++-15
           - name: Linux Arm64 (GCC 14.2.0 + tsan)
             os: ubuntu-24.04-arm
             CC: gcc-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Route libcurl debug output through the Sentry logger (`SENTRY_TRACE`) instead of writing to `stderr`. ([#1854](https://github.com/getsentry/sentry-native/pull/1854))
   - NOTE: `sentry_options_set_debug(options, true)` no longer displays verbose libcurl debug output by default. To restore it, call `sentry_options_set_logger_level(options, SENTRY_LEVEL_TRACE)`.
 - Windows: fix symlink detection used to prevent database cleanup from following symlinks in run and cache directories. ([#1857](https://github.com/getsentry/sentry-native/pull/1857))
+- Linux: avoid unsafe `copy_file_range` at crash time. ([#1868](https://github.com/getsentry/sentry-native/pull/1868))
 
 ## 0.15.3
 

--- a/src/path/sentry_path_unix.c
+++ b/src/path/sentry_path_unix.c
@@ -2,6 +2,7 @@
 #include "sentry_core.h"
 #include "sentry_path.h"
 #include "sentry_string.h"
+#include "sentry_unix_pageallocator.h"
 #include "sentry_utils.h"
 
 #ifdef SENTRY_PLATFORM_PS
@@ -366,29 +367,43 @@ sentry__path_copy(const sentry_path_t *src, const sentry_path_t *dst)
     int rv = 0;
 
 #    ifdef SENTRY_HAVE_COPY_FILE_RANGE
-    while (true) {
-        ssize_t n
-            = copy_file_range(src_fd, NULL, dst_fd, NULL, SIZE_MAX / 2, 0);
-        if (n > 0) {
-            continue;
-        } else if (n == 0) {
-            goto done;
-        } else if (errno == EAGAIN || errno == EINTR) {
-            continue;
-        } else if (errno == ENOSYS || errno == EXDEV || errno == EOPNOTSUPP
-            || errno == EINVAL) {
-            break;
-        } else {
-            rv = 1;
-            goto done;
+    // When the page allocator is enabled, this may be running from a crash
+    // handler on a constrained signal stack. Avoid copy_file_range() there:
+    // it is not async-signal-safe, and lazy PLT resolution can consume enough
+    // crash stack to clobber adjacent heap allocations.
+    if (!sentry__page_allocator_enabled()) {
+        while (true) {
+            ssize_t n
+                = copy_file_range(src_fd, NULL, dst_fd, NULL, SIZE_MAX / 2, 0);
+            if (n > 0) {
+                continue;
+            } else if (n == 0) {
+                goto done;
+            } else if (errno == EAGAIN || errno == EINTR) {
+                continue;
+            } else if (errno == ENOSYS || errno == EXDEV || errno == EOPNOTSUPP
+                || errno == EINVAL) {
+                break;
+            } else {
+                rv = 1;
+                goto done;
+            }
         }
     }
 #    endif
 
     {
-        char buf[16384];
+        // Keep the fallback buffer off the stack. Crash handlers may run on
+        // constrained signal stacks, so a large stack buffer is unsafe when
+        // attachments are cached during crash handling.
+        const size_t buf_len = 16384;
+        char *buf = sentry_malloc(buf_len);
+        if (!buf) {
+            rv = 1;
+            goto done;
+        }
         while (true) {
-            ssize_t n = read(src_fd, buf, sizeof(buf));
+            ssize_t n = read(src_fd, buf, buf_len);
             if (n < 0 && (errno == EAGAIN || errno == EINTR)) {
                 continue;
             } else if (n <= 0) {
@@ -400,11 +415,10 @@ sentry__path_copy(const sentry_path_t *src, const sentry_path_t *dst)
                 break;
             }
         }
+        sentry_free(buf);
     }
 
-#    ifdef SENTRY_HAVE_COPY_FILE_RANGE
 done:
-#    endif
     close(src_fd);
     close(dst_fd);
     return rv;


### PR DESCRIPTION
Avoid `copy_file_range()` while the page allocator is enabled, because file copies may happen from crash handling on a constrained signal stack.

On Ubuntu 26.04 / glibc 2.43, the TUS crash restart test can corrupt the crash envelope when the first `copy_file_range()` call happens inside crash handling. In that case, lazy PLT resolution enters the dynamic linker from the crash path, which is not async-signal-safe.

The fallback copy path is also changed to allocate its buffer on the heap instead of using a large stack buffer, reducing crash-handler stack pressure while caching attachments.

Before:
```sh
$ pytest -v "tests/test_integration_tus.py::test_tus_crash_restart[breakpad]"
...
FAILED tests/test_integration_tus.py::test_tus_crash_restart[breakpad] - UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 260: invalid continuation byte
```
After:
```sg
$ pytest -v "tests/test_integration_tus.py::test_tus_crash_restart[breakpad]"
...
tests/test_integration_tus.py::test_tus_crash_restart[breakpad] PASSED                                                                                                                                [100%]
```