### PR TITLE
ref(internal): add sentry_telemetry module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ sentry_target_sources_cwd(sentry
 	sentry_symbolizer.h
 	sentry_sync.c
 	sentry_sync.h
+	sentry_telemetry.c
+	sentry_telemetry.h
 	sentry_thread_stackwalk.h
 	sentry_transport.c
 	sentry_transport.h

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -9,8 +9,6 @@ extern "C" {
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_logger.h"
-#include "sentry_logs.h"
-#include "sentry_metrics.h"
 #include "sentry_options.h"
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include "sentry_os.h"
@@ -20,6 +18,7 @@ extern "C" {
 #include "sentry_session_replay.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
+#include "sentry_telemetry.h"
 #include "sentry_tracing.h"
 #include "sentry_transport.h"
 #include "sentry_unix_pageallocator.h"
@@ -169,12 +168,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
         sentry__transport_suspend(options->transport);
 
         // Flush logs and metrics in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
-        if (options->enable_metrics) {
-            sentry__metrics_flush_crash_safe();
-        }
+        sentry__telemetry_flush_crash_safe();
 
         if (should_handle) {
             bool capture_screenshot = options->attach_screenshot;

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -9,8 +9,6 @@ extern "C" {
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_logger.h"
-#include "sentry_logs.h"
-#include "sentry_metrics.h"
 #include "sentry_options.h"
 #ifdef SENTRY_PLATFORM_WINDOWS
 #    include "sentry_os.h"
@@ -19,6 +17,7 @@ extern "C" {
 #include "sentry_screenshot.h"
 #include "sentry_session_replay.h"
 #include "sentry_sync.h"
+#include "sentry_telemetry.h"
 #include "sentry_transport.h"
 #include "sentry_value.h"
 #ifdef SENTRY_PLATFORM_LINUX
@@ -479,12 +478,7 @@ crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
         sentry__transport_suspend(options->transport);
 
         // Flush logs and metrics in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
-        if (options->enable_metrics) {
-            sentry__metrics_flush_crash_safe();
-        }
+        sentry__telemetry_flush_crash_safe();
 
         should_dump = !sentry_value_is_null(crash_event);
 

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -8,14 +8,13 @@
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_logger.h"
-#include "sentry_logs.h"
-#include "sentry_metrics.h"
 #include "sentry_options.h"
 #include "sentry_os.h"
 #include "sentry_scope.h"
 #include "sentry_screenshot.h"
 #include "sentry_session_replay.h"
 #include "sentry_sync.h"
+#include "sentry_telemetry.h"
 #include "sentry_tracing.h"
 #include "sentry_transport.h"
 #include "sentry_unix_pageallocator.h"
@@ -1088,12 +1087,7 @@ process_ucontext_deferred(const sentry_ucontext_t *uctx,
         sentry__transport_suspend(options->transport);
 
         // Flush logs in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
-        if (options->enable_metrics) {
-            sentry__metrics_flush_crash_safe();
-        }
+        sentry__telemetry_flush_crash_safe();
         TEST_CRASH_POINT("before_capture");
         if (should_handle) {
             bool capture_screenshot = options->attach_screenshot;

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -28,8 +28,6 @@
 #include "sentry_envelope.h"
 #include "sentry_json.h"
 #include "sentry_logger.h"
-#include "sentry_logs.h"
-#include "sentry_metrics.h"
 #include "sentry_options.h"
 #include "sentry_os.h"
 #include "sentry_path.h"
@@ -37,6 +35,7 @@
 #include "sentry_scope.h"
 #include "sentry_session.h"
 #include "sentry_sync.h"
+#include "sentry_telemetry.h"
 #include "sentry_tracing.h"
 #include "sentry_transport.h"
 #include "sentry_value.h"
@@ -991,12 +990,7 @@ native_backend_except(sentry_backend_t *backend, const sentry_ucontext_t *uctx)
         sentry__transport_suspend(options->transport);
 
         // Flush logs and metrics in a crash-safe manner before crash handling
-        if (options->enable_logs) {
-            sentry__logs_flush_crash_safe();
-        }
-        if (options->enable_metrics) {
-            sentry__metrics_flush_crash_safe();
-        }
+        sentry__telemetry_flush_crash_safe();
 
         // Write crash marker
         sentry__write_crash_marker(options);

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -12,8 +12,6 @@
 #include "sentry_database.h"
 #include "sentry_envelope.h"
 #include "sentry_hint.h"
-#include "sentry_logs.h"
-#include "sentry_metrics.h"
 #include "sentry_options.h"
 #include "sentry_path.h"
 #include "sentry_process.h"
@@ -22,6 +20,7 @@
 #include "sentry_session.h"
 #include "sentry_string.h"
 #include "sentry_sync.h"
+#include "sentry_telemetry.h"
 #include "sentry_tracing.h"
 #include "sentry_transport.h"
 #include "sentry_tsan.h"
@@ -287,13 +286,7 @@ sentry_init(sentry_options_t *options)
         sentry_start_session();
     }
 
-    if (options->enable_logs) {
-        sentry__logs_startup(options);
-    }
-
-    if (options->enable_metrics) {
-        sentry__metrics_startup(options);
-    }
+    sentry__telemetry_startup(options);
 
     if (options->enable_app_hang_tracking) {
         sentry__app_hang_monitor_start(options);
@@ -318,20 +311,7 @@ sentry_flush(uint64_t timeout)
     int rv = 0;
     SENTRY_WITH_OPTIONS (options) {
         // flush logs and metrics in parallel
-        uintptr_t ltoken = 0;
-        uintptr_t mtoken = 0;
-        if (options->enable_logs) {
-            ltoken = sentry__logs_force_flush_begin();
-        }
-        if (options->enable_metrics) {
-            mtoken = sentry__metrics_force_flush_begin();
-        }
-        if (ltoken) {
-            sentry__logs_force_flush_wait(ltoken);
-        }
-        if (mtoken) {
-            sentry__metrics_force_flush_wait(mtoken);
-        }
+        sentry__telemetry_force_flush();
         rv = sentry__transport_flush(options->transport, timeout);
     }
     return rv;
@@ -350,12 +330,7 @@ sentry_close(void)
             }
         }
 
-        if (options->enable_logs) {
-            sentry__logs_shutdown(options->shutdown_timeout);
-        }
-        if (options->enable_metrics) {
-            sentry__metrics_shutdown(options->shutdown_timeout);
-        }
+        sentry__telemetry_shutdown(options);
     }
 
     // Stop it before locking options to prevent a deadlock. The watchdog

--- a/src/sentry_logs.c
+++ b/src/sentry_logs.c
@@ -649,24 +649,20 @@ sentry__logs_startup(const sentry_options_t *options)
 void
 sentry__logs_shutdown(uint64_t timeout)
 {
-    SENTRY_DEBUG("shutting down logs system");
     sentry_batcher_t *batcher = sentry__batcher_swap(&g_batcher, NULL);
     if (batcher) {
         sentry__batcher_shutdown(batcher, timeout);
         sentry__batcher_release(batcher);
     }
-    SENTRY_DEBUG("logs system shutdown complete");
 }
 
 void
 sentry__logs_flush_crash_safe(void)
 {
-    SENTRY_SIGNAL_SAFE_LOG("DEBUG crash-safe logs flush");
     sentry_batcher_t *batcher = sentry__batcher_peek(&g_batcher);
     if (batcher) {
         sentry__batcher_flush_crash_safe(batcher);
     }
-    SENTRY_SIGNAL_SAFE_LOG("DEBUG crash-safe logs flush complete");
 }
 
 uintptr_t

--- a/src/sentry_metrics.c
+++ b/src/sentry_metrics.c
@@ -154,24 +154,20 @@ sentry__metrics_startup(const sentry_options_t *options)
 void
 sentry__metrics_shutdown(uint64_t timeout)
 {
-    SENTRY_DEBUG("shutting down metrics system");
     sentry_batcher_t *batcher = sentry__batcher_swap(&g_batcher, NULL);
     if (batcher) {
         sentry__batcher_shutdown(batcher, timeout);
         sentry__batcher_release(batcher);
     }
-    SENTRY_DEBUG("metrics system shutdown complete");
 }
 
 void
 sentry__metrics_flush_crash_safe(void)
 {
-    SENTRY_SIGNAL_SAFE_LOG("DEBUG crash-safe metrics flush");
     sentry_batcher_t *batcher = sentry__batcher_peek(&g_batcher);
     if (batcher) {
         sentry__batcher_flush_crash_safe(batcher);
     }
-    SENTRY_SIGNAL_SAFE_LOG("DEBUG crash-safe metrics flush complete");
 }
 
 uintptr_t

--- a/src/sentry_telemetry.c
+++ b/src/sentry_telemetry.c
@@ -1,0 +1,47 @@
+#include "sentry_telemetry.h"
+#include "sentry_logger.h"
+#include "sentry_logs.h"
+#include "sentry_metrics.h"
+#include "sentry_options.h"
+
+void
+sentry__telemetry_startup(const sentry_options_t *options)
+{
+    if (options->enable_logs) {
+        sentry__logs_startup(options);
+    }
+    if (options->enable_metrics) {
+        sentry__metrics_startup(options);
+    }
+}
+
+void
+sentry__telemetry_shutdown(const sentry_options_t *options)
+{
+    if (!options->enable_logs && !options->enable_metrics) {
+        return;
+    }
+
+    SENTRY_DEBUG("shutting down telemetry");
+    sentry__logs_shutdown(options->shutdown_timeout);
+    sentry__metrics_shutdown(options->shutdown_timeout);
+    SENTRY_DEBUG("telemetry shutdown complete");
+}
+
+void
+sentry__telemetry_force_flush(void)
+{
+    uintptr_t ltoken = sentry__logs_force_flush_begin();
+    uintptr_t mtoken = sentry__metrics_force_flush_begin();
+    sentry__logs_force_flush_wait(ltoken);
+    sentry__metrics_force_flush_wait(mtoken);
+}
+
+void
+sentry__telemetry_flush_crash_safe(void)
+{
+    SENTRY_SIGNAL_SAFE_LOG("DEBUG crash-safe telemetry flush");
+    sentry__logs_flush_crash_safe();
+    sentry__metrics_flush_crash_safe();
+    SENTRY_SIGNAL_SAFE_LOG("DEBUG crash-safe telemetry flush complete");
+}

--- a/src/sentry_telemetry.h
+++ b/src/sentry_telemetry.h
@@ -1,0 +1,11 @@
+#ifndef SENTRY_TELEMETRY_H_INCLUDED
+#define SENTRY_TELEMETRY_H_INCLUDED
+
+#include "sentry_boot.h"
+
+void sentry__telemetry_startup(const sentry_options_t *options);
+void sentry__telemetry_shutdown(const sentry_options_t *options);
+void sentry__telemetry_force_flush(void);
+void sentry__telemetry_flush_crash_safe(void);
+
+#endif


### PR DESCRIPTION
Adds an internal `sentry_telemetry` module with a shared coordination API for starting up, flushing, and shutting down logs and metrics. Later on, the telemetry module will be used to manage a shared thread pool. Also, lifting up the "shutting down logs/metrics system" etc. debug logs to the shared module helps to reduce those repetitive logs.

#skip-changelog (internal)