### PR TITLE
fix(unwind): prevent section table size overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Fixes**:
 
 - Native/Linux: prevent the crash daemon from hanging when module discovery encounters device-backed memory mappings. ([#2025](https://github.com/getsentry/sentry-native/pull/2025))
+- Linux: prevent integer overflow when validating ELF section tables in vendored libunwind. ([#2028](https://github.com/getsentry/sentry-native/pull/2028))
 
 **Other changes**:
 

--- a/vendor/libunwind/VENDORING.md
+++ b/vendor/libunwind/VENDORING.md
@@ -122,7 +122,7 @@ never calls into the C++ exception ABI.
 
 ## Source Modifications
 
-Only **one** upstream source file was modified:
+Two upstream source files were modified:
 
 ### `include/libunwind-aarch64.h` — `alignas` → `__attribute__((aligned))`
 
@@ -137,6 +137,15 @@ uint8_t __reserved[(66 * 8)] __attribute__((aligned(16)));
 **Reason**: The SDK targets C99.  `alignas` is a C11 keyword.  The
 `__attribute__((aligned(...)))` form is semantically equivalent and supported by
 both GCC and Clang.
+
+### `src/elfxx.c` — overflow-safe section table bounds check
+
+The section table size is calculated as `size_t`, and its bounds are checked
+against the remaining image size instead of adding it to the section offset.
+
+**Reason**: Malformed ELF header values could overflow during the section table
+size calculation or offset addition and bypass the bounds check.  Identified by
+[CodeQL alert #5](https://github.com/getsentry/sentry-native/security/code-scanning/5).
 
 ## How to Update the Vendored Version
 
@@ -169,6 +178,8 @@ both GCC and Clang.
 6. **Re-apply source modifications**:
    - Check `include/libunwind-aarch64.h` for `alignas` — replace with
      `__attribute__((aligned(...)))`.
+   - Re-apply the overflow-safe section table bounds check in `src/elfxx.c` if
+     upstream does not contain an equivalent fix.
    - Scan for other C11/C23 constructs incompatible with C99.
 
 7. Build and test on all four architectures: x86_64, x86 (32-bit), aarch64, arm (32-bit).

--- a/vendor/libunwind/src/elfxx.c
+++ b/vendor/libunwind/src/elfxx.c
@@ -67,12 +67,14 @@ elf_w (section_table) (const struct elf_image *ei)
 {
   Elf_W (Ehdr) *ehdr = ei->image;
   Elf_W (Off) soff;
+  size_t table_size;
 
   soff = ehdr->e_shoff;
-  if (soff + ehdr->e_shnum * ehdr->e_shentsize > ei->size)
+  table_size = (size_t) ehdr->e_shnum * ehdr->e_shentsize;
+  if (soff > ei->size || table_size > ei->size - (size_t) soff)
     {
-      Debug (1, "section table outside of image? (%lu > %lu)\n",
-             (unsigned long) (soff + ehdr->e_shnum * ehdr->e_shentsize),
+      Debug (1, "section table outside of image? (%lu + %lu > %lu)\n",
+             (unsigned long) soff, (unsigned long) table_size,
              (unsigned long) ei->size);
       return NULL;
     }

--- a/vendor/libunwind/src/elfxx.c
+++ b/vendor/libunwind/src/elfxx.c
@@ -73,9 +73,8 @@ elf_w (section_table) (const struct elf_image *ei)
   table_size = (size_t) ehdr->e_shnum * ehdr->e_shentsize;
   if (soff > ei->size || table_size > ei->size - (size_t) soff)
     {
-      Debug (1, "section table outside of image? (%lu + %lu > %lu)\n",
-             (unsigned long) soff, (unsigned long) table_size,
-             (unsigned long) ei->size);
+      Debug(1, "section table outside of image? (%lu + %zu > %zu)\n",
+            (unsigned long)soff, table_size, ei->size);
       return NULL;
     }
 


### PR DESCRIPTION
Calculate malformed ELF section table bounds without overflowing the promoted header fields or their offset sum.

Fixes: https://github.com/getsentry/sentry-native/security/code-scanning/5

> [!WARNING]
> ### Multiplication result converted to larger type
> Multiplication result may overflow 'int' before it is converted to 'unsigned long'.

https://codeql.github.com/codeql-query-help/cpp/cpp-integer-multiplication-cast-to-long/