### PR TITLE
fix(sync): harden pre-Vista condition waiters

### DIFF
--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -122,12 +122,14 @@ WakeConditionVariable_PREVISTA(PCONDITION_VARIABLE_PREVISTA ConditionVariable)
         return;
     }
 
-    if (ConditionVariable->Waiters == 0) {
+    const LONG waiters = InterlockedCompareExchange(
+        (volatile LONG *)&ConditionVariable->Waiters, 0, 0);
+    if (waiters == 0) {
         return;
     }
 
     // set target for continue event, alert it on first occurance
-    ConditionVariable->Target = ConditionVariable->Waiters - 1;
+    ConditionVariable->Target = waiters - 1;
 
     SignalObjectAndWait(ConditionVariable->Semaphore,
         ConditionVariable->ContinueEvent, INFINITE, FALSE);

--- a/src/sentry_sync.h
+++ b/src/sentry_sync.h
@@ -99,9 +99,9 @@ SleepConditionVariableCS_PREVISTA(
 {
     DWORD result = 0;
 
+    InterlockedIncrement((LONG *)&cv->Waiters);
     LeaveCriticalSection(cs);
 
-    InterlockedIncrement((LONG *)&cv->Waiters);
     result = WaitForSingleObject(cv->Semaphore, timeout);
 
     // send event only on target


### PR DESCRIPTION
Fix the pre-Vista condition-variable fallback so waiter accounting is incremented before the critical section is released, and waiter counts are read atomically before wake decisions. The following AI review comments pointed out these non-threadpool-related issues:

- cursor: "PREVISTA wake-all can deadlock"
  https://github.com/getsentry/sentry-native/pull/1883#discussion_r3712589914

- sentry: "non-atomic read of ConditionVariable->Waiters"
  https://github.com/getsentry/sentry-native/pull/1883#discussion_r3712744571

#skip-changelog