### PR TITLE
fix(logging): drop noisy envelope-serialization debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixes**:
 
+- Remove the `serializing envelope into buffer` debug log that could flood logs on every scope flush when an external crash reporter is configured. ([#1988](https://github.com/getsentry/sentry-native/pull/1988))
 - Crashpad: avoid allocating while handling a crash. The backend built the attachment `base::FilePath` inside the crash handler; if the crash corrupted the heap (e.g. via an overridden `operator new`) that allocation faults again and the report is lost. The paths are now cached at startup. ([#1984](https://github.com/getsentry/sentry-native/pull/1984))
 - Crashpad: prevent external crash reporters from bypassing revoked user consent. ([#1972](https://github.com/getsentry/sentry-native/pull/1972), [crashpad#168](https://github.com/getsentry/crashpad/pull/168))
 - Native/Linux: improve startup time by avoiding zeroing a large shmem module array during crash context initialization. ([#1966](https://github.com/getsentry/sentry-native/pull/1966))

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -835,7 +835,6 @@ sentry__envelope_serialize_into_stringbuilder(
         return;
     }
 
-    SENTRY_DEBUG("serializing envelope into buffer");
     sentry__envelope_serialize_headers_into_stringbuilder(envelope, sb);
 
     for (const sentry_envelope_item_t *item


### PR DESCRIPTION
The `serializing envelope into buffer` debug line is emitted on every envelope serialization. Since #1841 the crashpad backend serializes the external crash report envelope on every scope mutation (`flush_external_crash_report` → `sentry_envelope_serialize` → `sentry__envelope_serialize_into_stringbuilder`), so with debug logging enabled this floods the logs. It was reported by an Unreal SDK user who wants to keep debug logging on.