### PR TITLE
perf(native): load libcurl lazily in crash daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Native/Windows: capture WER report ID and expose as `contexts.wer.report_id` in crash events when the WER integration is enabled. ([#1970](https://github.com/getsentry/sentry-native/pull/1970))
 - Add `sentry_set_tags` and `sentry_scope_set_tags` for updating multiple tags with a single scope flush, improving bulk-update performance. ([#1993](https://github.com/getsentry/sentry-native/pull/1993))
 - Add `sentry_get_last_event_id` and `sentry_scope_get_last_event_id` for retrieving the last event ID captured with the global or given scope, respectively. ([#1992](https://github.com/getsentry/sentry-native/pull/1992))
+- Native/Unix: The native crash daemon now loads `libcurl` dynamically at runtime by default when `SENTRY_LINK_CURL=AUTO`, avoiding `libcurl` linker work during process startup and significantly speeding up startup time. Explicitly set `SENTRY_LINK_CURL=ON` to link it directly. ([#1955](https://github.com/getsentry/sentry-native/pull/1955))
 
 **Fixes**:
 
@@ -36,7 +37,6 @@
 - Add `sentry_scope_remove_fingerprint` to remove a fingerprint set on a scope, matching the global `sentry_remove_fingerprint`. ([#1932](https://github.com/getsentry/sentry-native/pull/1932))
 - Add `sentry_options_set_before_send_feedback` to filter or enrich user feedback. Feedback does not go through `before_send`. ([#1923](https://github.com/getsentry/sentry-native/pull/1923))
 - Unix: Add `SENTRY_LINK_CURL` to control whether the curl transport links `libcurl` directly, loads it dynamically at runtime, or uses the default behavior. ([#1954](https://github.com/getsentry/sentry-native/pull/1954))
-- Native/Unix: The native crash daemon now loads `libcurl` dynamically at runtime by default when `SENTRY_LINK_CURL=AUTO`, avoiding `libcurl` linker work during process startup and significantly speeding up startup time. Explicitly set `SENTRY_LINK_CURL=ON` to link it directly. ([#1955](https://github.com/getsentry/sentry-native/pull/1955))
 
 **Fixes**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Add `sentry_scope_remove_fingerprint` to remove a fingerprint set on a scope, matching the global `sentry_remove_fingerprint`. ([#1932](https://github.com/getsentry/sentry-native/pull/1932))
 - Add `sentry_options_set_before_send_feedback` to filter or enrich user feedback. Feedback does not go through `before_send`. ([#1923](https://github.com/getsentry/sentry-native/pull/1923))
 - Unix: Add `SENTRY_LINK_CURL` to control whether the curl transport links `libcurl` directly, loads it dynamically at runtime, or uses the default behavior. ([#1954](https://github.com/getsentry/sentry-native/pull/1954))
+- Native/Unix: The native crash daemon now loads `libcurl` dynamically at runtime by default when `SENTRY_LINK_CURL=AUTO`, avoiding `libcurl` linker work during process startup and significantly speeding up startup time. Explicitly set `SENTRY_LINK_CURL=ON` to link it directly. ([#1955](https://github.com/getsentry/sentry-native/pull/1955))
 
 **Fixes**:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -875,7 +875,7 @@ elseif(SENTRY_BACKEND_NATIVE)
 	get_target_property(SENTRY_COMPILE_DEFS sentry COMPILE_DEFINITIONS)
 	if(SENTRY_COMPILE_DEFS)
 		# The daemon is always a static executable, never a shared library
-		list(REMOVE_ITEM SENTRY_COMPILE_DEFS "SENTRY_BUILD_SHARED")
+		list(REMOVE_ITEM SENTRY_COMPILE_DEFS "SENTRY_BUILD_SHARED" "SENTRY_LINK_CURL")
 		list(FILTER SENTRY_COMPILE_DEFS EXCLUDE REGEX "^SENTRY_INTEGRATION_")
 		target_compile_definitions(sentry-crash PRIVATE ${SENTRY_COMPILE_DEFS})
 	endif()
@@ -910,7 +910,11 @@ elseif(SENTRY_BACKEND_NATIVE)
 
 	# Transport-specific libraries
 	if(SENTRY_TRANSPORT_CURL)
-		sentry_target_link_curl(sentry-crash ${_SENTRY_LINK_CURL})
+		set(_SENTRY_CRASH_LINK_CURL ${_SENTRY_LINK_CURL})
+		if(SENTRY_LINK_CURL STREQUAL "AUTO" AND UNIX)
+			set(_SENTRY_CRASH_LINK_CURL OFF)
+		endif()
+		sentry_target_link_curl(sentry-crash ${_SENTRY_CRASH_LINK_CURL})
 	endif()
 
 	if(SENTRY_TRANSPORT_WINHTTP)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ using `cmake -D BUILD_SHARED_LIBS=OFF ..`.
 - `SENTRY_LINK_CURL` (Default: `AUTO`):
   Controls whether the `curl` transport links `libcurl` directly or loads it
   dynamically at runtime on UNIX targets. Possible values are `AUTO`, `ON`, and
-  `OFF`. `AUTO` currently behaves like `ON`.
+  `OFF`. `AUTO` currently behaves like `ON`, except for the native crash daemon
+  on UNIX targets, where it behaves like `OFF`.
 
 - `SENTRY_BUILD_FORCE32` (Default: `OFF`):
   Forces cross-compilation from 64-bit host to 32-bit target. Only affects Linux.

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -4677,18 +4677,6 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
         }
     }
 
-    // Transport is already initialized by sentry_options_new(), just start it
-    if (options->transport) {
-        SENTRY_DEBUG("Starting transport");
-        sentry__transport_startup(options->transport, options);
-        // Set http_retry after transport startup to keep daemon-side retry
-        // polling disabled, while letting capture cache consent-revoked
-        // envelopes in retry format for the app to send on restart.
-        options->http_retry = ipc->shmem->http_retry;
-    } else {
-        SENTRY_WARN("No transport available");
-    }
-
     SENTRY_DEBUG("Daemon options fully initialized");
 
 #if defined(SENTRY_PLATFORM_LINUX) || defined(SENTRY_PLATFORM_ANDROID)
@@ -4717,6 +4705,18 @@ sentry__crash_daemon_main(pid_t app_pid, uint64_t app_tid, HANDLE event_handle,
     // Signal to parent that daemon is ready
     SENTRY_DEBUG("Signaling ready to parent");
     sentry__crash_ipc_signal_ready(ipc);
+
+    // Transport is already initialized by sentry_options_new(), just start it
+    if (options->transport) {
+        SENTRY_DEBUG("Starting transport");
+        sentry__transport_startup(options->transport, options);
+        // Set http_retry after transport startup to keep daemon-side retry
+        // polling disabled, while letting capture cache consent-revoked
+        // envelopes in retry format for the app to send on restart.
+        options->http_retry = ipc->shmem->http_retry;
+    } else {
+        SENTRY_WARN("No transport available");
+    }
 
     SENTRY_DEBUG("Entering main loop");
 


### PR DESCRIPTION
Default the Native Unix crash daemon to runtime libcurl loading when `SENTRY_LINK_CURL` is not explicitly set. Keep explicit `SENTRY_LINK_CURL=ON/OFF` respected for the daemon. This lets sentry-crash avoid a direct libcurl dependency by default while the SDK continues to link libcurl directly unless configured otherwise.

Signal readiness to the parent process before starting the daemon transport. This keeps libcurl loading and curl transport initialization out of the startup handshake, while still starting the transport before the daemon enters its crash wait loop.

> [!IMPORTANT]
> Native/Unix daemon readiness now means the daemon IPC is ready, not that the HTTP transport has already been started. The daemon signals readiness to the parent first, then starts the transport immediately afterward. In practice, this keeps app startup from waiting on libcurl loading/initialization while preserving normal daemon-side sending once startup continues.

This shaves off ~60% startup time on Linux.

Before:
```
tests/benchmark.py::test_benchmark_init[native] PASSED
Min 4.661ms, Max 4.880ms, Mean 4.781ms, StdDev 0.081ms, Median 4.779ms, CPU 1.141ms
tests/benchmark.py::test_benchmark_backend[native] PASSED
Min 3.618ms, Max 4.443ms, Mean 4.133ms, StdDev 0.320ms, Median 4.233ms, CPU 0.414ms
```

After:
```
tests/benchmark.py::test_benchmark_init[native] PASSED
Min 1.625ms, Max 2.346ms, Mean 1.936ms, StdDev 0.283ms, Median 1.914ms, CPU 1.109ms
tests/benchmark.py::test_benchmark_backend[native] PASSED
Min 0.938ms, Max 1.626ms, Mean 1.294ms, StdDev 0.284ms, Median 1.324ms, CPU 0.394ms
```

Together with the earlier SHM optimization in #1966, this brings the Native startup time on par with Crashpad. :tada: 

Close: #1852