### PR TITLE
fix(crashpad): wait reliably for dump uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**Fixes**:
+
+- Crashpad: wait reliably for crash report uploads. ([#1885](https://github.com/getsentry/sentry-native/pull/1885))
+
+## Unreleased
+
 **Features**:
 
 - Add reusable, user-owned scopes. `sentry_scope_new` creates a scope that `sentry_capture_event_with_scope` applies without consuming, so you can configure it once and reuse it across many captures instead of building a new local scope each time. `sentry_scope_clone` copies a scope, and `sentry_scope_free` releases it. ([#1855](https://github.com/getsentry/sentry-native/pull/1855))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.15.4
+## Unreleased
 
 **Fixes**:
 
 - Crashpad: wait reliably for crash report uploads. ([#1885](https://github.com/getsentry/sentry-native/pull/1885))
 
-## Unreleased
+## 0.15.4
 
 **Features**:
 

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -5,7 +5,6 @@ import sys
 import time
 
 import pytest
-from flaky import flaky
 
 from . import (
     make_dsn,
@@ -421,7 +420,6 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
         ),
     ],
 )
-@flaky(max_runs=3)
 def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     build_args.update({"SENTRY_BACKEND": "crashpad"})
     tmp_path = cmake(["sentry_example"], build_args)
@@ -498,7 +496,6 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
         ),
     ],
 )
-@flaky(max_runs=3)
 def test_crashpad_dumping_stack_overflow(cmake, httpserver, stack_size):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 
@@ -517,6 +514,7 @@ def test_crashpad_dumping_stack_overflow(cmake, httpserver, stack_size):
                 "start-session",
                 "attachment",
                 "attach-view-hierarchy",
+                "crashpad-wait-for-upload",
                 "stack-overflow",
             ],
             expect_failure=True,


### PR DESCRIPTION
Depends on:
- https://github.com/getsentry/crashpad/pull/162

The crash dumping test enabled `crashpad-wait-for-upload` in #1728, but Crahspad's `ReportPendingSync()` could still race the background upload worker. The worker could consume the queued report first, allowing the synchronous caller to return while the report was still being uploaded and marked completed.

Session recovery only considers completed Crashpad reports. On Windows, the recovery process could therefore start too early, miss the crashed session, and make the dumping test fail intermittently. Retrying the test in #1737 reduced the symptom without fixing the race. The stack-overflow variant did not wait for upload and was later given the same retry workaround in #1870.

Update Crashpad to serialize pending-report processing so a synchronous upload waits for an active worker pass to finish. Enable `crashpad-wait-for-upload` for the stack-overflow case, remove both flaky markers, and remove the now-unused flaky import.