### PR TITLE
test(native): add coverage for max cache items/size/age

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -195,7 +195,14 @@ def run(
         "./{}".format(exe) if sys.platform != "win32" else "{}\\{}.exe".format(cwd, exe)
     ]
     if "asan" in os.environ.get("RUN_ANALYZER", ""):
-        env["ASAN_OPTIONS"] = "detect_leaks=1:detect_invalid_join=0"
+        asan_options = env.get("ASAN_OPTIONS", "")
+        if "detect_leaks" not in asan_options:
+            env["ASAN_OPTIONS"] = ":".join(
+                filter(
+                    None,
+                    [asan_options, "detect_leaks=1:detect_invalid_join=0"],
+                )
+            )
         env["LSAN_OPTIONS"] = "suppressions={}".format(
             os.path.join(sourcedir, "tests", "leaks.txt")
         )
@@ -263,9 +270,9 @@ def run_crash(tmp_path, exe, args, env, **kwargs):
             "handle_sigfpe=0:handle_sigill=0:allow_user_segv_handler=1"
         )
         if asan_opts:
-            env["ASAN_OPTIONS"] = f"{asan_opts}:{asan_signal_opts}"
+            env = dict(env, ASAN_OPTIONS=f"{asan_opts}:{asan_signal_opts}")
         else:
-            env["ASAN_OPTIONS"] = asan_signal_opts
+            env = dict(env, ASAN_OPTIONS=asan_signal_opts)
 
     run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,6 +29,7 @@ SENTRY_VERSION = "0.15.4"
 REPLAY_ID = "deadbeefdeadbeefdeadbeefdeadbeef"
 
 from .assertions import wait_for_daemon as _wait_for_daemon
+from .conditions import is_asan
 
 
 def make_dsn(httpserver, auth="uiaeosnrtdy", id=123456, proxy_host=False):
@@ -241,6 +242,32 @@ def run(
                 cmd=" ".join(cmd), args=" ".join(args)
             )
         ) from None
+
+
+def run_crash(tmp_path, exe, args, env, **kwargs):
+    """
+    Run a crash test.
+
+    When running under ASAN, we configure it to not intercept crash signals
+    so that our native crash handler can run and capture the crash.
+    """
+    # When running under ASAN, disable ASAN's signal handling so our crash
+    # handler can run. ASAN would otherwise intercept SIGSEGV/SIGABRT/etc
+    # and terminate the process before our handler completes.
+    if is_asan:
+        # Preserve existing ASAN_OPTIONS and add signal handling overrides
+        asan_opts = env.get("ASAN_OPTIONS", "")
+        # Disable handling of crash signals so our handler can run
+        asan_signal_opts = (
+            "handle_segv=0:handle_sigbus=0:handle_abort=0:"
+            "handle_sigfpe=0:handle_sigill=0:allow_user_segv_handler=1"
+        )
+        if asan_opts:
+            env["ASAN_OPTIONS"] = f"{asan_opts}:{asan_signal_opts}"
+        else:
+            env["ASAN_OPTIONS"] = asan_signal_opts
+
+    run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
 
 
 def check_output(*args, **kwargs):

--- a/tests/test_integration_cache.py
+++ b/tests/test_integration_cache.py
@@ -154,13 +154,17 @@ def test_cache_max_size(cmake, backend, unreachable_dsn):
             wait_for_daemon=backend == "native",
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
+    else:
+        # flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
 
     # 5 x 4mb
     assert cache_dir.exists()
@@ -215,13 +219,17 @@ def test_cache_max_age(cmake, backend, unreachable_dsn):
             wait_for_daemon=backend == "native",
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
+    else:
+        # flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
 
     # 2,4,6,8,10 days old
     assert cache_dir.exists()
@@ -277,6 +285,13 @@ def test_cache_max_items(cmake, backend, unreachable_dsn):
             wait_for_daemon=backend == "native",
         )
 
+    if backend == "native":
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 6)
+        for f in cache_dir.iterdir():
+            if f.is_file() and f.suffix != ".envelope":
+                with open(f, "r+b") as file:
+                    file.truncate(0)
+
     # flush + cache
     run(
         tmp_path,
@@ -325,13 +340,17 @@ def test_cache_max_items_with_retry(cmake, backend, unreachable_dsn):
             wait_for_daemon=backend == "native",
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 4)
+    else:
+        # flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
     assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 4)
 
     # Pre-populate cache/ with retry-format envelope files

--- a/tests/test_integration_cache.py
+++ b/tests/test_integration_cache.py
@@ -149,7 +149,15 @@ def test_cache_max_size(cmake, backend, unreachable_dsn):
         run_crash(
             tmp_path,
             "sentry_example",
-            ["log", "no-http-retry", "cache-keep", "flush", "crash"],
+            [
+                "log",
+                "no-http-retry",
+                "cache-keep",
+                "flush",
+                "crash",
+                "crash-mode",
+                "native",
+            ],
             env=env,
             wait_for_daemon=backend == "native",
         )
@@ -214,7 +222,15 @@ def test_cache_max_age(cmake, backend, unreachable_dsn):
         run_crash(
             tmp_path,
             "sentry_example",
-            ["log", "no-http-retry", "cache-keep", "flush", "crash"],
+            [
+                "log",
+                "no-http-retry",
+                "cache-keep",
+                "flush",
+                "crash",
+                "crash-mode",
+                "native",
+            ],
             env=env,
             wait_for_daemon=backend == "native",
         )
@@ -280,17 +296,21 @@ def test_cache_max_items(cmake, backend, unreachable_dsn):
         run_crash(
             tmp_path,
             "sentry_example",
-            ["log", "no-http-retry", "cache-keep", "flush", "crash"],
+            [
+                "log",
+                "no-http-retry",
+                "cache-keep",
+                "flush",
+                "crash",
+                "crash-mode",
+                "native",
+            ],
             env=env,
             wait_for_daemon=backend == "native",
         )
 
     if backend == "native":
         assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 6)
-        for f in cache_dir.iterdir():
-            if f.is_file() and f.suffix != ".envelope":
-                with open(f, "r+b") as file:
-                    file.truncate(0)
 
     # flush + cache
     run(
@@ -335,7 +355,7 @@ def test_cache_max_items_with_retry(cmake, backend, unreachable_dsn):
         run_crash(
             tmp_path,
             "sentry_example",
-            ["log", "cache-keep", "flush", "crash"],
+            ["log", "cache-keep", "flush", "crash", "crash-mode", "native"],
             env=env,
             wait_for_daemon=backend == "native",
         )

--- a/tests/test_integration_cache.py
+++ b/tests/test_integration_cache.py
@@ -151,19 +151,16 @@ def test_cache_max_size(cmake, backend, unreachable_dsn):
             "sentry_example",
             ["log", "no-http-retry", "cache-keep", "flush", "crash"],
             env=env,
+            wait_for_daemon=backend == "native",
         )
 
-    if backend == "native":
-        # wait for daemon to cache
-        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
-    else:
-        # re-run to flush + cache
-        run(
-            tmp_path,
-            "sentry_example",
-            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-            env=env,
-        )
+    # flush + cache
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+        env=env,
+    )
 
     # 5 x 4mb
     assert cache_dir.exists()
@@ -215,19 +212,16 @@ def test_cache_max_age(cmake, backend, unreachable_dsn):
             "sentry_example",
             ["log", "no-http-retry", "cache-keep", "flush", "crash"],
             env=env,
+            wait_for_daemon=backend == "native",
         )
 
-    if backend == "native":
-        # wait for daemon to cache
-        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
-    else:
-        # re-run to flush + cache
-        run(
-            tmp_path,
-            "sentry_example",
-            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-            env=env,
-        )
+    # flush + cache
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+        env=env,
+    )
 
     # 2,4,6,8,10 days old
     assert cache_dir.exists()
@@ -280,19 +274,16 @@ def test_cache_max_items(cmake, backend, unreachable_dsn):
             "sentry_example",
             ["log", "no-http-retry", "cache-keep", "flush", "crash"],
             env=env,
+            wait_for_daemon=backend == "native",
         )
 
-    if backend == "native":
-        # wait for daemon to cache
-        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
-    else:
-        # re-run to flush + cache
-        run(
-            tmp_path,
-            "sentry_example",
-            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-            env=env,
-        )
+    # flush + cache
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+        env=env,
+    )
 
     # max 5 items
     assert cache_dir.exists()
@@ -331,19 +322,16 @@ def test_cache_max_items_with_retry(cmake, backend, unreachable_dsn):
             "sentry_example",
             ["log", "cache-keep", "flush", "crash"],
             env=env,
+            wait_for_daemon=backend == "native",
         )
 
-    if backend == "native":
-        # wait for daemon to cache
-        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 4)
-    else:
-        # re-run to flush + cache
-        run(
-            tmp_path,
-            "sentry_example",
-            ["log", "cache-keep", "flush", "no-setup"],
-            env=env,
-        )
+    # flush + cache
+    run(
+        tmp_path,
+        "sentry_example",
+        ["log", "cache-keep", "flush", "no-setup"],
+        env=env,
+    )
     assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 4)
 
     # Pre-populate cache/ with retry-format envelope files

--- a/tests/test_integration_cache.py
+++ b/tests/test_integration_cache.py
@@ -2,8 +2,9 @@ import os
 import time
 import pytest
 
-from . import make_dsn, run
-from .conditions import has_breakpad, has_files, has_http, is_qemu
+from . import make_dsn, run, run_crash
+from .assertions import wait_for, wait_for_file
+from .conditions import has_breakpad, has_files, has_http, has_native, is_qemu
 
 pytestmark = [
     pytest.mark.skipif(not has_files, reason="tests need local filesystem"),
@@ -14,9 +15,9 @@ pytestmark = [
 @pytest.mark.parametrize(
     "cache_args,expect_cache",
     [
-        ([], False),
-        (["cache-keep"], True),
-        (["cache-keep-always"], True),
+        pytest.param([], False, id="none"),
+        pytest.param(["cache-keep"], True, id="offline"),
+        pytest.param(["cache-keep-always"], True, id="always"),
     ],
 )
 @pytest.mark.parametrize(
@@ -65,6 +66,42 @@ def test_cache_keep(cmake, backend, cache_args, expect_cache, unreachable_dsn):
             assert cache_files[0].stem == dmp_files[0].stem
 
 
+@pytest.mark.skipif(
+    not has_native or is_qemu,
+    reason="native backend not available",
+)
+@pytest.mark.parametrize(
+    "cache_args,expect_cache",
+    [
+        pytest.param([], False, id="none"),
+        pytest.param(["cache-keep"], True, id="offline"),
+        pytest.param(["cache-keep-always"], True, id="always"),
+    ],
+)
+def test_cache_keep_native(cmake, cache_args, expect_cache, unreachable_dsn):
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
+    cache_dir = tmp_path / ".sentry-native" / "cache"
+    env = dict(os.environ, SENTRY_DSN=unreachable_dsn)
+
+    run_crash(
+        tmp_path,
+        "sentry_example",
+        ["log", "stdout", "crash"] + cache_args,
+        env=env,
+        wait_for_daemon=not expect_cache,
+    )
+
+    if expect_cache:
+        assert wait_for_file(cache_dir / "*.envelope")
+        cache_files = list(cache_dir.glob("*.envelope"))
+        assert len(cache_files) == 1
+        dmp_files = list(cache_dir.glob("*.dmp"))
+        assert len(dmp_files) == 1
+        assert cache_files[0].stem == dmp_files[0].stem
+    else:
+        assert len(list(cache_dir.glob("*.envelope"))) == 0
+
+
 def test_cache_keep_always(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "inproc"})
     cache_dir = tmp_path.joinpath(".sentry-native/cache")
@@ -95,6 +132,12 @@ def test_cache_keep_always(cmake, httpserver):
                 not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
+        pytest.param(
+            "native",
+            marks=pytest.mark.skipif(
+                not has_native or is_qemu, reason="native backend not available"
+            ),
+        ),
     ],
 )
 def test_cache_max_size(cmake, backend, unreachable_dsn):
@@ -103,24 +146,28 @@ def test_cache_max_size(cmake, backend, unreachable_dsn):
     env = dict(os.environ, SENTRY_DSN=unreachable_dsn)
 
     for i in range(5):
-        run(
+        run_crash(
             tmp_path,
             "sentry_example",
             ["log", "no-http-retry", "cache-keep", "flush", "crash"],
-            expect_failure=True,
             env=env,
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
+    else:
+        # re-run to flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
 
     # 5 x 4mb
     assert cache_dir.exists()
+    assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
     cache_files = list(cache_dir.glob("*.envelope"))
     for f in cache_files:
         with open(f, "r+b") as file:
@@ -149,6 +196,12 @@ def test_cache_max_size(cmake, backend, unreachable_dsn):
                 not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
+        pytest.param(
+            "native",
+            marks=pytest.mark.skipif(
+                not has_native or is_qemu, reason="native backend not available"
+            ),
+        ),
     ],
 )
 def test_cache_max_age(cmake, backend, unreachable_dsn):
@@ -157,24 +210,28 @@ def test_cache_max_age(cmake, backend, unreachable_dsn):
     env = dict(os.environ, SENTRY_DSN=unreachable_dsn)
 
     for i in range(5):
-        run(
+        run_crash(
             tmp_path,
             "sentry_example",
             ["log", "no-http-retry", "cache-keep", "flush", "crash"],
-            expect_failure=True,
             env=env,
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
+    else:
+        # re-run to flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
 
     # 2,4,6,8,10 days old
     assert cache_dir.exists()
+    assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
     cache_files = list(cache_dir.glob("*.envelope"))
     for i, f in enumerate(cache_files):
         mtime = time.time() - ((i + 1) * 2 * 24 * 60 * 60)
@@ -204,6 +261,12 @@ def test_cache_max_age(cmake, backend, unreachable_dsn):
                 not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
+        pytest.param(
+            "native",
+            marks=pytest.mark.skipif(
+                not has_native or is_qemu, reason="native backend not available"
+            ),
+        ),
     ],
 )
 def test_cache_max_items(cmake, backend, unreachable_dsn):
@@ -212,24 +275,28 @@ def test_cache_max_items(cmake, backend, unreachable_dsn):
     env = dict(os.environ, SENTRY_DSN=unreachable_dsn)
 
     for i in range(6):
-        run(
+        run_crash(
             tmp_path,
             "sentry_example",
             ["log", "no-http-retry", "cache-keep", "flush", "crash"],
-            expect_failure=True,
             env=env,
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
+    else:
+        # re-run to flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "no-http-retry", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
 
     # max 5 items
     assert cache_dir.exists()
+    assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 5)
     cache_files = list(cache_dir.glob("*.envelope"))
     assert len(cache_files) == 5
 
@@ -244,6 +311,12 @@ def test_cache_max_items(cmake, backend, unreachable_dsn):
                 not has_breakpad or is_qemu, reason="breakpad backend not available"
             ),
         ),
+        pytest.param(
+            "native",
+            marks=pytest.mark.skipif(
+                not has_native or is_qemu, reason="native backend not available"
+            ),
+        ),
     ],
 )
 def test_cache_max_items_with_retry(cmake, backend, unreachable_dsn):
@@ -253,21 +326,25 @@ def test_cache_max_items_with_retry(cmake, backend, unreachable_dsn):
 
     # Create cache files via crash+restart cycles
     for i in range(4):
-        run(
+        run_crash(
             tmp_path,
             "sentry_example",
             ["log", "cache-keep", "flush", "crash"],
-            expect_failure=True,
             env=env,
         )
 
-    # flush + cache
-    run(
-        tmp_path,
-        "sentry_example",
-        ["log", "cache-keep", "flush", "no-setup"],
-        env=env,
-    )
+    if backend == "native":
+        # wait for daemon to cache
+        assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 4)
+    else:
+        # re-run to flush + cache
+        run(
+            tmp_path,
+            "sentry_example",
+            ["log", "cache-keep", "flush", "no-setup"],
+            env=env,
+        )
+    assert wait_for(lambda: len(list(cache_dir.glob("*.envelope"))) == 4)
 
     # Pre-populate cache/ with retry-format envelope files
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -363,3 +440,50 @@ def test_cache_consent_flush(cmake, httpserver):
 
     assert len(httpserver.log) >= 1
     assert not cache_dir.exists() or len(list(cache_dir.glob("*.envelope"))) == 0
+
+
+@pytest.mark.skipif(
+    not has_native or is_qemu,
+    reason="native backend not available",
+)
+def test_cache_consent_native(cmake, httpserver):
+    """Daemon honors revoked consent for crash envelopes."""
+    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
+    cache_dir = tmp_path / ".sentry-native" / "cache"
+    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+
+    run_crash(
+        tmp_path,
+        "sentry_example",
+        [
+            "log",
+            "stdout",
+            "cache-keep",
+            "http-retry",
+            "require-user-consent",
+            "user-consent-revoke",
+            "crash",
+        ],
+        env=env,
+    )
+
+    assert wait_for_file(cache_dir / "*.envelope")
+    assert len(list(cache_dir.glob("*.envelope"))) == 1
+    assert len(httpserver.log) == 0
+
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data("OK")
+    with httpserver.wait(timeout=10) as waiting:
+        run(
+            tmp_path,
+            "sentry_example",
+            [
+                "log",
+                "cache-keep",
+                "http-retry",
+                "require-user-consent",
+                "user-consent-give",
+            ],
+            env=env,
+        )
+    assert waiting.result
+    assert len(list(cache_dir.glob("*.envelope"))) == 0

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -18,6 +18,7 @@ from . import (
     is_replay_envelope,
     make_dsn,
     run,
+    run_crash,
     stage_replay,
     Envelope,
     split_log_request_cond,
@@ -44,32 +45,6 @@ pytestmark = pytest.mark.skipif(
 # Sanitizer builds are slower, so selected native crash tests use the same 10s
 # timeout the native daemon used before it respected the SDK shutdown timeout.
 SANITIZER_ARGS = ["shutdown-timeout", "10000"] if is_asan or is_tsan else []
-
-
-def run_crash(tmp_path, exe, args, env, **kwargs):
-    """
-    Run a crash test.
-
-    When running under ASAN, we configure it to not intercept crash signals
-    so that our native crash handler can run and capture the crash.
-    """
-    # When running under ASAN, disable ASAN's signal handling so our crash
-    # handler can run. ASAN would otherwise intercept SIGSEGV/SIGABRT/etc
-    # and terminate the process before our handler completes.
-    if is_asan:
-        # Preserve existing ASAN_OPTIONS and add signal handling overrides
-        asan_opts = env.get("ASAN_OPTIONS", "")
-        # Disable handling of crash signals so our handler can run
-        asan_signal_opts = (
-            "handle_segv=0:handle_sigbus=0:handle_abort=0:"
-            "handle_sigfpe=0:handle_sigill=0:allow_user_segv_handler=1"
-        )
-        if asan_opts:
-            env["ASAN_OPTIONS"] = f"{asan_opts}:{asan_signal_opts}"
-        else:
-            env["ASAN_OPTIONS"] = asan_signal_opts
-
-    run(tmp_path, exe, args, expect_failure=True, env=env, **kwargs)
 
 
 def test_native_capture_crash(cmake, httpserver):
@@ -1050,79 +1025,6 @@ def test_crash_mode_native_with_minidump(cmake, httpserver):
     assert "debug_meta" in event
     if sys.platform == "darwin":
         assert_debug_meta_images_do_not_overlap(event)
-
-
-def test_native_cache_consent(cmake, httpserver):
-    """Daemon honors revoked consent: envelope is cached, not sent. Giving
-    consent in a subsequent run flushes the cached envelope."""
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
-    cache_dir = tmp_path / ".sentry-native" / "cache"
-    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
-
-    # 1) Crash while consent is revoked. Envelope is cached, no upload.
-    run_crash(
-        tmp_path,
-        "sentry_example",
-        [
-            "log",
-            "stdout",
-            "cache-keep",
-            "http-retry",
-            "require-user-consent",
-            "user-consent-revoke",
-            "crash",
-        ],
-        env=env,
-    )
-
-    assert wait_for_file(cache_dir / "*.envelope")
-    assert len(list(cache_dir.glob("*.envelope"))) == 1
-    assert len(httpserver.log) == 0
-
-    # 2) Give consent. The cached envelope should be flushed to the server.
-    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data("OK")
-    with httpserver.wait(timeout=10) as waiting:
-        run(
-            tmp_path,
-            "sentry_example",
-            [
-                "log",
-                "cache-keep",
-                "http-retry",
-                "require-user-consent",
-                "user-consent-give",
-            ],
-            env=env,
-        )
-    assert waiting.result
-    assert len(list(cache_dir.glob("*.envelope"))) == 0
-
-
-@pytest.mark.parametrize("cache_keep", [True, False])
-def test_native_cache_keep(cmake, cache_keep, unreachable_dsn):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
-    db_dir = tmp_path / ".sentry-native"
-    cache_dir = db_dir / "cache"
-    env = dict(os.environ, SENTRY_DSN=unreachable_dsn)
-
-    # crash -> daemon sends via HTTP -> unreachable -> cache
-    run_crash(
-        tmp_path,
-        "sentry_example",
-        ["log", "stdout", "crash"] + (["cache-keep"] if cache_keep else []),
-        env=env,
-        wait_for_daemon=not cache_keep,
-    )
-
-    if cache_keep:
-        assert wait_for_file(cache_dir / "*.envelope")
-        cache_files = list(cache_dir.glob("*.envelope"))
-        assert len(cache_files) == 1
-        dmp_files = list(cache_dir.glob("*.dmp"))
-        assert len(dmp_files) == 1
-        assert cache_files[0].stem == dmp_files[0].stem
-    else:
-        assert len(list(cache_dir.glob("*.envelope"))) == 0
 
 
 def test_native_restart_on_crash(cmake, httpserver):


### PR DESCRIPTION
- Parameterizes `test_integration_cache.py` for the native backend to add missing native coverage for cache max size, max age, max items, and retry item limits.
- Moves the remaining cache tests from `test_integration_native.py` to `test_integration_cache.py`.
- Promotes the `run_crash` helper for reuse outside `test_integration_native.py`.