### PR TITLE
fix(crashpad): terminate Linux handler re-entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix scope data loss from shared `sentry_value_t` containers while significantly improving scope merge performance with copy-on-write cloning. ([#1794](https://github.com/getsentry/sentry-native/pull/1794))
 - Fix a memory leak when JSON parsing rejects invalid input after partially parsed value. ([#1887](https://github.com/getsentry/sentry-native/pull/1887))
 - Crashpad: wait reliably for crash report uploads. ([#1885](https://github.com/getsentry/sentry-native/pull/1885))
+- Crashpad/Linux: terminate Linux handler re-entry. ([#1894](https://github.com/getsentry/sentry-native/pull/1894))
 
 ## 0.15.4
 

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -368,7 +368,14 @@ flush_scope_from_handler(
     auto state = static_cast<crashpad_state_t *>(options->backend->data);
 
     // this blocks any further calls to `crashpad_backend_flush_scope`
-    state->crashed.store(true, std::memory_order_relaxed);
+    if (state->crashed.exchange(true, std::memory_order_relaxed)) {
+#    ifdef SENTRY_PLATFORM_LINUX
+        // Re-entry cannot flush again because the flush lock is never released
+        // after a crash. PID 1 can hit this when it survives crashpad's
+        // default-signal re-raise.
+        _exit(EXIT_FAILURE);
+#    endif
+    }
 
     // busy-wait until any in-progress scope flushes are finished
     bool expected = false;


### PR DESCRIPTION
Crashpad expects the crashing process to terminate after it restores the default signal handler and re-raises the crash signal. Linux PID namespace init processes can survive that default-disposition signal, which lets glibc abort fall through into a second fault.

That second signal re-enters the handler after the first pass has acquired the scope flush lock. The lock is intentionally never released after a crash, so the second pass spins forever trying to acquire it.

Use the existing crashed flag as a re-entry guard. On Linux, terminate with `_exit()` before trying to flush again.

The hang was reproduced locally in a Docker container by running the crashpad example as PID 1 without an init process.

Close: #1893
