### PR TITLE
fix(breakpad): avoid double decref after `on_crash`

### DIFF
--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -160,9 +160,8 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
 #endif
 
             SENTRY_SIGNAL_SAFE_LOG("DEBUG invoking `on_crash` hook");
-            sentry_value_t result
-                = options->on_crash_func(uctx, event, options->on_crash_data);
-            should_handle = !sentry_value_is_null(result);
+            event = options->on_crash_func(uctx, event, options->on_crash_data);
+            should_handle = !sentry_value_is_null(event);
         }
 
         sentry__transport_suspend(options->transport);


### PR DESCRIPTION
Similar to [how we do it in inproc](https://github.com/getsentry/sentry-native/blob/master/src/backends/sentry_backend_inproc.c#L1081-L1082), we re-assign to the event itself. The subsequent `decref(event)` becomes a no-op (since the return value of the `on_crash` on a discard is supposed to be `sentry_value_new_null` as per the contract), whereas before, we would have a double `decref(event)` (once by the user in the on_crash, and once in the [!should_handle branch](https://github.com/getsentry/sentry-native/blob/master/src/backends/sentry_backend_breakpad.cpp#L270).

#skip-changelog 