### PR TITLE
ci: investigate codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,16 @@ jobs:
             os: ubuntu-22.04
             CC: clang-11
             CXX: clang++-11
-          - name: Linux (clang 20 + asan + llvm-cov)
-            os: ubuntu-24.04
-            CC: clang-20
-            CXX: clang++-20
+          - name: Linux (clang 22 + asan + llvm-cov)
+            os: ubuntu-26.04
+            CC: clang-22
+            CXX: clang++-22
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
-          - name: Linux Arm64 (clang 20 + asan + llvm-cov)
-            os: ubuntu-24.04-arm
-            CC: clang-20
-            CXX: clang++-20
+          - name: Linux Arm64 (clang 22 + asan + llvm-cov)
+            os: ubuntu-26.04-arm
+            CC: clang-22
+            CXX: clang++-22
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang 20 + tsan)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,14 @@ jobs:
         working-directory: ndk
         run: make check
 
+      - name: Upload coverage artifacts
+        if: ${{ contains(env['RUN_ANALYZER'], 'cov') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-${{ matrix.name }}
+          if-no-files-found: warn
+          path: coverage/
+
       - name: "Upload to codecov.io"
         if: ${{ contains(env['RUN_ANALYZER'], 'cov') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # pin@v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,9 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # pin@v7.0.0
         with:
           directory: coverage
+          name: ${{ matrix.name }}
+          job_code: ${{ matrix.name }}
+          flags: ${{ runner.os }},${{ runner.arch }},${{ matrix.RUN_ANALYZER }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
<!--
The initial suspect was Linux `clang-20` / `llvm-cov` because the last Codecov commit that still exposed upload records showed a very specific pattern.

Commit:

`67a9f8ec856ecfc83c6817284120a36e5896035c`

Codecov uploads API:

https://api.codecov.io/api/v2/github/getsentry/repos/sentry-native/commits/67a9f8ec856ecfc83c6817284120a36e5896035c/uploads/

That commit had four coverage uploads:

- Linux `clang 20 + kcov`: `PROCESSED`
- Linux Arm64 `clang 20 + asan + llvm-cov`: `ERROR`
- Linux `clang 20 + asan + llvm-cov`: `ERROR`
- macOS `clang 18 + asan + llvm-cov`: `PROCESSED`

So the common factor for the two failed uploads was:

- Linux
- `clang-20`
- `llvm-cov`
- LCOV-style coverage generated from LLVM source-based coverage

The same commit showed that Codecov could still process:

- Linux coverage from `kcov`
- macOS coverage from `llvm-cov`

That made a general Codecov token/upload/action failure less likely, and made the Linux LLVM 20 LCOV output the most plausible initial suspect.

We then tested an upgrade path by changing the Linux `llvm-cov` jobs from clang 20 on Ubuntu 24.04 to clang 22 on Ubuntu 26.04:

- `Linux (clang 22 + asan + llvm-cov)`
- `Linux Arm64 (clang 22 + asan + llvm-cov)`

However, the clang 22 PR run did not produce a useful per-upload comparison, because Codecov accepted all four uploads with HTTP 200 but failed to create/index the commit record at all. The Codecov API still returns 404 for the entire commit/uploads endpoint.

So clang 20 was a reasonable suspect based on the old `PROCESSED` vs `ERROR` split, but the clang 22 test did not confirm or disprove it. The current failure mode is broader: Codecov accepts uploads but does not expose the commit record.
-->