### PR TITLE
fix: silence warnings on Linux/GCC 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Windows: fix symlink detection used to prevent database cleanup from following symlinks in run and cache directories. ([#1857](https://github.com/getsentry/sentry-native/pull/1857))
 - Linux: avoid unsafe `copy_file_range` at crash time. ([#1868](https://github.com/getsentry/sentry-native/pull/1868))
 - Fix a lifetime issue when reading `sample_rand` from the scope propagation context. ([#1869](https://github.com/getsentry/sentry-native/pull/1869))
+- Linux: silence harmless compilation warnings in `sentry_modulefinder_linux.c` and `sentry_backend_inproc.c`. ([#1871](https://github.com/getsentry/sentry-native/pull/1871))
 
 ## 0.15.3
 

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -318,7 +318,7 @@ wait_for_handler_ready(int timeout_ms)
         SENTRY_WARNF("poll for handler ready failed: %s", strerror(errno));
     } else if (rv > 0) {
         char c;
-        read(g_handler_ready_pipe[0], &c, 1);
+        (void)!read(g_handler_ready_pipe[0], &c, 1);
     }
 #elif defined(SENTRY_PLATFORM_WINDOWS)
     WaitForSingleObject(g_handler_ready_event, (DWORD)timeout_ms);

--- a/src/modulefinder/sentry_modulefinder_linux.c
+++ b/src/modulefinder/sentry_modulefinder_linux.c
@@ -239,7 +239,7 @@ sentry__procmaps_parse_module_line(
     line += consumed;
     module->file.ptr = line;
     module->file.len = 0;
-    char *nl = strchr(line, '\n');
+    const char *nl = strchr(line, '\n');
     // `consumed` skips over whitespace (the trailing newline), so we have to
     // check for that explicitly
     if (consumed && (line - 1)[0] == '\n') {

--- a/tests/unit/test_retry.c
+++ b/tests/unit/test_retry.c
@@ -66,7 +66,7 @@ write_retry_file(const sentry_run_t *run, uint64_t timestamp, int retry_count,
 
     sentry_path_t *path
         = sentry__run_make_cache_path(run, timestamp, retry_count, uuid);
-    (void)sentry_envelope_write_to_path(envelope, path);
+    (void)!sentry_envelope_write_to_path(envelope, path);
     sentry__path_free(path);
     sentry_envelope_free(envelope);
 }


### PR DESCRIPTION
```
src/backends/sentry_backend_inproc.c: In function ‘wait_for_handler_ready’:
src/backends/sentry_backend_inproc.c:321:9: warning: ignoring return value of ‘read’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  321 |         read(g_handler_ready_pipe[0], &c, 1);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
src/modulefinder/sentry_modulefinder_linux.c: In function ‘sentry__procmaps_parse_module_line’:
src/modulefinder/sentry_modulefinder_linux.c:242:16: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  242 |     char *nl = strchr(line, '\n');
      |                ^~~~~~
```

```
tests/unit/test_retry.c: In function ‘write_retry_file’:
tests/unit/test_retry.c:69:11: warning: ignoring return value of ‘sentry_envelope_write_to_path’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
    69 |     (void)sentry_envelope_write_to_path(envelope, path);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```