### PR TITLE
ci(dependabot): group CodeQL updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    github-codeql-action:
+      patterns:
+        - "github/codeql-action/*"


### PR DESCRIPTION
Group CodeQL action entries so Dependabot updates both in one PR:
- https://github.com/getsentry/sentry-native/pull/1951
- https://github.com/getsentry/sentry-native/pull/1952

The two need to advance together instead of being submitted separately:
> Error: analyze post-action step failed: Loaded a configuration file for version '4.37.4', but running version '4.37.3'

See also:
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--