### PR TITLE
doc(logs): correct format argument guidance

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -1025,8 +1025,7 @@ main(int argc, char **argv)
         sentry_value_set_by_key(attributes, "number.first", attr_2);
         sentry_value_set_by_key(attributes, "number.second", attr_3);
         // testing multiple attributes
-        sentry_log_debug(
-            "logging with %d custom attributes", attributes, (int64_t)3);
+        sentry_log_debug("logging with %d custom attributes", attributes, 3);
         // testing no attributes
         sentry_log_debug("logging with %s custom attributes",
             sentry_value_new_object(), "no");

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -3027,18 +3027,16 @@ typedef enum {
  * Format string restrictions:
  * Only a subset of printf format specifiers are supported for parameter
  * extraction. Supported specifiers include:
- * - %d, %i - signed integers (treated as long long)
- * - %u, %x, %X, %o - unsigned integers (treated as unsigned long long)
- * - %f, %F, %e, %E, %g, %G - floating point numbers (treated as double)
+ * - %d, %i - signed integers
+ * - %u, %x, %X, %o - unsigned integers
+ * - %f, %F, %e, %E, %g, %G - floating point numbers
  * - %c - single character
  * - %s - null-terminated string (null pointers are handled as "(null)")
  * - %p - pointer value (formatted as hexadecimal string)
  *
  * Unsupported format specifiers will consume their corresponding argument
  * but will be recorded as "(unknown)" in the structured log data.
- * Length modifiers (h, l, L, z, j, t) are parsed but ignored.
- *
- * Because of this, please only use 64-bit types/casts for your arguments.
+ * Standard printf argument types and length modifiers are honored.
  *
  * Flags, width, and precision specifiers are parsed but currently ignored for
  * parameter extraction purposes.


### PR DESCRIPTION
Use the standard `%d` argument type in the example and remove the stale guidance requiring 64-bit arguments.

See also:
- #1752
