### PR TITLE
ci: add GCC+MSVC analyzer builds and CppCheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
             os: ubuntu-24.04
             CC: gcc-14
             CXX: g++-14
+          - name: Linux (GCC 14 + analyzer)
+            os: ubuntu-24.04
+            CC: gcc-14
+            CXX: g++-14
+            RUN_ANALYZER: gcc
           - name: Linux (GCC 15 + runtime curl)
             os: ubuntu-26.04
             CC: gcc-15
@@ -189,6 +194,9 @@ jobs:
             TEST_X86: 1
           - name: Windows (latest)
             os: windows-latest
+          - name: Windows (MSVC analyzer)
+            os: windows-2022
+            RUN_ANALYZER: msvc
           - name: Windows arm64
             os: windows-11-arm
           - name: Windows (latest, UTF-8 paths)
@@ -537,7 +545,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install cmake clang clang-tidy gcc-13 g++-13 zlib1g-dev libcurl4-openssl-dev
+          sudo apt install cmake clang clang-tidy cppcheck gcc-13 g++-13 zlib1g-dev libcurl4-openssl-dev
           python -m pip install codechecker==6.28.2
 
       - name: Analyze

--- a/scripts/run-codechecker.py
+++ b/scripts/run-codechecker.py
@@ -62,6 +62,7 @@ def main():
             "--analyzers",
             "clangsa",
             "clang-tidy",
+            "cppcheck",
             *("--disable={}".format(checker) for checker in disabled_checkers),
             "--print-steps",
             "--ignore",

--- a/tests/build_config.py
+++ b/tests/build_config.py
@@ -99,7 +99,7 @@ def get_cflags(extra_cflags=None):
 
     This handles:
     - ERROR_ON_WARNINGS -> -Werror
-    - MSVC parallel builds and warnings as errors
+    - MSVC parallel builds, warnings as errors, and code analysis
     - GCC analyzer
 
     Args:
@@ -113,6 +113,8 @@ def get_cflags(extra_cflags=None):
     if sys.platform == "win32" and not os.environ.get("TEST_MINGW"):
         cpus = os.cpu_count()
         cflags.append("/WX /MP{}".format(cpus))
+        if "msvc" in os.environ.get("RUN_ANALYZER", ""):
+            cflags.append("/analyze /analyze:WX-")
 
     if "gcc" in os.environ.get("RUN_ANALYZER", ""):
         cflags.append("-fanalyzer")


### PR DESCRIPTION
To increase confidence that https://github.com/getsentry/sentry-native/pull/2013 won't accidentally trigger static code analysis failures.

See also:
- https://github.com/getsentry/sentry-native/pull/2013