### PR TITLE
fix(native): let WER finish native crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Crashpad/Windows: flush Windows attachment IPC responses. ([#1895](https://github.com/getsentry/sentry-native/pull/1895))
 - Crashpad/Linux: terminate Linux handler re-entry. ([#1894](https://github.com/getsentry/sentry-native/pull/1894))
 - Android: create the outbox directory before writing NDK crash envelopes into it, so envelopes are not lost when the head SDK creates the outbox lazily. ([#1889](https://github.com/getsentry/sentry-native/pull/1889))
+- Native/Windows: let WER finish native crash reports to preserve WER custom metadata. ([#1904](https://github.com/getsentry/sentry-native/pull/1904))
 
 ## 0.15.4
 

--- a/src/backends/native/sentry_wer.c
+++ b/src/backends/native/sentry_wer.c
@@ -161,8 +161,8 @@ process_wer_exception(
                 }
                 Sleep(SENTRY_CRASH_HANDLER_POLL_INTERVAL_MS);
             }
-            TerminateProcess(exception_info->hProcess,
-                exception_info->exceptionRecord.ExceptionCode);
+            // Return control to WER so it can finish report generation,
+            // including custom metadata registered by the crashed process.
         }
     }
 

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -163,6 +163,14 @@ def assert_event_meta(
     if sdk_override is not None:
         expected_sdk["name"] = sdk_override
 
+    # ignore e2e test tags
+    event = event.copy()
+    event["tags"] = {
+        key: value
+        for key, value in event["tags"].items()
+        if not key.startswith("test.")
+    }
+
     assert_matches(event, expected)
     assert event["user"]["username"] == "some_name"
     assert INSTALLATION_ID_RE.match(event["user"]["id"])

--- a/tests/test_integration_wer.py
+++ b/tests/test_integration_wer.py
@@ -8,8 +8,16 @@ from pathlib import Path
 
 import pytest
 
-from . import run
-from .assertions import wait_for
+from . import Envelope, make_dsn, run
+from .assertions import (
+    assert_breakpad_crash,
+    assert_crashpad_upload,
+    assert_event_meta,
+    assert_inproc_crash,
+    assert_minidump,
+    assert_native_crash,
+    wait_for,
+)
 from .conditions import has_breakpad, has_crashpad, has_native, is_qemu
 
 pytestmark = [
@@ -115,6 +123,100 @@ def wait_for_wer_report(store, test_id):
     )
 
 
+def assert_sentry_event(httpserver, backend, crash_arg):
+    assert len(httpserver.log) >= 1
+
+    if backend == "crashpad":
+        assert httpserver.log[0][0].path == "/api/123456/minidump/"
+        attachments = assert_crashpad_upload(httpserver.log[0][0])
+        assert attachments.event["event_id"]
+        return
+
+    envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
+    event = envelope.get_event()
+    assert event is not None
+    assert event["event_id"]
+    assert_event_meta(event, integration=backend)
+
+    if backend == "inproc":
+        assert_inproc_crash(envelope)
+    elif backend == "breakpad":
+        assert_minidump(envelope)
+        assert_breakpad_crash(envelope)
+    elif backend == "native":
+        assert_native_crash(envelope)
+
+
+def run_wer_crash(cmake, backend, crash_arg, httpserver=None):
+    build_options = {
+        "SENTRY_BACKEND": backend,
+        "SENTRY_INTEGRATION_WER": "ON",
+    }
+    if httpserver is None:
+        build_options["SENTRY_TRANSPORT"] = "none"
+
+    tmp_path = cmake(
+        ["sentry_example"],
+        build_options,
+    )
+
+    env = None
+    if httpserver is not None:
+        env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+        if backend == "crashpad":
+            httpserver.expect_oneshot_request(
+                "/api/123456/minidump/"
+            ).respond_with_data("OK")
+        else:
+            httpserver.expect_oneshot_request(
+                "/api/123456/envelope/"
+            ).respond_with_data("OK")
+
+    run_args = ["e2e-test", crash_arg]
+    if backend == "crashpad":
+        run_args.append("crashpad-wait-for-upload")
+
+    if httpserver is None:
+        completed = run(
+            tmp_path,
+            "sentry_example",
+            run_args,
+            expect_failure=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    else:
+        with httpserver.wait(timeout=10) as waiting:
+            completed = run(
+                tmp_path,
+                "sentry_example",
+                run_args,
+                expect_failure=True,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            if backend in ("breakpad", "inproc"):
+                run(tmp_path, "sentry_example", ["no-setup"], env=env)
+
+        assert waiting.result
+        assert_sentry_event(httpserver, backend, crash_arg)
+
+    test_id = None
+    for line in completed.stdout.splitlines():
+        if line.startswith("TEST_ID:"):
+            test_id = line.removeprefix("TEST_ID:")
+            break
+    assert test_id, completed.stdout
+
+    report_path, report = wait_for_wer_report(WerStore(), test_id)
+    assert report_path.name == "Report.wer"
+
+    return report
+
+
 @pytest.mark.parametrize(
     "backend",
     [
@@ -127,7 +229,7 @@ def wait_for_wer_report(store, test_id):
                     not has_breakpad or is_qemu, reason="breakpad backend not available"
                 ),
                 pytest.mark.xfail(
-                    reason="breakpad swallows the exception",
+                    reason="breakpad swallows SEH exceptions",
                     strict=True,
                 ),
             ],
@@ -139,7 +241,7 @@ def wait_for_wer_report(store, test_id):
                     not has_crashpad, reason="crashpad backend not available"
                 ),
                 pytest.mark.xfail(
-                    reason="crashpad handler terminates the process",
+                    reason="crashpad terminates the process",
                     strict=True,
                 ),
             ],
@@ -149,39 +251,98 @@ def wait_for_wer_report(store, test_id):
             marks=pytest.mark.skipif(
                 not has_native or is_qemu, reason="native backend not available"
             ),
-            id="native",
         ),
     ],
 )
 def test_wer_custom_metadata(cmake, backend):
-    tmp_path = cmake(
-        ["sentry_example"],
-        {
-            "SENTRY_BACKEND": backend,
-            "SENTRY_TRANSPORT": "none",
-            "SENTRY_INTEGRATION_WER": "ON",
-        },
-    )
+    report = run_wer_crash(cmake, backend, "crash")
 
-    completed = run(
-        tmp_path,
-        "sentry_example",
-        ["e2e-test", "crash"],
-        expect_failure=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
-    test_id = None
-    for line in completed.stdout.splitlines():
-        if line.startswith("TEST_ID:"):
-            test_id = line.removeprefix("TEST_ID:")
-            break
-    assert test_id, completed.stdout
-
-    report_path, report = wait_for_wer_report(WerStore(), test_id)
-    assert report_path.name == "Report.wer"
     assert "expected-tag" in report
     assert "some value" in report
     assert "not-expected-tag" not in report
+
+
+@pytest.mark.parametrize(
+    "backend,crash_arg",
+    [
+        pytest.param("inproc", "crash"),
+        pytest.param(
+            "inproc",
+            "fastfail",
+            marks=pytest.mark.xfail(
+                reason="inproc does not capture WER exceptions",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "breakpad",
+            "crash",
+            marks=[
+                pytest.mark.skipif(
+                    not has_breakpad or is_qemu, reason="breakpad backend not available"
+                ),
+                pytest.mark.xfail(
+                    reason="breakpad swallows SEH exceptions",
+                    strict=True,
+                ),
+            ],
+        ),
+        pytest.param(
+            "breakpad",
+            "fastfail",
+            marks=[
+                pytest.mark.skipif(
+                    not has_breakpad or is_qemu, reason="breakpad backend not available"
+                ),
+                pytest.mark.xfail(
+                    reason="breakpad does not capture WER exceptions",
+                    strict=True,
+                ),
+            ],
+        ),
+        pytest.param(
+            "crashpad",
+            "crash",
+            marks=[
+                pytest.mark.skipif(
+                    not has_crashpad, reason="crashpad backend not available"
+                ),
+                pytest.mark.xfail(
+                    reason="crashpad terminates the process",
+                    strict=True,
+                ),
+            ],
+        ),
+        pytest.param(
+            "crashpad",
+            "fastfail",
+            marks=[
+                pytest.mark.skipif(
+                    not has_crashpad, reason="crashpad backend not available"
+                ),
+                pytest.mark.xfail(
+                    reason="crashpad terminates the process",
+                    strict=True,
+                ),
+            ],
+        ),
+        pytest.param(
+            "native",
+            "crash",
+            marks=pytest.mark.skipif(
+                not has_native or is_qemu, reason="native backend not available"
+            ),
+        ),
+        pytest.param(
+            "native",
+            "fastfail",
+            marks=pytest.mark.skipif(
+                not has_native or is_qemu, reason="native backend not available"
+            ),
+        ),
+    ],
+)
+def test_wer_compatibility(cmake, httpserver, backend, crash_arg):
+    report = run_wer_crash(cmake, backend, crash_arg, httpserver)
+
+    assert "test.id" in report.lower()


### PR DESCRIPTION
The native WER runtime exception callback previously terminated the crashed process after signaling the native daemon. That made sense for the original WER capture path: once the callback claimed ownership and the daemon had been notified, terminating the process ensured the crash was finalized even when the crashed thread did not return normally.

However, terminating from the callback prevents WER from completing its normal report generation. In particular, `Report.wer` can be written without custom metadata registered by the crashed process, so Sentry's WER integration tags are missing from native fast-fail reports.

Keep claiming ownership and keep waiting for daemon processing, but return control to WER afterwards. This lets WER complete the report, including registered custom metadata, while the native daemon still captures and uploads the Sentry crash event.

Add `test_wer_compatibility` documenting which backends allow WER to see SEH and fast-fail crashes alongside Sentry capture:

```cmd
>pytest --with_wer -k wer -v tests\
...
tests/test_integration_crashpad.py::test_crashpad_wer_crash[run_args0] PASSED
tests/test_integration_crashpad.py::test_crashpad_wer_crash[run_args1] PASSED
tests/test_integration_crashpad.py::test_crashpad_wer_crash[run_args2] PASSED
tests/test_integration_crashpad.py::test_crashpad_wer_crash[run_args3] PASSED
tests/test_integration_crashpad.py::test_crashpad_wer_crash[run_args4] PASSED
tests/test_integration_crashpad.py::test_crashpad_wer_crash[run_args5] PASSED
tests/test_integration_crashpad.py::test_crashpad_external_crash_reporter_wer[run_args0] PASSED
tests/test_integration_native.py::test_native_wer_crash[fastfail] PASSED
tests/test_integration_native.py::test_native_wer_crash[stack-buffer-overrun] PASSED
tests/test_integration_screenshot.py::test_capture_screenshot_crashpad_wer[run_args0] PASSED
tests/test_integration_wer.py::test_wer_custom_metadata[none] PASSED
tests/test_integration_wer.py::test_wer_custom_metadata[inproc] PASSED
tests/test_integration_wer.py::test_wer_custom_metadata[breakpad] XFAIL (breakpad swallows SEH exceptions)
tests/test_integration_wer.py::test_wer_custom_metadata[crashpad] XFAIL (crashpad terminates the process)
tests/test_integration_wer.py::test_wer_custom_metadata[native] PASSED
tests/test_integration_wer.py::test_wer_compatibility[inproc-crash] PASSED
tests/test_integration_wer.py::test_wer_compatibility[inproc-fastfail] XFAIL (inproc does not capture WER exceptions)
tests/test_integration_wer.py::test_wer_compatibility[breakpad-crash] XFAIL (breakpad swallows SEH exceptions)
tests/test_integration_wer.py::test_wer_compatibility[breakpad-fastfail] XFAIL (breakpad does not capture WER exceptions)
tests/test_integration_wer.py::test_wer_compatibility[crashpad-crash] XFAIL (crashpad terminates the process)
tests/test_integration_wer.py::test_wer_compatibility[crashpad-fastfail] XFAIL (crashpad terminates the process)
tests/test_integration_wer.py::test_wer_compatibility[native-crash] PASSED
tests/test_integration_wer.py::test_wer_compatibility[native-fastfail] PASSED
```