### PR TITLE
fix(docker): expand PIPX_BIN_DIR when adding it to PATH

### DIFF
--- a/.github/docker/alpine/Dockerfile
+++ b/.github/docker/alpine/Dockerfile
@@ -59,4 +59,4 @@ ENV PIPX_BIN_DIR=/opt/pipx_bin
 ENV PIPX_HOME=/opt/pipx
 RUN python3 -m pip install pipx
 RUN python3 -m pipx ensurepath
-ENV PATH="PIPX_BIN_DIR:$PATH"
+ENV PATH="${PIPX_BIN_DIR}:$PATH"


### PR DESCRIPTION
The Alpine Dockerfile currently adds the literal string `PIPX_BIN_DIR` to `PATH`, so executables installed by pipx into `/opt/pipx_bin` are not discoverable.

Expand the existing environment variable when constructing `PATH`.

#skip-changelog