### PR TITLE
fix(native): Disable debug logs when debug flag is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Crashpad/Linux: terminate Linux handler re-entry. ([#1894](https://github.com/getsentry/sentry-native/pull/1894))
 - Android: create the outbox directory before writing NDK crash envelopes into it, so envelopes are not lost when the head SDK creates the outbox lazily. ([#1889](https://github.com/getsentry/sentry-native/pull/1889))
 - Native/macOS: write signal-handler-captured thread names into the minidump's ThreadNames stream when `task_for_pid` fails (e.g. sandboxed apps), so thread names resolve in crash events from packaged apps. ([#1905](https://github.com/getsentry/sentry-native/pull/1905))
-- Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1910](https://github.com/getsentry/sentry-native/issues/1910))
+- Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1910](https://github.com/getsentry/sentry-native/pull/1910))
 
 ## 0.15.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Crashpad/Linux: terminate Linux handler re-entry. ([#1894](https://github.com/getsentry/sentry-native/pull/1894))
 - Android: create the outbox directory before writing NDK crash envelopes into it, so envelopes are not lost when the head SDK creates the outbox lazily. ([#1889](https://github.com/getsentry/sentry-native/pull/1889))
 - Native/macOS: write signal-handler-captured thread names into the minidump's ThreadNames stream when `task_for_pid` fails (e.g. sandboxed apps), so thread names resolve in crash events from packaged apps. ([#1905](https://github.com/getsentry/sentry-native/pull/1905))
-- Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1908](https://github.com/getsentry/sentry-native/issues/1908))
+- Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1910](https://github.com/getsentry/sentry-native/issues/1910))
 
 ## 0.15.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Crashpad/Linux: terminate Linux handler re-entry. ([#1894](https://github.com/getsentry/sentry-native/pull/1894))
 - Android: create the outbox directory before writing NDK crash envelopes into it, so envelopes are not lost when the head SDK creates the outbox lazily. ([#1889](https://github.com/getsentry/sentry-native/pull/1889))
 - Native/macOS: write signal-handler-captured thread names into the minidump's ThreadNames stream when `task_for_pid` fails (e.g. sandboxed apps), so thread names resolve in crash events from packaged apps. ([#1905](https://github.com/getsentry/sentry-native/pull/1905))
+- Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1908](https://github.com/getsentry/sentry-native/issues/1908))
 
 ## 0.15.4
 

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -600,7 +600,7 @@ native_backend_shutdown(sentry_backend_t *backend)
     // This bypasses the SDK logger and writes straight to stderr, so it must
     // only run when debug logging was enabled. When debug is off the daemon
     // keeps logging to its file (at INFO level), but we stay silent on stderr
-    // rather than spamming the terminal on shutdown (see #1908).
+    // rather than spamming the terminal on shutdown.
     if (state->ipc && state->ipc->shmem && state->ipc->shmem->debug_enabled) {
         char log_path[SENTRY_CRASH_MAX_PATH];
         int log_path_len = -1;

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -596,9 +596,12 @@ native_backend_shutdown(sentry_backend_t *backend)
     }
 #endif
 
-    // Dump daemon log file for debugging (especially useful in CI)
-    // Use same naming as shared memory to find the correct log file
-    if (state->ipc && state->ipc->shmem) {
+    // Dump daemon log file for debugging (especially useful in CI).
+    // This bypasses the SDK logger and writes straight to stderr, so it must
+    // only run when debug logging was enabled. When debug is off the daemon
+    // keeps logging to its file (at INFO level), but we stay silent on stderr
+    // rather than spamming the terminal on shutdown (see #1908).
+    if (state->ipc && state->ipc->shmem && state->ipc->shmem->debug_enabled) {
         char log_path[SENTRY_CRASH_MAX_PATH];
         int log_path_len = -1;
 


### PR DESCRIPTION
* Disable debug logs when debug flag is not set

Fixes: https://github.com/getsentry/sentry-native/issues/1908