### PR TITLE
test(windows): cover invalid-parameter crashes

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -7,6 +7,9 @@
 #endif
 
 #include "sentry.h"
+#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
+#    include <corecrt.h>
+#endif
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -500,6 +503,14 @@ trigger_fastfail_crash()
     // this bypasses WINDOWS SEH and will only be caught with the
     // crashpad/native WER module enabled
     RaiseFailFastException(NULL, NULL, 0);
+}
+
+static void
+trigger_invalid_parameter()
+{
+    // with no custom handler, this invokes _invoke_watson and fast-fails:
+    // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/invalid-parameter-functions
+    _invalid_parameter_noinfo();
 }
 
 #endif
@@ -1325,6 +1336,9 @@ main(int argc, char **argv)
     && !defined(__MINGW64__)
     if (has_arg(argc, argv, "fastfail")) {
         trigger_fastfail_crash();
+    }
+    if (has_arg(argc, argv, "invalid-parameter")) {
+        trigger_invalid_parameter();
     }
     if (has_arg(argc, argv, "stack-buffer-overrun")) {
         trigger_stack_buffer_overrun();

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -425,7 +425,7 @@ def wait_for_no_werfault(timeout=30.0, poll_interval=0.5):
         (["fastfail"]),
         (["fastfail", "discarding-before-send"]),
         (["fastfail", "discarding-on-crash"]),
-        pytest.param(["invalid-parameter"], id="invalid-parameter"),
+        (["invalid-parameter"]),
     ],
 )
 def test_crashpad_wer_crash(cmake, httpserver, run_args):

--- a/tests/test_integration_crashpad.py
+++ b/tests/test_integration_crashpad.py
@@ -425,6 +425,7 @@ def wait_for_no_werfault(timeout=30.0, poll_interval=0.5):
         (["fastfail"]),
         (["fastfail", "discarding-before-send"]),
         (["fastfail", "discarding-on-crash"]),
+        pytest.param(["invalid-parameter"], id="invalid-parameter"),
     ],
 )
 def test_crashpad_wer_crash(cmake, httpserver, run_args):

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -145,6 +145,11 @@ def test_native_on_crashed_last_run(cmake, httpserver):
     "crash_arg,exception_code",
     [
         pytest.param("fastfail", STATUS_FAIL_FAST_EXCEPTION, id="fastfail"),
+        pytest.param(
+            "invalid-parameter",
+            STATUS_STACK_BUFFER_OVERRUN,
+            id="invalid-parameter",
+        ),
         pytest.param("heap-corruption", STATUS_HEAP_CORRUPTION, id="heap-corruption"),
         pytest.param(
             "stack-buffer-overrun",


### PR DESCRIPTION
Both `crashpad` and `native` capture [invalid-parameter](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/invalid-parameter-functions?view=msvc-170) errors via WER:

```cmd
(.venv) C:\Users\jpnurmi\Projects\sentry\sentry-native>pytest --with_wer -v tests\ -k "invalid-parameter"
=================================================================== test session starts ====================================================================
platform win32 -- Python 3.13.3, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\jpnurmi\Projects\sentry\sentry-native\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\jpnurmi\Projects\sentry\sentry-native
plugins: flaky-3.8.1, pytest_httpserver-1.0.10, xdist-3.8.0
collected 2020 items / 2018 deselected / 2 selected

tests/test_integration_crashpad.py::test_crashpad_wer_crash[invalid-parameter] PASSED                                                                 [ 50%]
tests/test_integration_native.py::test_native_wer_crash[invalid-parameter] PASSED                                                                     [100%]
```

Close: #327