### PR TITLE
ci: fix llvm coverage uploads

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,4 +8,4 @@ coverage:
 comment:
   layout: "diff"
   require_changes: true
-  after_n_builds: 3 # linux llvm-cov, linux kcov, mac llvm-cov
+  after_n_builds: 4 # linux llvm-cov, linux arm64 llvm-cov, linux kcov, mac llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,16 @@ jobs:
             os: ubuntu-22.04
             CC: clang-11
             CXX: clang++-11
-          - name: Linux (clang 22 + asan + llvm-cov)
-            os: ubuntu-26.04
-            CC: clang-22
-            CXX: clang++-22
+          - name: Linux (clang 20 + asan + llvm-cov)
+            os: ubuntu-24.04
+            CC: clang-20
+            CXX: clang++-20
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
-          - name: Linux Arm64 (clang 22 + asan + llvm-cov)
-            os: ubuntu-26.04-arm
-            CC: clang-22
-            CXX: clang++-22
+          - name: Linux Arm64 (clang 20 + asan + llvm-cov)
+            os: ubuntu-24.04-arm
+            CC: clang-20
+            CXX: clang++-20
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang 20 + tsan)
@@ -282,6 +282,12 @@ jobs:
             sudo apt install "${CC}" "${CXX}"
           elif [[ "$CC" == clang-* ]]; then
             sudo apt install "${CC}"
+            if [[ "$RUN_ANALYZER" == *llvm-cov* ]]; then
+              llvm_version="${CC#clang-}"
+              sudo apt install "llvm-${llvm_version}"
+              echo "LLVM_PROFDATA=llvm-profdata-${llvm_version}" >> "$GITHUB_ENV"
+              echo "LLVM_COV=llvm-cov-${llvm_version}" >> "$GITHUB_ENV"
+            fi
           else
             echo "Unknown CC: $CC" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,16 @@ jobs:
             os: ubuntu-22.04
             CC: clang-11
             CXX: clang++-11
-          - name: Linux (clang 20 + asan + llvm-cov)
-            os: ubuntu-24.04
-            CC: clang-20
-            CXX: clang++-20
+          - name: Linux (clang 22 + asan + llvm-cov)
+            os: ubuntu-26.04
+            CC: clang-22
+            CXX: clang++-22
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
-          - name: Linux Arm64 (clang 20 + asan + llvm-cov)
-            os: ubuntu-24.04-arm
-            CC: clang-20
-            CXX: clang++-20
+          - name: Linux Arm64 (clang 22 + asan + llvm-cov)
+            os: ubuntu-26.04-arm
+            CC: clang-22
+            CXX: clang++-22
             ERROR_ON_WARNINGS: 1
             RUN_ANALYZER: asan,llvm-cov
           - name: Linux (clang 20 + tsan)

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -78,7 +78,7 @@ class CMake:
                 if len(files) == 0:
                     continue
                 cmd = [
-                    "llvm-profdata",
+                    os.environ.get("LLVM_PROFDATA", "llvm-profdata"),
                     "merge",
                     "-sparse",
                     "-o=sentry.profdata",
@@ -95,7 +95,7 @@ class CMake:
                     "libsentry.dylib" if sys.platform == "darwin" else "libsentry.so",
                 ]
                 cmd = [
-                    "llvm-cov",
+                    os.environ.get("LLVM_COV", "llvm-cov"),
                     "export",
                     "-format=lcov",
                     "-instr-profile=sentry.profdata",

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -85,7 +85,7 @@ class CMake:
                     *files,
                 ]
                 print("{} > {}".format(d, " ".join(cmd)))
-                subprocess.run(cmd, cwd=d)
+                subprocess.run(cmd, cwd=d, check=True)
 
                 # then export lcov from the profiling data, since this needs access
                 # to the object files, we need to do it per-test
@@ -105,7 +105,7 @@ class CMake:
                 lcov = os.path.join(coveragedir, f"run-{i}.lcov")
                 with open(lcov, "w") as lcov_file:
                     print("{} > {} > {}".format(d, " ".join(cmd), lcov))
-                    subprocess.run(cmd, stdout=lcov_file, cwd=d)
+                    subprocess.run(cmd, stdout=lcov_file, cwd=d, check=True)
 
         if "kcov" in os.environ.get("RUN_ANALYZER", ""):
             coverage_dirs = [


### PR DESCRIPTION
The Linux clang 20 coverage jobs were generating `.profraw` files with a newer raw profile format than the `llvm-profdata` binary on PATH expected. As a result, `llvm-profdata merge` failed, `llvm-cov export` produced empty LCOV files, and Codecov received uploads with no coverage data.

This installs the LLVM package matching the selected clang version for Linux `llvm-cov` jobs, passes the matching `llvm-profdata-*` and `llvm-cov-*` tools to the test helper, and makes coverage conversion failures fatal so future toolchain mismatches fail CI instead of uploading empty reports.

<img width="306" alt="image" src="https://github.com/user-attachments/assets/bff799db-a83c-45d9-ace9-fbb66d3f7776" />

Coverage data is missing:
```
...
<<<<<< network

# path=coverage/run-18.lcov

<<<<<< EOF

# path=coverage/run-4.lcov

<<<<<< EOF

# path=coverage/run-22.lcov
...
```

Close: #1799