### PR TITLE
ref(batcher): name dedicated batcher threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add `sentry_scope_remove_fingerprint` to remove a fingerprint set on a scope, matching the global `sentry_remove_fingerprint`. ([#1932](https://github.com/getsentry/sentry-native/pull/1932))
 - Add `sentry_options_set_before_send_feedback` to filter or enrich user feedback. Feedback does not go through `before_send`. ([#1923](https://github.com/getsentry/sentry-native/pull/1923))
 
+**Fixes**:
+
+- Name `sentry-logs` and `sentry-metrics` telemetry batcher threads so they can be identified in debuggers, profilers, and crash reports. ([#1937](https://github.com/getsentry/sentry-native/pull/1937))
+
 ## 0.16.1
 
 **Features**:

--- a/src/sentry_batcher.c
+++ b/src/sentry_batcher.c
@@ -2,12 +2,14 @@
 #include "sentry_alloc.h"
 #include "sentry_cpu_relax.h"
 #include "sentry_options.h"
+#include "sentry_string.h"
 #include "sentry_utils.h"
 
 // The batcher thread sleeps for this interval between flush cycles.
 // When the timer fires and there are items in the buffer, they are flushed
 // regardless of how recently they were enqueued.
 #define SENTRY_BATCHER_FLUSH_INTERVAL_MS 5000
+#define SENTRY_BATCHER_THREAD_NAME "sentry-batcher"
 
 #ifdef SENTRY_UNITTEST
 #    ifdef SENTRY_PLATFORM_WINDOWS
@@ -20,8 +22,7 @@
 #endif
 
 sentry_batcher_t *
-sentry__batcher_new(
-    sentry_batch_func_t batch_func, sentry_data_category_t data_category)
+sentry__batcher_new(sentry_batch_func_t batch_func)
 {
     sentry_batcher_t *batcher = SENTRY_MAKE(sentry_batcher_t);
     if (!batcher) {
@@ -29,7 +30,6 @@ sentry__batcher_new(
     }
     batcher->refcount = 1;
     batcher->batch_func = batch_func;
-    batcher->data_category = data_category;
     batcher->thread_state = (long)SENTRY_BATCHER_THREAD_STOPPED;
     sentry__waitable_flag_init(&batcher->request_flush);
     sentry__thread_init(&batcher->batching_thread);
@@ -59,9 +59,22 @@ sentry__batcher_release(sentry_batcher_t *batcher)
     for (long i = 0; i < SENTRY_BATCHER_BUFFER_COUNT; i++) {
         buffer_drain(&batcher->buffers[i]);
     }
+    sentry_free(batcher->thread_name);
     sentry__dsn_decref(batcher->dsn);
     sentry__thread_free(&batcher->batching_thread);
     sentry_free(batcher);
+}
+
+void
+sentry__batcher_set_category(sentry_batcher_t *batcher,
+    sentry_data_category_t data_category, const char *thread_name)
+{
+    if (!batcher) {
+        return;
+    }
+    batcher->data_category = data_category;
+    sentry_free(batcher->thread_name);
+    batcher->thread_name = sentry__string_clone(thread_name);
 }
 
 static inline void
@@ -321,7 +334,10 @@ SENTRY_THREAD_FN
 batcher_thread_func(void *data)
 {
     sentry_batcher_t *batcher = data;
-    SENTRY_DEBUG("Starting batching thread");
+    const char *thread_name = batcher->thread_name ? batcher->thread_name
+                                                   : SENTRY_BATCHER_THREAD_NAME;
+    sentry__thread_setname(sentry__current_thread(), thread_name);
+    SENTRY_DEBUGF("Starting %s thread", thread_name);
 
     // Transition from STARTING to RUNNING using compare-and-swap
     // CAS ensures atomic state verification: only succeeds if state is STARTING

--- a/src/sentry_batcher.h
+++ b/src/sentry_batcher.h
@@ -50,6 +50,7 @@ typedef struct {
     sentry_threadid_t batching_thread; // the batching thread
     sentry_batch_func_t batch_func; // function to add items to envelope
     sentry_data_category_t data_category; // for client report discard tracking
+    char *thread_name;
     sentry_dsn_t *dsn;
     sentry_transport_t *transport;
     sentry_run_t *run;
@@ -62,8 +63,9 @@ typedef struct {
 
 #define SENTRY_BATCHER_REF_INIT { NULL, 0 }
 
-sentry_batcher_t *sentry__batcher_new(
-    sentry_batch_func_t batch_func, sentry_data_category_t data_category);
+sentry_batcher_t *sentry__batcher_new(sentry_batch_func_t batch_func);
+void sentry__batcher_set_category(sentry_batcher_t *batcher,
+    sentry_data_category_t data_category, const char *thread_name);
 
 /**
  * Acquires a reference to the batcher behind `ref`, atomically incrementing

--- a/src/sentry_logs.c
+++ b/src/sentry_logs.c
@@ -629,13 +629,14 @@ sentry_scope_capture_log(sentry_scope_t *scope, sentry_level_t level,
 void
 sentry__logs_startup(const sentry_options_t *options)
 {
-    sentry_batcher_t *batcher = sentry__batcher_new(
-        sentry__envelope_add_logs, SENTRY_DATA_CATEGORY_LOG_ITEM);
+    sentry_batcher_t *batcher = sentry__batcher_new(sentry__envelope_add_logs);
     if (!batcher) {
         SENTRY_WARN("failed to allocate logs batcher");
         return;
     }
 
+    sentry__batcher_set_category(
+        batcher, SENTRY_DATA_CATEGORY_LOG_ITEM, "sentry-logs");
     sentry__batcher_startup(batcher, options);
     sentry_batcher_t *old = sentry__batcher_swap(&g_batcher, batcher);
 

--- a/src/sentry_metrics.c
+++ b/src/sentry_metrics.c
@@ -133,13 +133,15 @@ sentry_metrics_distribution(
 void
 sentry__metrics_startup(const sentry_options_t *options)
 {
-    sentry_batcher_t *batcher = sentry__batcher_new(
-        sentry__envelope_add_metrics, SENTRY_DATA_CATEGORY_TRACE_METRIC);
+    sentry_batcher_t *batcher
+        = sentry__batcher_new(sentry__envelope_add_metrics);
     if (!batcher) {
         SENTRY_WARN("failed to allocate metrics batcher");
         return;
     }
 
+    sentry__batcher_set_category(
+        batcher, SENTRY_DATA_CATEGORY_TRACE_METRIC, "sentry-metrics");
     sentry__batcher_startup(batcher, options);
     sentry_batcher_t *old = sentry__batcher_swap(&g_batcher, batcher);
 

--- a/src/sentry_sync.c
+++ b/src/sentry_sync.c
@@ -101,6 +101,12 @@ thread_setname(sentry_threadid_t thread_id, const char *thread_name)
 }
 #endif
 
+int
+sentry__thread_setname(sentry_threadid_t thread_id, const char *thread_name)
+{
+    return thread_setname(thread_id, thread_name);
+}
+
 /**
  * Queue operations, locking and Reference counting:
  *

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -457,6 +457,17 @@ sentry__atomic_fetch_u64(uint64_t *val)
 #endif
 }
 
+/**
+ * Sets the OS-level name for a thread.
+ *
+ * On macOS, only the current thread can be named.
+ *
+ * Returns 0 on success, or a non-zero value if the platform reports that
+ * setting the thread name failed.
+ */
+int sentry__thread_setname(
+    sentry_threadid_t thread_id, const char *thread_name);
+
 struct sentry_bgworker_s;
 typedef struct sentry_bgworker_s sentry_bgworker_t;
 

--- a/tests/test_integration_logger.py
+++ b/tests/test_integration_logger.py
@@ -1,6 +1,7 @@
 import shutil
 import subprocess
 import sys
+import re
 
 import pytest
 
@@ -67,7 +68,7 @@ def parse_logger_output(output):
     # Background thread startup messages (e.g. from the metrics/logs batcher) can
     # race with the pre-crash marker and are not crash-time logs.
     # (from batcher_thread_func in sentry_batcher.c)
-    background_thread_messages = {"Starting batching thread"}
+    background_thread_message = re.compile(r"^Starting sentry-(logs|metrics) thread$")
 
     lines = output.split("\n")
 
@@ -89,7 +90,7 @@ def parse_logger_output(output):
 
             # Track logs that occur after the pre-crash marker,
             # excluding background thread noise
-            if pre_crash_completed and log_message not in background_thread_messages:
+            if pre_crash_completed and not background_thread_message.match(log_message):
                 parsed_data["logs_after_pre_crash"].append(log_message)
 
     return parsed_data

--- a/tests/unit/test_client_report.c
+++ b/tests/unit/test_client_report.c
@@ -390,9 +390,9 @@ SENTRY_TEST(client_report_queue_overflow)
     SENTRY_TEST_OPTIONS_NEW(options);
     sentry_init(options);
 
-    sentry_batcher_t *batcher
-        = sentry__batcher_new(dummy_batch_func, SENTRY_DATA_CATEGORY_LOG_ITEM);
+    sentry_batcher_t *batcher = sentry__batcher_new(dummy_batch_func);
     TEST_CHECK(!!batcher);
+    sentry__batcher_set_category(batcher, SENTRY_DATA_CATEGORY_LOG_ITEM, NULL);
 
     // Fill all buffers (SENTRY_BATCHER_QUEUE_LENGTH is 5 in unit tests)
     for (int i = 0;


### PR DESCRIPTION
Give the logs and metrics batchers distinct OS-level thread names.

Named dedicated threads make profiling and tracing easier because background work can be identified directly in debuggers, crash dumps, and trace timelines instead of showing up as anonymous worker activity.

### Before
```
$ ps -T -p $(pidof sentry-playground) -o pid,tid,comm
    PID     TID COMMAND
  88207   88207 sentry-playgrou
  88207   88208 QDBusConnection
  88207   88210 [pango] fontcon
  88207   88211 pool-spawner
  88207   88212 gmain
  88207   88213 pool-0
  88207   88214 gdbus
  88207   88215 dconf worker
  88207   88216 WaylandEventThr
  88207   88217 WaylandEventThr
  88207   88225 Thread (pooled)
  [...]
  88207   88232 Thread (pooled)
  88207   88265 sentry-http
  88207   88268 sentry-playgrou     ### <===
  88207   88269 sentry-playgrou     ### <===
```

### After
```
$ ps -T -p $(pidof sentry-playground) -o pid,tid,comm
    PID     TID COMMAND
  86707   86707 sentry-playgrou
  86707   86708 QDBusConnection
  86707   86710 [pango] fontcon
  86707   86711 pool-spawner
  86707   86712 gmain
  86707   86714 gdbus
  86707   86715 dconf worker
  86707   86716 WaylandEventThr
  86707   86717 WaylandEventThr
  86707   86720 Thread (pooled)
  [...]
  86707   86727 Thread (pooled)
  86707   86732 sentry-http
  86707   86735 sentry-logs         ### <===
  86707   86736 sentry-metrics      ### <===
```