### PR TITLE
ci: enable llvm-cov for Windows ClangCL

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,4 +8,4 @@ coverage:
 comment:
   layout: "diff"
   require_changes: true
-  after_n_builds: 4 # linux llvm-cov, linux arm64 llvm-cov, linux kcov, mac llvm-cov
+  after_n_builds: 5 # linux llvm-cov, linux arm64 llvm-cov, linux kcov, mac llvm-cov, windows clangcl llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,14 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
 
+      - name: Set LLVM tools for ClangCL
+        if: ${{ runner.os == 'Windows' && env['VS_GENERATOR_TOOLSET'] == 'ClangCL' && contains(env['RUN_ANALYZER'], 'llvm-cov') }}
+        shell: powershell
+        run: |
+          $llvm = Split-Path (Get-Command clang-cl.exe).Source
+          "LLVM_PROFDATA=$llvm\llvm-profdata.exe" >> $env:GITHUB_ENV
+          "LLVM_COV=$llvm\llvm-cov.exe" >> $env:GITHUB_ENV
+
       - name: Remove Strawberry Perl from PATH
         if: ${{ runner.os == 'Windows' }}
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,11 +368,12 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
 
-      - name: Set LLVM tools for ClangCL
+      - name: Set VS LLVM tools for ClangCL
         if: ${{ runner.os == 'Windows' && env['VS_GENERATOR_TOOLSET'] == 'ClangCL' && contains(env['RUN_ANALYZER'], 'llvm-cov') }}
         shell: powershell
         run: |
-          $llvm = Split-Path (Get-Command clang-cl.exe).Source
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $llvm = Join-Path $vs "VC\Tools\Llvm\x64\bin"
           "LLVM_PROFDATA=$llvm\llvm-profdata.exe" >> $env:GITHUB_ENV
           "LLVM_COV=$llvm\llvm-cov.exe" >> $env:GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,10 @@ jobs:
           - name: Windows (latest, ninja + sccache)
             os: windows-latest
             USE_SCCACHE: 1
-          - name: Windows ClangCL (2022)
+          - name: Windows ClangCL (2022 + llvm-cov)
             os: windows-2022
             VS_GENERATOR_TOOLSET: ClangCL
+            RUN_ANALYZER: llvm-cov
           - name: LLVM-Mingw
             os: windows-latest
             TEST_MINGW: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,14 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
 
+      - name: Set LLVM tools for ClangCL
+        if: ${{ runner.os == 'Windows' && env['VS_GENERATOR_TOOLSET'] == 'ClangCL' && contains(env['RUN_ANALYZER'], 'llvm-cov') }}
+        shell: powershell
+        run: |
+          $llvm = Split-Path (Get-Command clang-cl.exe).Source
+          "LLVM_PROFDATA=$llvm\llvm-profdata.exe" >> $env:GITHUB_ENV
+          "LLVM_COV=$llvm\llvm-cov.exe" >> $env:GITHUB_ENV
+
       - name: Remove Strawberry Perl from PATH
         if: ${{ runner.os == 'Windows' }}
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,8 +375,8 @@ jobs:
         run: |
           $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
           $llvm = Join-Path $vs "VC\Tools\Llvm\x64\bin"
-          "LLVM_PROFDATA=$llvm\llvm-profdata.exe" >> $env:GITHUB_ENV
-          "LLVM_COV=$llvm\llvm-cov.exe" >> $env:GITHUB_ENV
+          "LLVM_PROFDATA=$llvm\llvm-profdata.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LLVM_COV=$llvm\llvm-cov.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Remove Strawberry Perl from PATH
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,9 +197,10 @@ jobs:
           - name: Windows (latest, ninja + sccache)
             os: windows-latest
             USE_SCCACHE: 1
-          - name: Windows ClangCL (2022)
+          - name: Windows ClangCL (2022 + llvm-cov)
             os: windows-2022
             VS_GENERATOR_TOOLSET: ClangCL
+            RUN_ANALYZER: llvm-cov
           - name: LLVM-Mingw
             os: windows-latest
             TEST_MINGW: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,11 +369,12 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
 
-      - name: Set LLVM tools for ClangCL
+      - name: Set VS LLVM tools for ClangCL
         if: ${{ runner.os == 'Windows' && env['VS_GENERATOR_TOOLSET'] == 'ClangCL' && contains(env['RUN_ANALYZER'], 'llvm-cov') }}
         shell: powershell
         run: |
-          $llvm = Split-Path (Get-Command clang-cl.exe).Source
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $llvm = Join-Path $vs "VC\Tools\Llvm\x64\bin"
           "LLVM_PROFDATA=$llvm\llvm-profdata.exe" >> $env:GITHUB_ENV
           "LLVM_COV=$llvm\llvm-cov.exe" >> $env:GITHUB_ENV
 

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -72,6 +72,17 @@ class CMake:
         os.mkdir(coveragedir)
 
         if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
+
+            def exe_name(name):
+                return name + ".exe" if sys.platform == "win32" else name
+
+            def lib_name(name):
+                if sys.platform == "win32":
+                    return name + ".dll"
+                elif sys.platform == "darwin":
+                    return "lib" + name + ".dylib"
+                return "lib" + name + ".so"
+
             for i, (d, _) in enumerate(self.runs.values()):
                 # first merge the raw profiling runs
                 files = [f for f in os.listdir(d) if f.endswith(".profraw")]
@@ -90,10 +101,10 @@ class CMake:
                 # then export lcov from the profiling data, since this needs access
                 # to the object files, we need to do it per-test
                 objects = [
-                    "sentry_example",
-                    "sentry_test_unit",
-                    "libsentry.dylib" if sys.platform == "darwin" else "libsentry.so",
-                    "sentry-crash",
+                    exe_name("sentry_example"),
+                    exe_name("sentry_test_unit"),
+                    lib_name("sentry"),
+                    exe_name("sentry-crash"),
                 ]
                 cmd = [
                     os.environ.get("LLVM_COV", "llvm-cov"),
@@ -343,6 +354,14 @@ def configure_llvm_cov(config_cmd: list[str]):
         config_cmd.append(f"-DCMAKE_MODULE_LINKER_FLAGS='{profile_lib}'")
     else:
         flags = "-fprofile-instr-generate -fcoverage-mapping"
+        if os.environ.get("VS_GENERATOR_TOOLSET") == "ClangCL":
+            # clang-cl source-based coverage needs the profile runtime explicitly linked.
+            # The flags above enable instrumentation; the runtime library merges and
+            # writes the raw profile at process exit.
+            profile_lib = "clang_rt.profile-x86_64.lib"
+            config_cmd.append(f"-DCMAKE_EXE_LINKER_FLAGS={profile_lib}")
+            config_cmd.append(f"-DCMAKE_SHARED_LINKER_FLAGS={profile_lib}")
+            config_cmd.append(f"-DCMAKE_MODULE_LINKER_FLAGS={profile_lib}")
     config_cmd.append("-DCMAKE_C_FLAGS='{}'".format(flags))
 
     # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for the GHA runner that builds

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -72,6 +72,17 @@ class CMake:
         os.mkdir(coveragedir)
 
         if "llvm-cov" in os.environ.get("RUN_ANALYZER", ""):
+
+            def exe_name(name):
+                return name + ".exe" if sys.platform == "win32" else name
+
+            def lib_name(name):
+                if sys.platform == "win32":
+                    return name + ".dll"
+                elif sys.platform == "darwin":
+                    return "lib" + name + ".dylib"
+                return "lib" + name + ".so"
+
             for i, (d, _) in enumerate(self.runs.values()):
                 # first merge the raw profiling runs
                 files = [f for f in os.listdir(d) if f.endswith(".profraw")]
@@ -90,11 +101,11 @@ class CMake:
                 # then export lcov from the profiling data, since this needs access
                 # to the object files, we need to do it per-test
                 objects = [
-                    "sentry_example",
-                    "sentry_test_unit",
-                    "libsentry.dylib" if sys.platform == "darwin" else "libsentry.so",
-                    "sentry-crash",
-                    "sentry_early_init",
+                    exe_name("sentry_example"),
+                    exe_name("sentry_test_unit"),
+                    lib_name("sentry"),
+                    exe_name("sentry-crash"),
+                    exe_name("sentry_early_init"),
                 ]
                 cmd = [
                     os.environ.get("LLVM_COV", "llvm-cov"),
@@ -344,6 +355,14 @@ def configure_llvm_cov(config_cmd: list[str]):
         config_cmd.append(f"-DCMAKE_MODULE_LINKER_FLAGS='{profile_lib}'")
     else:
         flags = "-fprofile-instr-generate -fcoverage-mapping"
+        if os.environ.get("VS_GENERATOR_TOOLSET") == "ClangCL":
+            # clang-cl source-based coverage needs the profile runtime explicitly linked.
+            # The flags above enable instrumentation; the runtime library merges and
+            # writes the raw profile at process exit.
+            profile_lib = "clang_rt.profile-x86_64.lib"
+            config_cmd.append(f"-DCMAKE_EXE_LINKER_FLAGS={profile_lib}")
+            config_cmd.append(f"-DCMAKE_SHARED_LINKER_FLAGS={profile_lib}")
+            config_cmd.append(f"-DCMAKE_MODULE_LINKER_FLAGS={profile_lib}")
     config_cmd.append("-DCMAKE_C_FLAGS='{}'".format(flags))
 
     # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for the GHA runner that builds

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -338,6 +338,11 @@ def configure_clang_cl(config_cmd: list[str]):
 
 
 def configure_llvm_cov(config_cmd: list[str]):
+    def cmake_flags(name: str, value: str) -> str:
+        if os.environ.get("VS_GENERATOR_TOOLSET") == "ClangCL":
+            return f"-D{name}={value}"
+        return f"-D{name}='{value}'"
+
     if False and os.environ.get("VS_GENERATOR_TOOLSET") == "ClangCL":
         # for clang-cl in CI we have to use `--coverage` rather than `fprofile-instr-generate` and provide an
         # architecture-specific profiling library for it work:
@@ -363,7 +368,7 @@ def configure_llvm_cov(config_cmd: list[str]):
             config_cmd.append(f"-DCMAKE_EXE_LINKER_FLAGS={profile_lib}")
             config_cmd.append(f"-DCMAKE_SHARED_LINKER_FLAGS={profile_lib}")
             config_cmd.append(f"-DCMAKE_MODULE_LINKER_FLAGS={profile_lib}")
-    config_cmd.append("-DCMAKE_C_FLAGS='{}'".format(flags))
+    config_cmd.append(cmake_flags("CMAKE_C_FLAGS", flags))
 
     # Since we overwrite `CXXFLAGS` below, we must add the experimental library here for the GHA runner that builds
     # sentry-native with LLVM clang for macOS (to run ASAN on macOS) rather than the version coming with XCode.
@@ -378,4 +383,4 @@ def configure_llvm_cov(config_cmd: list[str]):
             + " -L/usr/local/opt/llvm@15/lib/c++ -fexperimental-library -Wno-unused-command-line-argument"
         )
 
-    config_cmd.append("-DCMAKE_CXX_FLAGS='{}'".format(flags))
+    config_cmd.append(cmake_flags("CMAKE_CXX_FLAGS", flags))


### PR DESCRIPTION
Previously, coverage was only measured on Linux and macOS. Adding Windows to the mix increases the total amount of code to measure, including uncovered parts, so the overall coverage decreases slightly.