### PR TITLE
fix: avoid borrowed `sample_rand` after unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - NOTE: `sentry_options_set_debug(options, true)` no longer displays verbose libcurl debug output by default. To restore it, call `sentry_options_set_logger_level(options, SENTRY_LEVEL_TRACE)`.
 - Windows: fix symlink detection used to prevent database cleanup from following symlinks in run and cache directories. ([#1857](https://github.com/getsentry/sentry-native/pull/1857))
 - Linux: avoid unsafe `copy_file_range` at crash time. ([#1868](https://github.com/getsentry/sentry-native/pull/1868))
+- Fix a lifetime issue when reading `sample_rand` from the scope propagation context. ([#1869](https://github.com/getsentry/sentry-native/pull/1869))
 
 ## 0.15.3
 

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -13,6 +13,7 @@
 #include "sentry_value.h"
 #include <assert.h>
 #include <limits.h>
+#include <math.h>
 #include <string.h>
 
 struct sentry_envelope_item_s {
@@ -391,12 +392,12 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
         traces_sample_rate = options->traces_sample_rate;
     }
     sentry_value_t dsc = sentry_value_new_null();
-    sentry_value_t sample_rand = sentry_value_new_null();
+    double sample_rand = NAN;
     SENTRY_WITH_SCOPE (scope) {
         dsc = sentry__value_clone(scope->dynamic_sampling_context);
-        sample_rand = sentry_value_get_by_key(
+        sample_rand = sentry_value_as_double(sentry_value_get_by_key(
             sentry_value_get_by_key(scope->propagation_context, "trace"),
-            "sample_rand");
+            "sample_rand"));
     }
     if (!sentry_value_is_null(dsc)) {
         sentry_value_t trace_id = sentry_value_get_by_key(
@@ -410,8 +411,8 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
             SENTRY_WARN("couldn't retrieve trace_id from scope to apply to the "
                         "dynamic sampling context");
         }
-        if (!sentry_value_is_null(sample_rand)) {
-            if (sentry_value_as_double(sample_rand) >= traces_sample_rate) {
+        if (!isnan(sample_rand)) {
+            if (sample_rand >= traces_sample_rate) {
                 sentry_value_set_by_key(
                     dsc, "sampled", sentry_value_new_string("false"));
             } else {

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -392,7 +392,7 @@ sentry__envelope_add_event(sentry_envelope_t *envelope, sentry_value_t event)
         traces_sample_rate = options->traces_sample_rate;
     }
     sentry_value_t dsc = sentry_value_new_null();
-    double sample_rand = NAN;
+    double sample_rand = (double)NAN;
     SENTRY_WITH_SCOPE (scope) {
         dsc = sentry__value_clone(scope->dynamic_sampling_context);
         sample_rand = sentry_value_as_double(sentry_value_get_by_key(


### PR DESCRIPTION
Copy `sample_rand` out of the scope propagation context while the scope lock is held. This fixes a lifetime violation of a borrowed reference, detected while experimenting with replacing the global scope mutex with a read-write lock for #1862. Previously, it kept a borrowed `sentry_value_t` and read it unsafely after releasing the lock.

<!--
This is a small checklist for you as a contributor:

* Make sure code is formatted properly: `make format`.
* Make sure to run tests for your code: `make test`.
* Create new tests where appropriate:
  - Create new unit-tests or integration-tests covering your change.
  - When you create a bugfix, try to add a regression-test as well.
  - Make sure you run the tests with a leak checker or other static analyzer.
-->
