### PR TITLE
ref: add sentry_attachment_t accessors

### DIFF
--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -789,7 +789,11 @@ crashpad_backend_startup(
     // register attachments
     for (sentry_attachment_t *attachment = options->attachments; attachment;
         attachment = attachment->next) {
-        attachments.emplace_back(SENTRY_PATH_PLATFORM_STR(attachment->path));
+        sentry_path_t *path = sentry__attachment_make_path(attachment);
+        if (path) {
+            attachments.emplace_back(SENTRY_PATH_PLATFORM_STR(path));
+            sentry__path_free(path);
+        }
     }
 
     // and add the serialized event, and two rotating breadcrumb files
@@ -1162,18 +1166,24 @@ crashpad_backend_add_attachment(
         return;
     }
 
-    if (attachment->buf) {
-        if (!ensure_unique_path(attachment)
-            || sentry__path_write_buffer(
-                   attachment->path, attachment->buf, attachment->buf_len)
-                != 0) {
-            SENTRY_WARNF("failed to write crashpad attachment \"%s\"",
-                attachment->path->path);
-        }
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(attachment, &bytes_len);
+    sentry_path_t *path = nullptr;
+    if (!bytes || ensure_unique_path(attachment)) {
+        path = sentry__attachment_make_path(attachment);
     }
 
-    data->client->AddAttachment(
-        base::FilePath(SENTRY_PATH_PLATFORM_STR(attachment->path)));
+    if (bytes
+        && (!path || sentry__path_write_buffer(path, bytes, bytes_len) != 0)) {
+        SENTRY_WARNF("failed to write crashpad attachment \"%s\"",
+            sentry__attachment_get_path(attachment));
+    }
+
+    if (path) {
+        data->client->AddAttachment(
+            base::FilePath(SENTRY_PATH_PLATFORM_STR(path)));
+    }
+    sentry__path_free(path);
 }
 
 static void
@@ -1184,13 +1194,18 @@ crashpad_backend_remove_attachment(
     if (!data || !data->client) {
         return;
     }
-    data->client->RemoveAttachment(
-        base::FilePath(SENTRY_PATH_PLATFORM_STR(attachment->path)));
-
-    if (attachment->buf && sentry__path_remove(attachment->path) != 0) {
-        SENTRY_WARNF("failed to remove crashpad attachment \"%s\"",
-            attachment->path->path);
+    sentry_path_t *path = sentry__attachment_make_path(attachment);
+    if (!path) {
+        return;
     }
+    data->client->RemoveAttachment(
+        base::FilePath(SENTRY_PATH_PLATFORM_STR(path)));
+
+    if (sentry__attachment_get_bytes(attachment, nullptr)
+        && sentry__path_remove(path) != 0) {
+        SENTRY_WARNF("failed to remove crashpad attachment \"%s\"", path->path);
+    }
+    sentry__path_free(path);
 }
 #endif
 

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -741,23 +741,26 @@ native_backend_write_attachments(const sentry_path_t *event_path)
             sentry_value_t attach_list = sentry_value_new_list();
             for (sentry_attachment_t *it = scope->attachments; it;
                 it = it->next) {
-                if (!it->path) {
+                const char *path = sentry__attachment_get_path(it);
+                if (!path) {
                     continue;
                 }
                 sentry_value_t attach_info = sentry_value_new_object();
-                sentry_value_set_by_key(attach_info, "path",
-                    sentry_value_new_string(it->path->path));
-                const char *filename = sentry__path_filename(
-                    it->filename ? it->filename : it->path);
+                sentry_value_set_by_key(
+                    attach_info, "path", sentry_value_new_string(path));
+                const char *filename = sentry__attachment_get_filename(it);
                 sentry_value_set_by_key(
                     attach_info, "filename", sentry_value_new_string(filename));
-                if (it->type && *it->type) {
+                const char *type = sentry__attachment_get_type(it);
+                if (type && *type) {
                     sentry_value_set_by_key(attach_info, "attachment_type",
-                        sentry_value_new_string(it->type));
+                        sentry_value_new_string(type));
                 }
-                if (it->content_type) {
+                const char *content_type
+                    = sentry__attachment_get_content_type(it);
+                if (content_type) {
                     sentry_value_set_by_key(attach_info, "content_type",
-                        sentry_value_new_string(it->content_type));
+                        sentry_value_new_string(content_type));
                 }
                 sentry_value_append(attach_list, attach_info);
             }
@@ -941,8 +944,10 @@ native_backend_add_attachment(
 
     // For buffer attachments, assign a path in the run directory and write to
     // disk
-    if (attachment->buf) {
-        if (!attachment->path) {
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(attachment, &bytes_len);
+    if (bytes) {
+        if (!sentry__attachment_get_path(attachment)) {
             if (!ensure_attachment_path(attachment)) {
                 SENTRY_WARN("failed to assign path for buffer attachment");
                 return;
@@ -950,12 +955,12 @@ native_backend_add_attachment(
         }
 
         // Write buffer to disk
-        if (sentry__path_write_buffer(
-                attachment->path, attachment->buf, attachment->buf_len)
-            != 0) {
+        sentry_path_t *path = sentry__attachment_make_path(attachment);
+        if (!path || sentry__path_write_buffer(path, bytes, bytes_len) != 0) {
             SENTRY_WARNF("failed to write native backend attachment \"%s\"",
-                attachment->path->path);
+                sentry__attachment_get_path(attachment));
         }
+        sentry__path_free(path);
     }
     // For file attachments, the path is already set and points to the actual
     // file. The crash daemon will read these files from their original

--- a/src/integrations/sentry_integration_wer.c
+++ b/src/integrations/sentry_integration_wer.c
@@ -119,16 +119,24 @@ wer_remove_tag(void *data, const char *key)
     sentry_free(key_w);
 }
 
+static sentry_path_t *
+wer_attachment_path(const sentry_attachment_t *attachment)
+{
+    sentry_path_t *path = sentry__attachment_make_path(attachment);
+    if (!path) {
+        return NULL;
+    }
+    sentry_path_t *absolute_path = sentry__path_absolute(path);
+    sentry__path_free(path);
+    return absolute_path;
+}
+
 static void
 wer_add_attachment(void *UNUSED(data), sentry_attachment_t *attachment)
 {
-    if (!attachment) {
-        return;
-    }
-
-    if (attachment->path) {
-        sentry_path_t *path = sentry__path_absolute(attachment->path);
-        if (!path || wcslen(path->path_w) > WER_MAX_PARAM_LENGTH) {
+    sentry_path_t *path = wer_attachment_path(attachment);
+    if (path) {
+        if (wcslen(path->path_w) > WER_MAX_PARAM_LENGTH) {
             sentry__path_free(path);
             return;
         }
@@ -142,10 +150,10 @@ wer_add_attachment(void *UNUSED(data), sentry_attachment_t *attachment)
         return;
     }
 
-    if (attachment->buf && attachment->buf_len > 0
-        && attachment->buf_len <= WER_MAX_MEM_BLOCK_SIZE) {
-        HRESULT hr = WerRegisterMemoryBlock(
-            (PVOID)attachment->buf, (DWORD)attachment->buf_len);
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(attachment, &bytes_len);
+    if (bytes && bytes_len > 0 && bytes_len <= WER_MAX_MEM_BLOCK_SIZE) {
+        HRESULT hr = WerRegisterMemoryBlock((PVOID)bytes, (DWORD)bytes_len);
         if (FAILED(hr)) {
             SENTRY_WARNF(
                 "WerRegisterMemoryBlock failed: hr=0x%08lx", (unsigned long)hr);
@@ -157,13 +165,9 @@ wer_add_attachment(void *UNUSED(data), sentry_attachment_t *attachment)
 static void
 wer_remove_attachment(void *UNUSED(data), sentry_attachment_t *attachment)
 {
-    if (!attachment) {
-        return;
-    }
-
-    if (attachment->path) {
-        sentry_path_t *path = sentry__path_absolute(attachment->path);
-        if (!path || wcslen(path->path_w) > WER_MAX_PARAM_LENGTH) {
+    sentry_path_t *path = wer_attachment_path(attachment);
+    if (path) {
+        if (wcslen(path->path_w) > WER_MAX_PARAM_LENGTH) {
             sentry__path_free(path);
             return;
         }
@@ -176,9 +180,10 @@ wer_remove_attachment(void *UNUSED(data), sentry_attachment_t *attachment)
         return;
     }
 
-    if (attachment->buf && attachment->buf_len > 0
-        && attachment->buf_len <= WER_MAX_MEM_BLOCK_SIZE) {
-        HRESULT hr = WerUnregisterMemoryBlock((PVOID)attachment->buf);
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(attachment, &bytes_len);
+    if (bytes && bytes_len > 0 && bytes_len <= WER_MAX_MEM_BLOCK_SIZE) {
+        HRESULT hr = WerUnregisterMemoryBlock((PVOID)bytes);
         if (FAILED(hr)) {
             SENTRY_WARNF("WerUnregisterMemoryBlock failed: hr=0x%08lx",
                 (unsigned long)hr);

--- a/src/sentry_attachment.c
+++ b/src/sentry_attachment.c
@@ -8,6 +8,12 @@
 
 #include <string.h>
 
+const char *
+sentry__attachment_get_type(const sentry_attachment_t *attachment)
+{
+    return attachment ? attachment->type : NULL;
+}
+
 void
 sentry_attachment_set_type(sentry_attachment_t *attachment, const char *type)
 {
@@ -55,6 +61,12 @@ sentry__attachment_set_type_n(
             attachment->content_type = sentry__string_clone("application/json");
         }
     }
+}
+
+const char *
+sentry__attachment_get_content_type(const sentry_attachment_t *attachment)
+{
+    return attachment ? attachment->content_type : NULL;
 }
 
 void
@@ -220,11 +232,39 @@ sentry__attachment_get_size(const sentry_attachment_t *attachment)
 }
 
 const char *
+sentry__attachment_get_bytes(const sentry_attachment_t *attachment, size_t *len)
+{
+    if (!attachment || !attachment->buf) {
+        if (len) {
+            *len = 0;
+        }
+        return NULL;
+    }
+
+    if (len) {
+        *len = attachment->buf_len;
+    }
+    return attachment->buf;
+}
+
+const char *
 sentry__attachment_get_filename(const sentry_attachment_t *attachment)
 {
     const sentry_path_t *path
         = attachment->filename ? attachment->filename : attachment->path;
     return path ? sentry__path_filename(path) : NULL;
+}
+
+const char *
+sentry__attachment_get_path(const sentry_attachment_t *attachment)
+{
+    return attachment && attachment->path ? attachment->path->path : NULL;
+}
+
+sentry_path_t *
+sentry__attachment_make_path(const sentry_attachment_t *attachment)
+{
+    return sentry__path_from_str(sentry__attachment_get_path(attachment));
 }
 
 bool

--- a/src/sentry_attachment.h
+++ b/src/sentry_attachment.h
@@ -55,16 +55,45 @@ void sentry__attachment_set_filenamew_n(sentry_attachment_t *attachment,
 #endif
 
 /**
+ * Returns the attachment type.
+ */
+const char *sentry__attachment_get_type(const sentry_attachment_t *attachment);
+
+/**
+ * Returns the attachment content type.
+ */
+const char *sentry__attachment_get_content_type(
+    const sentry_attachment_t *attachment);
+
+/**
  * Returns the size in bytes of the attachment's data (buffer length or file
  * size).
  */
 size_t sentry__attachment_get_size(const sentry_attachment_t *attachment);
 
 /**
+ * Returns the in-memory attachment bytes and writes their length to `len` if
+ * provided.
+ */
+const char *sentry__attachment_get_bytes(
+    const sentry_attachment_t *attachment, size_t *len);
+
+/**
  * Returns the filename string for the attachment (basename of `filename` if
  * set, otherwise basename of `path`).
  */
 const char *sentry__attachment_get_filename(
+    const sentry_attachment_t *attachment);
+
+/**
+ * Returns the attachment path string.
+ */
+const char *sentry__attachment_get_path(const sentry_attachment_t *attachment);
+
+/**
+ * Creates an owned path object for the attachment path.
+ */
+sentry_path_t *sentry__attachment_make_path(
     const sentry_attachment_t *attachment);
 
 /**

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -314,7 +314,8 @@ static sentry_path_t *
 build_sibling_path(const sentry_path_t *cache_path, const char *uuid_str,
     const sentry_attachment_t *att)
 {
-    if (att->type && strcmp(att->type, SENTRY_ATTACHMENT_TYPE_MINIDUMP) == 0) {
+    const char *type = sentry__attachment_get_type(att);
+    if (type && strcmp(type, SENTRY_ATTACHMENT_TYPE_MINIDUMP) == 0) {
         char buf[41];
         snprintf(buf, sizeof(buf), "%s.dmp", uuid_str);
         return sentry__path_unique(cache_path, buf);
@@ -336,32 +337,40 @@ cache_attachment_ref(sentry_envelope_t *envelope,
     const sentry_attachment_t *att, const sentry_path_t *cache_path,
     const char *uuid_str, const sentry_path_t *run_path)
 {
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(att, &bytes_len);
+    sentry_path_t *path = bytes ? NULL : sentry__attachment_make_path(att);
+
     // File-backed attachments must exist on disk.
-    if (!att->buf && !sentry__path_is_file(att->path)) {
+    if (!bytes && (!path || !sentry__path_is_file(path))) {
+        sentry__path_free(path);
         return false;
     }
 
     if (sentry__path_create_dir_all(cache_path) != 0) {
+        sentry__path_free(path);
         return false;
     }
 
     const char *raw_filename = sentry__attachment_get_filename(att);
     sentry_path_t *dst = build_sibling_path(cache_path, uuid_str, att);
     if (!dst) {
+        sentry__path_free(path);
         return false;
     }
 
     int rv;
-    if (att->buf) {
-        rv = sentry__path_write_buffer(dst, att->buf, att->buf_len);
+    if (bytes) {
+        rv = sentry__path_write_buffer(dst, bytes, bytes_len);
     } else {
-        sentry_path_t *src_dir = sentry__path_dir(att->path);
+        sentry_path_t *src_dir = sentry__path_dir(path);
         bool is_run_owned
             = run_path && src_dir && sentry__path_eq(src_dir, run_path);
         sentry__path_free(src_dir);
-        rv = is_run_owned ? sentry__path_rename(att->path, dst)
-                          : sentry__path_copy(att->path, dst);
+        rv = is_run_owned ? sentry__path_rename(path, dst)
+                          : sentry__path_copy(path, dst);
     }
+    sentry__path_free(path);
     if (rv != 0) {
         sentry__path_remove(dst);
         sentry__path_free(dst);
@@ -371,9 +380,10 @@ cache_attachment_ref(sentry_envelope_t *envelope,
     size_t file_size = sentry__path_get_size(dst);
     sentry_attachment_ref_t ref = { 0 };
     ref.path = sentry__path_filename(dst);
-    ref.content_type = att->content_type;
+    ref.content_type = sentry__attachment_get_content_type(att);
+    const char *type = sentry__attachment_get_type(att);
     sentry_envelope_item_t *item = sentry__envelope_add_attachment_ref(
-        envelope, &ref, raw_filename, att->type, file_size);
+        envelope, &ref, raw_filename, type, file_size);
     if (!item) {
         sentry__path_remove(dst);
         sentry__path_free(dst);

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -791,7 +791,7 @@ sentry_envelope_item_t *
 sentry__envelope_add_from_path(
     sentry_envelope_t *envelope, const sentry_path_t *path, const char *type)
 {
-    if (!envelope) {
+    if (!envelope || !path) {
         return NULL;
     }
     size_t buf_len;

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -729,24 +729,29 @@ sentry__envelope_add_attachment(
         return NULL;
     }
 
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(attachment, &bytes_len);
     sentry_envelope_item_t *item = NULL;
-    if (attachment->buf) {
+    if (bytes) {
         item = sentry__envelope_add_from_buffer(
-            envelope, attachment->buf, attachment->buf_len, "attachment");
+            envelope, bytes, bytes_len, "attachment");
     } else {
-        item = sentry__envelope_add_from_path(
-            envelope, attachment->path, "attachment");
+        sentry_path_t *path = sentry__attachment_make_path(attachment);
+        item = sentry__envelope_add_from_path(envelope, path, "attachment");
+        sentry__path_free(path);
     }
     if (!item) {
         return NULL;
     }
-    if (attachment->type && *attachment->type) {
+    const char *type = sentry__attachment_get_type(attachment);
+    if (type && *type) {
         sentry__envelope_item_set_header(
-            item, "attachment_type", sentry_value_new_string(attachment->type));
+            item, "attachment_type", sentry_value_new_string(type));
     }
-    if (attachment->content_type) {
-        sentry__envelope_item_set_header(item, "content_type",
-            sentry_value_new_string(attachment->content_type));
+    const char *content_type = sentry__attachment_get_content_type(attachment);
+    if (content_type) {
+        sentry__envelope_item_set_header(
+            item, "content_type", sentry_value_new_string(content_type));
     }
     sentry__envelope_item_set_header(item, "filename",
         sentry_value_new_string(sentry__attachment_get_filename(attachment)));

--- a/tests/unit/test_attachments.c
+++ b/tests/unit/test_attachments.c
@@ -355,16 +355,18 @@ SENTRY_TEST(attachment_properties)
 
     sentry_attachment_t attachment = { 0 };
     sentry_attachment_set_type(&attachment, SENTRY_ATTACHMENT_TYPE_MINIDUMP);
-    TEST_CHECK_STRING_EQUAL(
-        attachment.content_type, "application/octet-stream");
+    TEST_CHECK_STRING_EQUAL(sentry__attachment_get_content_type(&attachment),
+        "application/octet-stream");
     sentry_attachment_set_content_type(&attachment, "application/x-dmp");
     sentry_attachment_set_type(
         &attachment, SENTRY_ATTACHMENT_TYPE_VIEW_HIERARCHY);
-    TEST_CHECK_STRING_EQUAL(attachment.content_type, "application/x-dmp");
+    TEST_CHECK_STRING_EQUAL(
+        sentry__attachment_get_content_type(&attachment), "application/x-dmp");
     sentry_attachment_set_content_type(&attachment, NULL);
     sentry_attachment_set_type(
         &attachment, SENTRY_ATTACHMENT_TYPE_VIEW_HIERARCHY);
-    TEST_CHECK_STRING_EQUAL(attachment.content_type, "application/json");
+    TEST_CHECK_STRING_EQUAL(
+        sentry__attachment_get_content_type(&attachment), "application/json");
     sentry_free(attachment.type);
     sentry_free(attachment.content_type);
 

--- a/tests/unit/test_scope.c
+++ b/tests/unit/test_scope.c
@@ -1467,9 +1467,11 @@ observe_add_attachment(void *data, sentry_attachment_t *attachment)
         sentry_value_set_by_key(
             obj, "filename", sentry_value_new_string(filename));
     }
-    if (attachment->buf) {
-        sentry_value_set_by_key(obj, "buf",
-            sentry_value_new_string_n(attachment->buf, attachment->buf_len));
+    size_t bytes_len = 0;
+    const char *bytes = sentry__attachment_get_bytes(attachment, &bytes_len);
+    if (bytes) {
+        sentry_value_set_by_key(
+            obj, "buf", sentry_value_new_string_n(bytes, bytes_len));
     }
     sentry_value_append(d->attachments, obj);
     d->was_called = true;
@@ -2526,7 +2528,7 @@ SENTRY_TEST(scope_clone_preserves_data)
     TEST_CHECK(clone->attachments != scope->attachments);
     TEST_CHECK_STRING_EQUAL(
         sentry__attachment_get_filename(clone->attachments), "file.bin");
-    TEST_CHECK_INT_EQUAL(clone->attachments->buf_len, 7);
+    TEST_CHECK_INT_EQUAL(sentry__attachment_get_size(clone->attachments), 7);
 
     sentry_scope_free(clone);
     sentry_scope_free(scope);


### PR DESCRIPTION
This is a **non-breaking** preparation step for the breaking stacked PR:
- #1974

This adds internal accessors for attachment properties, reducing direct access to the `sentry_attachment_s` data structure and moving mechanical churn out of #1974. This makes the large value-based attachment migration slightly smaller, easier to review, and less conflict-prone without changing behavior, and helps with partial pre-migration of console repos.

#skip-changelog (internal)