### PR TITLE
ref(value): cache string length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `sentry_attachment_set_filename`, `sentry_attachment_set_type`, and `sentry_attachment_set_content_type` now flush the scope, so changes applied after `sentry_attach_file`/`sentry_attach_bytes` also apply to hard-crash events instead of only to normal events. ([#1934](https://github.com/getsentry/sentry-native/pull/1934))
 - Crashpad: fix a crash when calling `sentry_init` before C++ dynamic initializers have run. ([#1930](https://github.com/getsentry/sentry-native/issues/1930), [mini_chromium#8](https://github.com/getsentry/mini_chromium/pull/8))
 - Reduce the size of native-generated minidumps on Windows ([#1929](https://github.com/getsentry/sentry-native/pull/1929))
+- Preserve embedded `NUL` bytes in strings created with `sentry_value_new_string_n` during JSON and MessagePack serialization. `sentry_value_get_length` now returns the full byte length, which can exceed `strlen(sentry_value_as_string(value))`. ([#1968](https://github.com/getsentry/sentry-native/pull/1968))
 
 ## 0.16.1
 

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -471,9 +471,9 @@ SENTRY_API sentry_value_t sentry_value_get_by_index_owned(
     sentry_value_t value, size_t index);
 
 /**
- * Returns the length of the given map or list.
+ * Returns the length of the given map, list, or string.
  *
- * If an item is not a list or map, the return value is 0.
+ * If an item is not a list, map, or string, the return value is 0.
  */
 SENTRY_API size_t sentry_value_get_length(sentry_value_t value);
 

--- a/src/sentry_json.c
+++ b/src/sentry_json.c
@@ -22,6 +22,7 @@
 #include "sentry_value.h"
 
 #define SENTRY_JSON_MAX_DEPTH 64
+#define SENTRY_JSON_STRLEN ((size_t)-1)
 
 struct sentry_jsonwriter_s {
     sentry_writer_t *writer;
@@ -201,12 +202,15 @@ static unsigned char needs_escaping[256] = {
 };
 
 static void
-write_json_str(sentry_jsonwriter_t *jw, const char *str)
+write_json_str(sentry_jsonwriter_t *jw, const char *str, size_t str_len)
 {
     // using unsigned here because utf-8 is > 127 :-)
     const unsigned char *ptr = (const unsigned char *)str;
     const unsigned char *start = ptr;
-    for (; *ptr && !sentry__jsonwriter_has_failed(jw); ptr++) {
+    const unsigned char *end
+        = str_len == SENTRY_JSON_STRLEN ? NULL : ptr + str_len;
+    for (; (end ? ptr < end : *ptr) && !sentry__jsonwriter_has_failed(jw);
+        ptr++) {
         if (!needs_escaping[*ptr]) {
             continue;
         }
@@ -353,13 +357,20 @@ sentry__jsonwriter_write_double(sentry_jsonwriter_t *jw, double val)
 void
 sentry__jsonwriter_write_str(sentry_jsonwriter_t *jw, const char *val)
 {
+    sentry__jsonwriter_write_str_n(jw, val, SENTRY_JSON_STRLEN);
+}
+
+void
+sentry__jsonwriter_write_str_n(
+    sentry_jsonwriter_t *jw, const char *val, size_t val_len)
+{
     if (!val) {
         sentry__jsonwriter_write_null(jw);
         return;
     }
     if (can_write_item(jw)) {
         write_char(jw, '"');
-        write_json_str(jw, val);
+        write_json_str(jw, val, val_len);
         write_char(jw, '"');
     }
 }
@@ -390,7 +401,7 @@ sentry__jsonwriter_write_key(sentry_jsonwriter_t *jw, const char *val)
 {
     if (can_write_item(jw)) {
         write_char(jw, '"');
-        write_json_str(jw, val);
+        write_json_str(jw, val, SENTRY_JSON_STRLEN);
         write_char(jw, '"');
         write_char(jw, ':');
         jw->last_was_key = true;

--- a/src/sentry_json.c
+++ b/src/sentry_json.c
@@ -470,7 +470,7 @@ read_escaped_unicode_char(const char *buf)
 }
 
 static bool
-decode_string_inplace(char *buf)
+decode_string_inplace(char *buf, size_t *len_out)
 {
     const char *input = buf;
     char *output = buf;
@@ -519,9 +519,7 @@ decode_string_inplace(char *buf)
                 return false;
             }
 
-            if (uchar) {
-                output += sentry__unichar_to_utf8((uint32_t)uchar, output);
-            }
+            output += sentry__unichar_to_utf8((uint32_t)uchar, output);
             break;
         }
         default:
@@ -531,6 +529,9 @@ decode_string_inplace(char *buf)
 
 #undef SIMPLE_ESCAPE
 
+    if (len_out) {
+        *len_out = (size_t)(output - buf);
+    }
     *output = 0;
     return true;
 }
@@ -615,8 +616,9 @@ tokens_to_value(jsmntok_t *tokens, size_t token_count, const char *buf,
     case JSMN_STRING: {
         char *string = sentry__string_clone_n_unchecked(
             buf + root->start, (size_t)(root->end - root->start));
-        if (decode_string_inplace(string)) {
-            rv = sentry__value_new_string_owned(string);
+        size_t string_len = 0;
+        if (decode_string_inplace(string, &string_len)) {
+            rv = sentry__value_new_string_owned_n(string, string_len);
         } else {
             sentry_free(string);
             rv = sentry_value_new_null();
@@ -639,7 +641,7 @@ tokens_to_value(jsmntok_t *tokens, size_t token_count, const char *buf,
 
             char *key = sentry__string_clone_n_unchecked(
                 buf + token->start, (size_t)(token->end - token->start));
-            if (decode_string_inplace(key)) {
+            if (decode_string_inplace(key, NULL)) {
                 sentry_value_set_by_key(rv, key, child);
             } else {
                 sentry_value_decref(child);

--- a/src/sentry_json.h
+++ b/src/sentry_json.h
@@ -89,6 +89,12 @@ void sentry__jsonwriter_write_double(sentry_jsonwriter_t *jw, double val);
 void sentry__jsonwriter_write_str(sentry_jsonwriter_t *jw, const char *val);
 
 /**
+ * Write a string with an explicit byte length.
+ */
+void sentry__jsonwriter_write_str_n(
+    sentry_jsonwriter_t *jw, const char *val, size_t val_len);
+
+/**
  * Write a UUID as a JSON string.
  * See `sentry_uuid_as_string`.
  */

--- a/src/sentry_uuid.c
+++ b/src/sentry_uuid.c
@@ -110,7 +110,7 @@ sentry_uuid_as_string(const sentry_uuid_t *uuid, char str[37])
 }
 
 void
-sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[37])
+sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[33])
 {
 #define B(X) (unsigned char)uuid->bytes[X]
     snprintf(str, 33,

--- a/src/sentry_uuid.h
+++ b/src/sentry_uuid.h
@@ -7,7 +7,7 @@
  * Converts a sentry UUID to a string representation used for internal
  * sentry UUIDs such as event IDs.
  */
-void sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[37]);
+void sentry__internal_uuid_as_string(const sentry_uuid_t *uuid, char str[33]);
 
 /**
  * Converts a sentry UUID to a string representation used for span IDs.

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -108,10 +108,20 @@ typedef struct {
     long refcount;
 } obj_t;
 
+#if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4200) // nonstandard extension used: zero-sized
+                                    // array in struct/union
+#endif
+
 typedef struct {
     size_t len;
-    char s[];
+    char s[]; // flexible array member
 } blob_t;
+
+#if defined(_MSC_VER)
+#    pragma warning(pop)
+#endif
 
 static const char *
 level_as_string(sentry_level_t level)

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -108,6 +108,11 @@ typedef struct {
     long refcount;
 } obj_t;
 
+typedef struct {
+    char *s;
+    size_t len;
+} blob_t;
+
 static const char *
 level_as_string(sentry_level_t level)
 {
@@ -316,7 +321,11 @@ thing_free(thing_t *thing)
         obj_free(thing->payload._ptr);
         break;
     case THING_TYPE_STRING:
-        sentry_free(thing->payload._ptr);
+        if (thing->payload._ptr) {
+            blob_t *blob = thing->payload._ptr;
+            sentry_free(blob->s);
+            sentry_free(blob);
+        }
         break;
     }
     sentry_free(thing);
@@ -377,6 +386,16 @@ value_as_thing(sentry_value_t value)
         return NULL;
     }
     return (thing_t *)(size_t)value._bits;
+}
+
+static const blob_t *
+value_as_blob(sentry_value_t value)
+{
+    const thing_t *thing = value_as_thing(value);
+    if (thing && thing_get_type(thing) == THING_TYPE_STRING) {
+        return (const blob_t *)thing->payload._ptr;
+    }
+    return NULL;
 }
 
 static thing_t *
@@ -511,7 +530,7 @@ sentry_value_new_string_n(const char *value, size_t value_len)
     if (!s) {
         return sentry_value_new_null();
     }
-    return sentry__value_new_string_owned(s);
+    return sentry__value_new_string_owned_n(s, value_len);
 }
 
 sentry_value_t
@@ -1173,7 +1192,7 @@ sentry_value_get_length(sentry_value_t value)
     if (thing) {
         switch (thing_get_type(thing)) {
         case THING_TYPE_STRING:
-            return strlen(thing->payload._ptr);
+            return ((const blob_t *)thing->payload._ptr)->len;
         case THING_TYPE_LIST:
             return ((const list_t *)thing->payload._ptr)->len;
         case THING_TYPE_OBJECT:
@@ -1267,9 +1286,9 @@ sentry_value_as_uint64(sentry_value_t value)
 const char *
 sentry_value_as_string(sentry_value_t value)
 {
-    const thing_t *thing = value_as_thing(value);
-    if (thing && thing_get_type(thing) == THING_TYPE_STRING) {
-        return (const char *)thing->payload._ptr;
+    const blob_t *blob = value_as_blob(value);
+    if (blob) {
+        return blob->s;
     }
     return "";
 }
@@ -1393,9 +1412,11 @@ sentry__jsonwriter_write_value(sentry_jsonwriter_t *jw, sentry_value_t value)
     case SENTRY_VALUE_TYPE_DOUBLE:
         sentry__jsonwriter_write_double(jw, sentry_value_as_double(value));
         break;
-    case SENTRY_VALUE_TYPE_STRING:
-        sentry__jsonwriter_write_str(jw, sentry_value_as_string(value));
+    case SENTRY_VALUE_TYPE_STRING: {
+        const blob_t *blob = value_as_blob(value);
+        sentry__jsonwriter_write_str_n(jw, blob->s, blob->len);
         break;
+    }
     case SENTRY_VALUE_TYPE_LIST: {
         const thing_t *thing = value_as_thing(value);
         if (!thing) {
@@ -1473,7 +1494,8 @@ value_to_msgpack(mpack_writer_t *writer, sentry_value_t value)
         mpack_write_double(writer, sentry_value_as_double(value));
         break;
     case SENTRY_VALUE_TYPE_STRING: {
-        mpack_write_cstr_or_nil(writer, sentry_value_as_string(value));
+        const blob_t *blob = value_as_blob(value);
+        mpack_write_str(writer, blob->s, (uint32_t)blob->len);
         break;
     }
     case SENTRY_VALUE_TYPE_LIST: {
@@ -1516,13 +1538,28 @@ sentry_value_to_msgpack(sentry_value_t value, size_t *size_out)
 sentry_value_t
 sentry__value_new_string_owned(char *s)
 {
+    return s ? sentry__value_new_string_owned_n(s, strlen(s))
+             : sentry_value_new_null();
+}
+
+sentry_value_t
+sentry__value_new_string_owned_n(char *s, size_t s_len)
+{
     if (!s) {
         return sentry_value_new_null();
     }
-    sentry_value_t rv
-        = new_thing_value(s, THING_TYPE_STRING | THING_TYPE_FROZEN);
-    if (sentry_value_is_null(rv)) {
+    blob_t *blob = SENTRY_MAKE(blob_t);
+    if (!blob) {
         sentry_free(s);
+        return sentry_value_new_null();
+    }
+    blob->s = s;
+    blob->len = s_len;
+    sentry_value_t rv
+        = new_thing_value(blob, THING_TYPE_STRING | THING_TYPE_FROZEN);
+    if (sentry_value_is_null(rv)) {
+        sentry_free(blob->s);
+        sentry_free(blob);
     }
     return rv;
 }
@@ -1564,7 +1601,7 @@ sentry__value_new_hexstring(const uint8_t *bytes, size_t len)
         written += rv;
     }
     buf[written] = '\0';
-    return sentry__value_new_string_owned(buf);
+    return sentry__value_new_string_owned_n(buf, written);
 }
 
 sentry_value_t
@@ -1576,7 +1613,7 @@ sentry__value_new_span_uuid(const sentry_uuid_t *uuid)
     }
     sentry__span_uuid_as_string(uuid, buf);
     buf[16] = '\0';
-    return sentry__value_new_string_owned(buf);
+    return sentry__value_new_string_owned_n(buf, 16);
 }
 
 sentry_value_t
@@ -1588,7 +1625,7 @@ sentry__value_new_internal_uuid(const sentry_uuid_t *uuid)
     }
     sentry__internal_uuid_as_string(uuid, buf);
     buf[32] = '\0';
-    return sentry__value_new_string_owned(buf);
+    return sentry__value_new_string_owned_n(buf, 32);
 }
 
 sentry_value_t
@@ -1600,7 +1637,7 @@ sentry__value_new_uuid(const sentry_uuid_t *uuid)
     }
     sentry_uuid_as_string(uuid, buf);
     buf[36] = '\0';
-    return sentry__value_new_string_owned(buf);
+    return sentry__value_new_string_owned_n(buf, 36);
 }
 
 sentry_value_t

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -109,8 +109,8 @@ typedef struct {
 } obj_t;
 
 typedef struct {
-    char *s;
     size_t len;
+    char s[];
 } blob_t;
 
 static const char *
@@ -197,7 +197,6 @@ obj_free(obj_t *obj)
 static void
 blob_free(blob_t *blob)
 {
-    sentry_free(blob->s);
     sentry_free(blob);
 }
 
@@ -382,6 +381,29 @@ new_thing_value(void *ptr, uint8_t thing_type)
     return rv;
 }
 
+static sentry_value_t
+new_string_value(const char *s, size_t s_len)
+{
+    if (!s || s_len > SIZE_MAX - sizeof(blob_t) - 1) {
+        return sentry_value_new_null();
+    }
+
+    blob_t *b = sentry_malloc(sizeof(blob_t) + s_len + 1);
+    if (!b) {
+        return sentry_value_new_null();
+    }
+    b->len = s_len;
+    memcpy(b->s, s, s_len);
+    b->s[s_len] = '\0';
+
+    sentry_value_t rv
+        = new_thing_value(b, THING_TYPE_STRING | THING_TYPE_FROZEN);
+    if (sentry_value_is_null(rv)) {
+        blob_free(b);
+    }
+    return rv;
+}
+
 static thing_t *
 value_as_thing(sentry_value_t value)
 {
@@ -519,11 +541,7 @@ sentry_value_new_bool(int value)
 sentry_value_t
 sentry_value_new_string_n(const char *value, size_t value_len)
 {
-    char *s = sentry__string_clone_n(value, value_len);
-    if (!s) {
-        return sentry_value_new_null();
-    }
-    return sentry__value_new_string_owned_n(s, value_len);
+    return new_string_value(value, value_len);
 }
 
 sentry_value_t
@@ -1545,23 +1563,9 @@ sentry__value_new_string_owned(char *s)
 sentry_value_t
 sentry__value_new_string_owned_n(char *s, size_t s_len)
 {
-    if (!s) {
-        return sentry_value_new_null();
-    }
-    blob_t *b = SENTRY_MAKE(blob_t);
-    if (b) {
-        b->s = s;
-        b->len = s_len;
-        sentry_value_t rv
-            = new_thing_value(b, THING_TYPE_STRING | THING_TYPE_FROZEN);
-        if (sentry_value_is_null(rv)) {
-            blob_free(b);
-        }
-        return rv;
-    } else {
-        sentry_free(s);
-        return sentry_value_new_null();
-    }
+    sentry_value_t rv = new_string_value(s, s_len);
+    sentry_free(s);
+    return rv;
 }
 
 #ifdef SENTRY_PLATFORM_WINDOWS

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -194,6 +194,13 @@ obj_free(obj_t *obj)
     sentry_free(obj);
 }
 
+static void
+blob_free(blob_t *blob)
+{
+    sentry_free(blob->s);
+    sentry_free(blob);
+}
+
 static list_t *
 list_clone(const list_t *list)
 {
@@ -321,11 +328,7 @@ thing_free(thing_t *thing)
         obj_free(thing->payload._ptr);
         break;
     case THING_TYPE_STRING:
-        if (thing->payload._ptr) {
-            blob_t *blob = thing->payload._ptr;
-            sentry_free(blob->s);
-            sentry_free(blob);
-        }
+        blob_free(thing->payload._ptr);
         break;
     }
     sentry_free(thing);
@@ -386,16 +389,6 @@ value_as_thing(sentry_value_t value)
         return NULL;
     }
     return (thing_t *)(size_t)value._bits;
-}
-
-static const blob_t *
-value_as_blob(sentry_value_t value)
-{
-    const thing_t *thing = value_as_thing(value);
-    if (thing && thing_get_type(thing) == THING_TYPE_STRING) {
-        return (const blob_t *)thing->payload._ptr;
-    }
-    return NULL;
 }
 
 static thing_t *
@@ -1286,9 +1279,9 @@ sentry_value_as_uint64(sentry_value_t value)
 const char *
 sentry_value_as_string(sentry_value_t value)
 {
-    const blob_t *blob = value_as_blob(value);
-    if (blob) {
-        return blob->s;
+    const thing_t *thing = value_as_thing(value);
+    if (thing && thing_get_type(thing) == THING_TYPE_STRING) {
+        return ((const blob_t *)thing->payload._ptr)->s;
     }
     return "";
 }
@@ -1413,8 +1406,14 @@ sentry__jsonwriter_write_value(sentry_jsonwriter_t *jw, sentry_value_t value)
         sentry__jsonwriter_write_double(jw, sentry_value_as_double(value));
         break;
     case SENTRY_VALUE_TYPE_STRING: {
-        const blob_t *blob = value_as_blob(value);
-        sentry__jsonwriter_write_str_n(jw, blob->s, blob->len);
+        const thing_t *thing = value_as_thing(value);
+        if (!thing) {
+            UNREACHABLE("thing of a string is NULL during serialization");
+            return;
+        }
+
+        const blob_t *b = thing->payload._ptr;
+        sentry__jsonwriter_write_str_n(jw, b->s, b->len);
         break;
     }
     case SENTRY_VALUE_TYPE_LIST: {
@@ -1494,8 +1493,9 @@ value_to_msgpack(mpack_writer_t *writer, sentry_value_t value)
         mpack_write_double(writer, sentry_value_as_double(value));
         break;
     case SENTRY_VALUE_TYPE_STRING: {
-        const blob_t *blob = value_as_blob(value);
-        mpack_write_str(writer, blob->s, (uint32_t)blob->len);
+        const blob_t *b = value_as_thing(value)->payload._ptr;
+
+        mpack_write_str(writer, b->s, (uint32_t)b->len);
         break;
     }
     case SENTRY_VALUE_TYPE_LIST: {
@@ -1548,20 +1548,20 @@ sentry__value_new_string_owned_n(char *s, size_t s_len)
     if (!s) {
         return sentry_value_new_null();
     }
-    blob_t *blob = SENTRY_MAKE(blob_t);
-    if (!blob) {
+    blob_t *b = SENTRY_MAKE(blob_t);
+    if (b) {
+        b->s = s;
+        b->len = s_len;
+        sentry_value_t rv
+            = new_thing_value(b, THING_TYPE_STRING | THING_TYPE_FROZEN);
+        if (sentry_value_is_null(rv)) {
+            blob_free(b);
+        }
+        return rv;
+    } else {
         sentry_free(s);
         return sentry_value_new_null();
     }
-    blob->s = s;
-    blob->len = s_len;
-    sentry_value_t rv
-        = new_thing_value(blob, THING_TYPE_STRING | THING_TYPE_FROZEN);
-    if (sentry_value_is_null(rv)) {
-        sentry_free(blob->s);
-        sentry_free(blob);
-    }
-    return rv;
 }
 
 #ifdef SENTRY_PLATFORM_WINDOWS

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -204,12 +204,6 @@ obj_free(obj_t *obj)
     sentry_free(obj);
 }
 
-static void
-blob_free(blob_t *blob)
-{
-    sentry_free(blob);
-}
-
 static list_t *
 list_clone(const list_t *list)
 {
@@ -337,7 +331,7 @@ thing_free(thing_t *thing)
         obj_free(thing->payload._ptr);
         break;
     case THING_TYPE_STRING:
-        blob_free(thing->payload._ptr);
+        sentry_free(thing->payload._ptr);
         break;
     }
     sentry_free(thing);
@@ -409,7 +403,7 @@ new_string_value(const char *s, size_t s_len)
     sentry_value_t rv
         = new_thing_value(b, THING_TYPE_STRING | THING_TYPE_FROZEN);
     if (sentry_value_is_null(rv)) {
-        blob_free(b);
+        sentry_free(b);
     }
     return rv;
 }

--- a/src/sentry_value.c
+++ b/src/sentry_value.c
@@ -1621,37 +1621,25 @@ sentry__value_new_hexstring(const uint8_t *bytes, size_t len)
 sentry_value_t
 sentry__value_new_span_uuid(const sentry_uuid_t *uuid)
 {
-    char *buf = sentry_malloc(17);
-    if (!buf) {
-        return sentry_value_new_null();
-    }
+    char buf[17];
     sentry__span_uuid_as_string(uuid, buf);
-    buf[16] = '\0';
-    return sentry__value_new_string_owned_n(buf, 16);
+    return sentry_value_new_string_n(buf, 16);
 }
 
 sentry_value_t
 sentry__value_new_internal_uuid(const sentry_uuid_t *uuid)
 {
-    char *buf = sentry_malloc(33);
-    if (!buf) {
-        return sentry_value_new_null();
-    }
+    char buf[33];
     sentry__internal_uuid_as_string(uuid, buf);
-    buf[32] = '\0';
-    return sentry__value_new_string_owned_n(buf, 32);
+    return sentry_value_new_string_n(buf, 32);
 }
 
 sentry_value_t
 sentry__value_new_uuid(const sentry_uuid_t *uuid)
 {
-    char *buf = sentry_malloc(37);
-    if (!buf) {
-        return sentry_value_new_null();
-    }
+    char buf[37];
     sentry_uuid_as_string(uuid, buf);
-    buf[36] = '\0';
-    return sentry__value_new_string_owned_n(buf, 36);
+    return sentry_value_new_string_n(buf, 36);
 }
 
 sentry_value_t

--- a/src/sentry_value.h
+++ b/src/sentry_value.h
@@ -8,6 +8,11 @@
  */
 sentry_value_t sentry__value_new_string_owned(char *s);
 
+/**
+ * Create a new Value from an owned string with explicit byte length.
+ */
+sentry_value_t sentry__value_new_string_owned_n(char *s, size_t s_len);
+
 #ifdef SENTRY_PLATFORM_WINDOWS
 /**
  * Create a new Value from a Wide String.

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -277,6 +277,16 @@ SENTRY_TEST(value_string_n)
                    sizeof(string_with_nul))
         == 0);
     TEST_CHECK_JSON_VALUE(val, "\"he\\u0000lo\"");
+
+    char *json = sentry_value_to_json(val);
+    sentry_value_t deserialized = sentry__value_from_json(json, strlen(json));
+    TEST_CHECK(
+        sentry_value_get_length(deserialized) == sizeof(string_with_nul));
+    TEST_CHECK(memcmp(sentry_value_as_string(deserialized), string_with_nul,
+                   sizeof(string_with_nul))
+        == 0);
+    sentry_free(json);
+    sentry_value_decref(deserialized);
     sentry_value_decref(val);
 }
 
@@ -1130,6 +1140,14 @@ SENTRY_TEST(value_json_parsing)
     TEST_CHECK_STRING_EQUAL(
         sentry_value_as_string(sentry_value_get_by_index(rv, 1)),
         "foo\xe2\x98\x83");
+    sentry_value_decref(rv);
+
+    char string_with_nul[] = { 'h', 'e', '\0', 'l', 'o' };
+    rv = sentry__value_from_json(STRING("\"he\\u0000lo\""));
+    TEST_CHECK(sentry_value_get_length(rv) == sizeof(string_with_nul));
+    TEST_CHECK(memcmp(sentry_value_as_string(rv), string_with_nul,
+                   sizeof(string_with_nul))
+        == 0);
     sentry_value_decref(rv);
 
     rv = sentry__value_from_json(

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -269,6 +269,15 @@ SENTRY_TEST(value_string_n)
     TEST_CHECK(sentry_value_get_type(val) == SENTRY_VALUE_TYPE_STRING);
     TEST_CHECK(sentry_value_is_true(val) == true);
     sentry_value_decref(val);
+
+    char string_with_nul[] = { 'h', 'e', '\0', 'l', 'o' };
+    val = sentry_value_new_string_n(string_with_nul, sizeof(string_with_nul));
+    TEST_CHECK(sentry_value_get_length(val) == sizeof(string_with_nul));
+    TEST_CHECK(memcmp(sentry_value_as_string(val), string_with_nul,
+                   sizeof(string_with_nul))
+        == 0);
+    TEST_CHECK_JSON_VALUE(val, "\"he\\u0000lo\"");
+    sentry_value_decref(val);
 }
 
 SENTRY_TEST(value_unicode)

--- a/tests/unit/test_value.c
+++ b/tests/unit/test_value.c
@@ -262,6 +262,10 @@ SENTRY_TEST(value_string_n)
     TEST_CHECK(sentry_value_is_true(val) == false);
     sentry_value_decref(val);
 
+    val = sentry_value_new_string_n("sentry", SIZE_MAX);
+    TEST_CHECK(sentry_value_is_null(val));
+    sentry_value_decref(val);
+
     char non_null_term_empty_str[] = { 'h', 'e', 'l', 'l', 'o' };
     val = sentry_value_new_string_n(
         non_null_term_empty_str, sizeof(non_null_term_empty_str));


### PR DESCRIPTION
Since `sentry_value_new_string` calls `strlen` + `sentry_value_new_string_n` anyway, we might as well store the length:

https://github.com/getsentry/sentry-native/blob/ff209d555ab75f203821d312ee6c8f4dbd31b014/src/sentry_value.c#L517-L522

The pre-determined length nicely flows into serialization etc. It not only saves us from calling `strlen` wherever we have `_n` APIs available, but also implicitly adds the capability to handle embedded `NUL` bytes for `sentry_value_t`-backed attachments in the future.

To avoid paying for an extra allocation (`char[]` AND `blob_t`), the proposal uses a flexible array member so the length and string bytes share a single allocation. This way, the number of allocations doesn't increase, but we just allocate `size_t` + string together in one go.

<!--
Scanning string lengths is not exactly the heaviest part of serialization, but the optimization does have a noticeable effect on large string-heavy event structures. For example, ~10% speedup for serializing a generated 230kb dummy event:

### Before

```
tests/benchmark.py::test_benchmark_capture_event PASSED
Min 1.409ms, Max 1.409ms, Mean 1.409ms, Median 1.409ms, CPU 1.409ms
```

### After

```
tests/benchmark.py::test_benchmark_capture_event PASSED
Min 1.231ms, Max 1.231ms, Mean 1.231ms, Median 1.231ms, CPU 1.231ms
```

[benchmark_capture.cpp](https://github.com/user-attachments/files/30834790/benchmark_capture.cpp)
-->

See also:
- #1945
