### PR TITLE
fix(native): write snapshot thread names in macOS minidump fallback path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Crashpad/Windows: flush Windows attachment IPC responses. ([#1895](https://github.com/getsentry/sentry-native/pull/1895))
 - Crashpad/Linux: terminate Linux handler re-entry. ([#1894](https://github.com/getsentry/sentry-native/pull/1894))
 - Android: create the outbox directory before writing NDK crash envelopes into it, so envelopes are not lost when the head SDK creates the outbox lazily. ([#1889](https://github.com/getsentry/sentry-native/pull/1889))
+- Native/macOS: write signal-handler-captured thread names into the minidump's ThreadNames stream when `task_for_pid` fails (e.g. sandboxed apps), so thread names resolve in crash events from packaged apps. ([#1905](https://github.com/getsentry/sentry-native/pull/1905))
 
 ## 0.15.4
 

--- a/src/backends/native/minidump/sentry_minidump_macos.c
+++ b/src/backends/native/minidump/sentry_minidump_macos.c
@@ -850,10 +850,9 @@ write_thread_list_stream(minidump_writer_t *writer, minidump_directory_t *dir)
  * `pth_name[64]` field set by pthread_setname_np(). This works cross-process,
  * so we can use it from the daemon as long as we have a valid task port.
  *
- * Fallback path (no task_for_pid): the signal-handler-captured snapshot in
- * ``ctx->platform.threads[]`` does not currently include names, so those
- * entries get an empty string — but the stream is still emitted with the
- * correct tid list so consumers see a non-empty thread_names list.
+ * Fallback path (no task_for_pid, e.g. sandboxed apps where the daemon
+ * inherits the sandbox): uses the names the signal handler snapshotted into
+ * ``ctx->platform.threads[].name`` via THREAD_EXTENDED_INFO at crash time.
  */
 static int
 write_thread_names_stream(minidump_writer_t *writer, minidump_directory_t *dir)
@@ -941,18 +940,18 @@ write_thread_names_stream(minidump_writer_t *writer, minidump_directory_t *dir)
         }
         for (uint32_t i = 0; i < thread_count; i++) {
             uint32_t tid = 0;
+            const char *name = "";
             if (i < num_captured) {
-                tid = (uint32_t)writer->crash_ctx->platform.threads[i].tid;
+                const sentry_thread_context_darwin_t *snapshot
+                    = &writer->crash_ctx->platform.threads[i];
+                tid = (uint32_t)snapshot->tid;
+                name = snapshot->name;
             } else if (writer->crash_ctx) {
-                // Last-resort single-thread path.
+                // Last-resort single-thread path, no name available.
                 tid = writer->crash_ctx->crashed_tid;
             }
             name_tids[i] = tid;
-            // No names are captured in the signal handler on macOS today, so
-            // emit an empty string. The stream is still useful: consumers can
-            // see the tid list, and the absence of names is consistent with
-            // "we couldn't task_for_pid and didn't snapshot names".
-            name_rvas[i] = write_minidump_string(writer, "");
+            name_rvas[i] = write_minidump_string(writer, name);
             if (!name_rvas[i]) {
                 sentry_free(name_rvas);
                 sentry_free(name_tids);


### PR DESCRIPTION
This PR fixes missing thread names in crash events reported from macOS apps where the daemon cannot acquire the crashed process's task port.

When writing the minidump, the daemon first tries `task_for_pid()` to read thread names cross-process via `thread_info(THREAD_EXTENDED_INFO)`. That call fails for sandboxed apps (the daemon is spawned with `posix_spawn` and inherits the sandbox) and for any target lacking the `get-task-allow` entitlement (i.e. for UE packaged/signed games it always fails, and the writer falls back to the signal-handler snapshot).

The fallback path in `write_thread_names_stream()` still hardcoded an empty string for every entry, a leftover from before #1766 - the signal handler has been capturing names into `ctx->platform.threads[].name` since then, but the minidump writer was never updated to use them. Since Sentry rebuilds the event's thread list from the minidump whenever an `event.minidump` attachment is present (discarding the SDK-provided thread list, which does carry the names), the resulting issue showed all threads without names while crashes captured from non-sandboxed processes (e.g. in the Unreal editor), where `task_for_pid()` succeeds, showed them fine.

The fix populates the ThreadNames stream (type 24) from the snapshot in the fallback path. The last-resort single-thread path (no snapshot at all) keeps emitting an empty string, as no name is available there.

Example events (Unreal Engine sample app, packaged macOS build):
- [Before (no thread names)](https://sentry-sdks.sentry.io/issues/7523496378/events/f16ee0c198c644ddb034975881facd04/)
- [After (thread names resolved)](https://sentry-sdks.sentry.io/issues/7523496378/events/0ce7bcdf226544f1df952966d831950a/)