### PR TITLE
test(crashpad): adjust Windows handler stack size minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
   This specifies the size in KiB of the stack reserved for the crash handler (including hooks like `on_crash` and
   `before_send`) on Windows, Linux, and the `inproc` backend in macOS. Reserving the stack is necessary in case of a
   stack-overflow, where the handler could otherwise no longer execute. This parameter allows users to specify their
-  target stack size in KiB, because some applications might require a different value from our default. This value can
-  be as small as 16KiB (on `crashpad` and `breakpad`) for handlers to work, but we recommend 32KiB as the lower bound
-  on 64-bit systems. **The value should be a multiple of the page size**.
+  target stack size in KiB, because some applications might require a different value from our default. On Windows,
+  this value can be as small as 16KiB with `breakpad` and 24KiB with `crashpad`, but we recommend 32KiB as the lower
+  bound on 64-bit systems. **The value should be a multiple of the page size**.
 
 - `SENTRY_THREAD_STACK_GUARANTEE_FACTOR` (Default: `10`, only for Windows):
   Defines the factor by which the thread's stack reserve must exceed the specified guarantee for the handler.

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -481,7 +481,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     [
         None,  # uses default of 64KiB
         pytest.param(
-            "16",
+            "24",
             marks=pytest.mark.skipif(
                 sys.platform != "win32",
                 reason="handler stack size parameterization tests stack guarantee on windows only",


### PR DESCRIPTION
The Windows stack-overflow integration test is unreliable when Crashpad is given a 16 KiB thread stack guarantee. The failure was most visible in Windows Ninja+sccache jobs and could disappear on retry.

Earlier fixes targeted a different, post-crash race. #1728 made the normal crash test wait for uploads, #1737 and #1870 retried the flaky tests, and #1885 fixed Crashpad's pending-upload synchronization and made the stack-overflow test wait as well. They could not fix this failure because affected processes fail before a dump reaches the upload path.

Instrumentation of Crashpad's Windows unhandled exception filter showed two stable runner states in the original execution and rerun of Actions run [29843274559](https://github.com/getsentry/sentry-native/actions/runs/29843274559). At 16 KiB, successful runs entered the filter with roughly 17-18 KiB remaining. In the failing rerun, every full and bare 16 KiB attempt reached only the minimal entry marker and could not complete the next diagnostic operation.

The same failing runner entered at 24, 32, and 64 KiB with exactly 8 KiB less stack than the earlier run. `SetThreadStackGuarantee` reported the requested value in both states, and removing Sentry's first-chance callback made no difference. This places the variability in Windows' stack-overflow dispatch, before Sentry callbacks and before Crashpad signals or uploads a dump.

Treat 24 KiB as Crashpad's supported Windows minimum so the observed two-page loss still leaves approximately the previously tested 16 KiB budget. Keep Breakpad's documented 16 KiB minimum, the 32 KiB recommendation on 64-bit systems, and the 64 KiB default unchanged. Update the integration matrix to exercise the new Crashpad minimum.