### PR TITLE
test: retry flaky crashpad dumping stack overflow test

### DIFF
--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -498,6 +498,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
         ),
     ],
 )
+@flaky(max_runs=3)
 def test_crashpad_dumping_stack_overflow(cmake, httpserver, stack_size):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 


### PR DESCRIPTION
This is a continuation of #1737 that did the same for `test_crashpad_dumping_crash`. After that, the next "dumping" crashpad test in line, `test_crashpad_dumping_stack_overflow` has been randomly failing the same way, causing friction in unrelated PRs.