### PR TITLE
ci: fix, update, and clean up alpine docker image

### DIFF
--- a/.github/docker/alpine/Dockerfile
+++ b/.github/docker/alpine/Dockerfile
@@ -1,8 +1,8 @@
-# docker build --build-arg BASE=alpine:3.21
+# docker build --build-arg BASE=alpine:3.24
 ARG BASE=alpine:latest
 FROM ${BASE}
 
-ARG PIP_INSTALL=
+ARG BPF_LINKER_VERSION=v0.10.4
 COPY requirements.txt /tmp/requirements.txt
 
 RUN apk add --no-cache \
@@ -32,21 +32,17 @@ RUN apk add --no-cache \
     sudo \
     tar \
     tree \
-    wget
+    wget \
+    zstd
 
-# 3.23+
-RUN if awk -F. '{ exit !($1 > 3 || ($1 == 3 && $2 >= 23)) }' /etc/alpine-release; then \
-        (apk add --no-cache llvm22-libs || \
-            apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main llvm22-libs) && \
-        cargo install --locked --git https://github.com/aya-rs/bpf-linker --root /usr/local bpf-linker && \
-        RUSTUP_INIT_SKIP_PATH_CHECK=yes rustup-init -y --profile minimal --default-toolchain none && \
-        . /root/.cargo/env && \
-        rustup toolchain install nightly --profile minimal --component rust-src && \
-        ln -s /root/.cargo/bin/rustup /usr/local/bin/rustup && \
-        if [ -n "${PIP_INSTALL}" ]; then \
-            python3 -m pip install --break-system-packages --upgrade --constraint /tmp/requirements.txt ${PIP_INSTALL}; \
-        fi; \
-    fi
+# mitmproxy-linux builds eBPF code for bpfel-unknown-none and needs bpf-linker plus nightly rust-src.
+RUN curl -sSL --retry 5 "https://github.com/aya-rs/bpf-linker/releases/download/${BPF_LINKER_VERSION}/bpf-linker-$(uname -m)-unknown-linux-musl.tar.zst" | \
+    tar --zstd -xpf - -C /usr/local/bin && \
+    RUSTUP_INIT_SKIP_PATH_CHECK=yes rustup-init -y --profile minimal --default-toolchain none && \
+    . /root/.cargo/env && \
+    rustup toolchain install nightly --profile minimal --component rust-src && \
+    ln -s /root/.cargo/bin/rustup /usr/local/bin/rustup && \
+    python3 -m pip install --break-system-packages --upgrade --constraint /tmp/requirements.txt mitmproxy
 ENV CARGO_HOME=/root/.cargo
 ENV RUSTUP_HOME=/root/.rustup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,14 @@ jobs:
             RUN_ANALYZER: code-checker,valgrind
           - name: Linux (GCC + musl + libunwind)
             os: ubuntu-latest
-            container: ghcr.io/getsentry/sentry-native-alpine:3.23
+            container: ghcr.io/getsentry/sentry-native-alpine:3.24
             CC: gcc
             CXX: g++
             SYSTEM_PYTHON: 1
             CMAKE_DEFINES: -DSENTRY_LIBUNWIND_SYSTEM=ON
           - name: Linux (clang + musl + libunwind)
             os: ubuntu-latest
-            container: ghcr.io/getsentry/sentry-native-alpine:3.23
+            container: ghcr.io/getsentry/sentry-native-alpine:3.24
             CC: clang
             CXX: clang++
             SYSTEM_PYTHON: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,8 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '3.21'
-          - '3.23'
+          - '3.24'
 
     permissions:
       contents: read
@@ -53,4 +52,3 @@ jobs:
           context: .github/docker/alpine
           build-args: |
             BASE=alpine:${{ matrix.version }}
-            PIP_INSTALL=${{ matrix.version == '3.23' && 'mitmproxy' || '' }}


### PR DESCRIPTION
The Alpine 3.23 image build failed while compiling `bpf-linker` from a moving git revision, exposing a fragile dependency on Alpine's LLVM and Rust build environment:

- https://github.com/getsentry/sentry-native/actions/runs/30376295681

Move to Alpine 3.24 and pin `bpf-linker` to an architecture-matched release binary instead of compiling it in the image. Set up nightly Rust and mitmproxy unconditionally, and drop the obsolete Alpine variants and PIP_INSTALL build argument. This keeps the CI image aligned with its actual consumers, while making the linker step more predictable and independent of Alpine's source-build toolchain.

The new `sentry-native-alpine:3.24` Docker images were built by a manually triggered job:
- https://github.com/getsentry/sentry-native/actions/runs/30820544741
