### PR TITLE
test: benchmark logs

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -11,6 +11,7 @@ def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label, runs=1)
         ["sentry_benchmark"],
         {
             "SENTRY_BACKEND": backend,
+            "SENTRY_BATCHER_BUFFER_COUNT": "10",
             "SENTRY_BUILD_BENCHMARKS": "ON",
             "CMAKE_BUILD_TYPE": "Release",
         },
@@ -65,4 +66,16 @@ def test_benchmark_scope(test_name, backend, cmake, httpserver, gbenchmark):
         httpserver,
         gbenchmark,
         f"Scope {test_name} ({backend})",
+    )
+
+
+@pytest.mark.parametrize("threads", [1, 8, 16, 32])
+def test_benchmark_logs(threads, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        f"^benchmark_logs.*threads:{threads}$",
+        "none",
+        cmake,
+        httpserver,
+        gbenchmark,
+        f"Logs ({threads} thread{'s' if threads > 1 else ''})",
     )

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(sentry_benchmark
 	${SENTRY_SOURCES}
 	benchmark_init.cpp
 	benchmark_backend.cpp
+	benchmark_logs.cpp
 	benchmark_scope.cpp
 )
 

--- a/tests/benchmark/benchmark_logs.cpp
+++ b/tests/benchmark/benchmark_logs.cpp
@@ -12,7 +12,7 @@ discard_envelope(sentry_envelope_t *envelope, void *state)
 }
 
 static void
-benchmark_logs(benchmark::State &state)
+setup_logs(const benchmark::State &)
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
@@ -24,7 +24,17 @@ benchmark_logs(benchmark::State &state)
 
     sentry_set_attribute("global",
         sentry_value_new_attribute(sentry_value_new_string("attribute"), NULL));
+}
 
+static void
+teardown_logs(const benchmark::State &)
+{
+    sentry_close();
+}
+
+static void
+benchmark_logs(benchmark::State &state)
+{
     sentry_value_t attributes = sentry_value_new_object();
     sentry_value_set_by_key(attributes, "local",
         sentry_value_new_attribute(sentry_value_new_string("attribute"), NULL));
@@ -35,7 +45,6 @@ benchmark_logs(benchmark::State &state)
     }
 
     sentry_value_decref(attributes);
-    sentry_close();
 }
 
 BENCHMARK(benchmark_logs)
@@ -44,4 +53,6 @@ BENCHMARK(benchmark_logs)
     ->Threads(16)
     ->Threads(32)
     ->Iterations(100)
-    ->Unit(benchmark::kMillisecond);
+    ->Unit(benchmark::kMillisecond)
+    ->Setup(setup_logs)
+    ->Teardown(teardown_logs);

--- a/tests/benchmark/benchmark_logs.cpp
+++ b/tests/benchmark/benchmark_logs.cpp
@@ -1,0 +1,47 @@
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#include "sentry.h"
+}
+
+static void
+discard_envelope(sentry_envelope_t *envelope, void *state)
+{
+    (void)state;
+    sentry_envelope_free(envelope);
+}
+
+static void
+benchmark_logs(benchmark::State &state)
+{
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    sentry_options_set_logs_with_attributes(options, true);
+    sentry_options_set_auto_session_tracking(options, 0);
+    sentry_options_set_transport(
+        options, sentry_transport_new(discard_envelope));
+    sentry_init(options);
+
+    sentry_set_attribute("global",
+        sentry_value_new_attribute(sentry_value_new_string("attribute"), NULL));
+
+    sentry_value_t attributes = sentry_value_new_object();
+    sentry_value_set_by_key(attributes, "local",
+        sentry_value_new_attribute(sentry_value_new_string("attribute"), NULL));
+
+    int i = 0;
+    for (auto _ : state) {
+        sentry_log_info("log %d", sentry_value_incref(attributes), i++, NULL);
+    }
+
+    sentry_value_decref(attributes);
+    sentry_close();
+}
+
+BENCHMARK(benchmark_logs)
+    ->Threads(1)
+    ->Threads(8)
+    ->Threads(16)
+    ->Threads(32)
+    ->Iterations(100)
+    ->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
Benchmarks `sentry_log_info` with 1/8/16/32 threads. Sample recorded on Framework 13, AMD Ryzen AI 9 HX 370:
```
tests/benchmark.py::test_benchmark_logs[1] PASSED
Min 0.004ms, Max 0.004ms, Mean 0.004ms, Median 0.004ms, CPU 0.004ms                                                                                                                                                                                                                                                                   [ 25%]
tests/benchmark.py::test_benchmark_logs[8] PASSED
Min 0.029ms, Max 0.029ms, Mean 0.029ms, Median 0.029ms, CPU 0.009ms                                                                                                                                                                                                                                                                   [ 50%]
tests/benchmark.py::test_benchmark_logs[16] PASSED
Min 0.052ms, Max 0.052ms, Mean 0.052ms, Median 0.052ms, CPU 0.007ms                                                                                                                                                                                                                                                                   [ 75%]
tests/benchmark.py::test_benchmark_logs[32] PASSED
Min 0.105ms, Max 0.105ms, Mean 0.105ms, Median 0.105ms, CPU 0.007ms
```

<img width="1537" height="751" alt="image" src="https://github.com/user-attachments/assets/33ae4399-c68e-4deb-8a4f-3c863d926a32" />

[sentry_benchmark.208870.ftrace.zip](https://github.com/user-attachments/files/30120475/sentry_benchmark.208870.ftrace.zip)

See also:
- #1862