### PR TITLE
fix: apply default thread stack guarantee in static builds and the native backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1910](https://github.com/getsentry/sentry-native/pull/1910))
 - Native/Windows: capture heap corruption crashes reported as `STATUS_HEAP_CORRUPTION` (`0xC0000374`). ([#1909](https://github.com/getsentry/sentry-native/pull/1909))
 - Native/Linux: add support for `sentry_options_set_handler_strategy(SENTRY_HANDLER_STRATEGY_CHAIN_AT_START)`. ([#1912](https://github.com/getsentry/sentry-native/pull/1912))
+- Windows: apply the default thread stack guarantee in static builds - kernel32 functions are now cached before backend startup, so `sentry__set_default_thread_stack_guarantee()` no longer silently no-ops. ([#1918](https://github.com/getsentry/sentry-native/pull/1918))
+- Native/Windows: set the default thread stack guarantee during backend startup, matching the other backends, so crash handling can run after a stack overflow. ([#1918](https://github.com/getsentry/sentry-native/pull/1918))
 
 ## 0.15.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@
 - Native: don't dump the crash daemon's log to `stderr` on shutdown unless debug logging is enabled, so terminal applications stay quiet when `debug` is off. ([#1910](https://github.com/getsentry/sentry-native/pull/1910))
 - Native/Windows: capture heap corruption crashes reported as `STATUS_HEAP_CORRUPTION` (`0xC0000374`). ([#1909](https://github.com/getsentry/sentry-native/pull/1909))
 - Native/Linux: add support for `sentry_options_set_handler_strategy(SENTRY_HANDLER_STRATEGY_CHAIN_AT_START)`. ([#1912](https://github.com/getsentry/sentry-native/pull/1912))
-- Windows: apply the default thread stack guarantee in static builds - kernel32 functions are now cached before backend startup, so `sentry__set_default_thread_stack_guarantee()` no longer silently no-ops. ([#1918](https://github.com/getsentry/sentry-native/pull/1918))
-- Native/Windows: set the default thread stack guarantee during backend startup, matching the other backends, so crash handling can run after a stack overflow. ([#1918](https://github.com/getsentry/sentry-native/pull/1918))
+- Windows: the default thread stack guarantee is now actually applied in static builds and is also set by the native backend, so crash handling can run after a stack overflow. ([#1918](https://github.com/getsentry/sentry-native/pull/1918))
 
 ## 0.15.4
 

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -191,6 +191,11 @@ native_backend_startup(
                 "development.");
     SENTRY_DEBUG("starting native backend");
 
+#if defined(SENTRY_PLATFORM_WINDOWS) && !defined(SENTRY_BUILD_SHARED)          \
+    && defined(SENTRY_THREAD_STACK_GUARANTEE_AUTO_INIT)
+    sentry__set_default_thread_stack_guarantee();
+#endif
+
 #if defined(SENTRY_PLATFORM_WINDOWS)
     // Create process-wide mutex for IPC synchronization (Windows)
     // Use portable mutex to protect Windows mutex creation

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -209,6 +209,14 @@ sentry_init(sentry_options_t *options)
 
     uint64_t last_crash = 0;
 
+#if defined(SENTRY_PLATFORM_WINDOWS)                                           \
+    && (!defined(SENTRY_BUILD_SHARED) || defined(SENTRY_PLATFORM_XBOX))
+    // This must run before backend startup so that dependents on its cached
+    // functions (e.g. the default thread stack guarantee set during backend
+    // startup) actually work.
+    sentry__init_cached_kernel32_functions();
+#endif
+
     // and then we will start the backend, since it requires a valid run
     sentry_backend_t *backend = options->backend;
     if (backend && backend->startup_func) {
@@ -252,13 +260,6 @@ sentry_init(sentry_options_t *options)
     if (backend && backend->user_consent_changed_func) {
         backend->user_consent_changed_func(backend);
     }
-
-#if defined(SENTRY_PLATFORM_WINDOWS)                                           \
-    && (!defined(SENTRY_BUILD_SHARED) || defined(SENTRY_PLATFORM_XBOX))
-    // This function must be positioned so that any dependents on its cached
-    // functions are invoked after it.
-    sentry__init_cached_kernel32_functions();
-#endif
 
     // after initializing the transport, we will submit all the unsent envelopes
     // and handle remaining sessions.

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -211,9 +211,8 @@ sentry_init(sentry_options_t *options)
 
 #if defined(SENTRY_PLATFORM_WINDOWS)                                           \
     && (!defined(SENTRY_BUILD_SHARED) || defined(SENTRY_PLATFORM_XBOX))
-    // This must run before backend startup so that dependents on its cached
-    // functions (e.g. the default thread stack guarantee set during backend
-    // startup) actually work.
+    // This function must be positioned so that any dependents on its cached
+    // functions are invoked after it.
     sentry__init_cached_kernel32_functions();
 #endif
 


### PR DESCRIPTION
Two related issues prevented the Windows thread stack guarantee from protecting crash handling after a stack overflow:

1. **Static builds never applied the guarantee on any backend.** In static builds, `sentry_init` cached the required kernel32 function pointers (`GetCurrentThreadStackLimits`, `SetThreadStackGuarantee`) *after* backend startup. `sentry__set_default_thread_stack_guarantee()`, called from the crashpad/breakpad/inproc backend startup, checks those pointers first and silently returns when they are `NULL` - so no thread ever got a stack guarantee, and `SENTRY_HANDLER_STACK_SIZE` had no effect. This PR moves the caching before backend startup.

2. **The native backend never requested a guarantee at all.** Unlike crashpad/breakpad/inproc, `native_backend_startup` had no `sentry__set_default_thread_stack_guarantee()` call. Its in-process exception filter does substantially more work on the crashing thread than crashpad's client filter, so running without a guarantee makes stack-overflow capture especially unreliable. This PR adds the same guarded call the other backends use.

### Related items

- https://github.com/getsentry/sentry-unreal/pull/1496