### PR TITLE
test: restore @flaky for test_crashpad_dumping_xxx

### DIFF
--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -5,6 +5,7 @@ import sys
 import time
 
 import pytest
+from flaky import flaky
 
 from . import (
     make_dsn,
@@ -420,6 +421,7 @@ def test_crashpad_wer_crash(cmake, httpserver, run_args):
         ),
     ],
 )
+@flaky(max_runs=3)
 def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
     build_args.update({"SENTRY_BACKEND": "crashpad"})
     tmp_path = cmake(["sentry_example"], build_args)
@@ -496,6 +498,7 @@ def test_crashpad_dumping_crash(cmake, httpserver, run_args, build_args):
         ),
     ],
 )
+@flaky(max_runs=3)
 def test_crashpad_dumping_stack_overflow(cmake, httpserver, stack_size):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "crashpad"})
 


### PR DESCRIPTION
Restore `@flaky(max_runs=3)` on the Crashpad dumping integration tests.

Sorry for the churn. 😢 These tests were previously retried in [#1737](https://github.com/getsentry/sentry-native/pull/1737) and [#1870](https://github.com/getsentry/sentry-native/pull/1870), then the flaky markers were removed in [#1885](https://github.com/getsentry/sentry-native/pull/1885) after fixing a race in the dump-upload wait path.

They are still failing intermittently in CI, for example:
- https://github.com/getsentry/sentry-native/actions/runs/29837681489/job/88682228387
- https://github.com/getsentry/sentry-native/actions/runs/29847468533/job/88691617683
- https://github.com/getsentry/sentry-native/actions/runs/30904625288/job/91976699038

This restores the retry marker so unrelated PRs do not fail while the remaining instability is investigated separately.