### PR TITLE
fix(batcher): synchronize task completion wakeups

### DIFF
--- a/src/sentry_batcher.c
+++ b/src/sentry_batcher.c
@@ -289,23 +289,17 @@ batch_task_unlink_locked(sentry_batch_task_t *task)
 }
 
 static void
-batch_task_notify_waiters(sentry_batcher_t *batcher)
-{
-    sentry__mutex_lock(&batcher->task_wait_mutex);
-    sentry__cond_wake_all(&batcher->task_wait_cond);
-    sentry__mutex_unlock(&batcher->task_wait_mutex);
-}
-
-static void
 batch_task_unlink(sentry_batch_task_t *task)
 {
     sentry_batcher_t *batcher = task->batcher;
+    sentry__mutex_lock(&batcher->task_wait_mutex);
     lock_tasks(batcher);
     const bool drained = batch_task_unlink_locked(task);
     unlock_tasks(batcher);
     if (drained) {
-        batch_task_notify_waiters(batcher);
+        sentry__cond_wake_all(&batcher->task_wait_cond);
     }
+    sentry__mutex_unlock(&batcher->task_wait_mutex);
 }
 
 static void
@@ -387,11 +381,8 @@ batch_task_complete(void *task_data)
     lock_tasks(batcher);
     const long state = sentry__atomic_fetch(&task->state);
     if (state == SENTRY_BATCH_TASK_DUMPED) {
-        const bool drained = batch_task_unlink_locked(task);
         unlock_tasks(batcher);
-        if (drained) {
-            batch_task_notify_waiters(batcher);
-        }
+        batch_task_unlink(task);
         return;
     }
     sentry__atomic_store(&task->state, SENTRY_BATCH_TASK_COMPLETING);


### PR DESCRIPTION
PR #1946 made telemetry pool workers notify batch-task waiters after removing the final task. The removal was protected by `task_lock`, but the notification acquired `task_wait_mutex` afterward. This left a narrow window where shutdown could observe `tasks == NULL`, destroy and free the batcher's wait primitives, and then have the worker lock, broadcast, and unlock those freed objects.

TSAN caught this heap-use-after-free in the first [Clang 20 TSAN job](https://github.com/getsentry/sentry-native/actions/runs/32364700595/job/96411581752). The rerun passed because it did not hit the same scheduling window.

This change makes the final unlink and wakeup one `task_wait_mutex` critical section. Shutdown therefore either sees the task still pending and waits, or cannot observe the empty task list until the notifier has finished using the batcher. Dumped-task completion uses the same helper after releasing `task_lock`, preserving the `task_wait_mutex` → `task_lock` order.

Verified with the focused TSAN shutdown, crash-completion, rejected-submission, and metrics re-init tests, followed by 1000 repeated `logs_reinit_stress` and `metrics_reinit_stress` runs:

```sh
$ RUN_ANALYZER=tsan CC=clang-20 CXX=clang++-20 pytest -s -v 'tests/test_unit.py::test_unit[metrics_reinit_stress]'
...
export TSAN_OPTIONS="verbosity=0:detect_deadlocks=1:second_deadlock_stack=1:suppressions=$PWD/tests/tsan.supp"
for tst in metrics_reinit_stress logs_reinit_stress; do for i in $(seq 1 1000); do /path/to/sentry_test_unit --no-summary "$tst" >/dev/null || exit 1; done; done
```

#skip-changelog (follow-up fix to unreleased #1946)