### PR TITLE
chore: fix Git pre-commit hook on Windows

### DIFF
--- a/scripts/git-precommit-hook.sh
+++ b/scripts/git-precommit-hook.sh
@@ -3,11 +3,16 @@
 CFILES=$(git diff-index --cached --name-only --diff-filter=dr HEAD | grep -E "^(examples|include|src|tests/unit).*\.(c|h|cpp)$")
 PYFILES=$(git diff-index --cached --name-only --diff-filter=dr HEAD | grep -E "^tests.*\.py$")
 
+VENV_BIN=".venv/bin"
+if [ "${OS:-}" = "Windows_NT" ]; then
+    VENV_BIN=".venv/Scripts"
+fi
+
 if [ -n "$CFILES" ]; then
-    .venv/bin/clang-format -i $CFILES
+    "$VENV_BIN/clang-format" -i $CFILES
 fi
 if [ -n "$PYFILES" ]; then
-    .venv/bin/black $PYFILES
+    "$VENV_BIN/black" $PYFILES
 fi
 if [ -n "$CFILES$PYFILES" ]; then
     git add $CFILES $PYFILES


### PR DESCRIPTION
Since #1786, the entire `make xxx` machinery works fine on Windows in Git Bash / MSYS2 / Cygwin -like environments, but `.git/hooks/pre-commit` still had hard-coded `.venv/bin/` occurrences. On Windows, the executables are in `.venv/Scripts/` instead.

This adds the same OS check to the pre-commit hook that we already have in the `Makefile`:
https://github.com/getsentry/sentry-native/blob/159d1855aabaa91aefffe1450fdf541096d82f63/Makefile#L5

P.S. It checks the OS instead of whether `.venv/bin` or `.venv/Scripts` exists because `make setup-git` can run before/independent of/without `make setup-venv`.

### Before
```sh
(.venv) jpnurmi@surface:~/Projects/sentry/sentry-native (tmp)$ git commit -a -m "just a test"
.git/hooks/pre-commit: line 7: .venv/bin/clang-format: No such file or directory
.git/hooks/pre-commit: line 10: .venv/bin/black: No such file or directory
[tmp 3f76fd73] just a test
 2 files changed, 2 insertions(+), 1 deletion(-)
```

### After
```sh
(.venv) jpnurmi@surface:~/Projects/sentry/sentry-native (jpnurmi/chore/win-precommit-hook)$ git commit -a -m "just a test"
reformatted tests\test_unit.py

All done! :sparkles: :cake: :sparkles:
1 file reformatted.
[jpnurmi/chore/win-precommit-hook 0f47181d] just a test
```
