### PR TITLE
test(benchmark): crash handler stack usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1050,6 +1050,7 @@ if(SENTRY_BUILD_TESTS)
 		set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
 		add_subdirectory(external/benchmark)
 		add_subdirectory(tests/benchmark)
+		add_subdirectory(tests/fixtures/stack_usage)
 	endif()
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,22 @@ benchmark: setup-venv
 	$(VENV_BIN)/pytest tests/benchmark.py --verbose
 .PHONY: benchmark
 
+stack-frames:
+	@cmake -E remove_directory stack-frames-build/CMakeFiles/sentry.dir
+	@cmake -S . -B stack-frames-build \
+		-DCMAKE_C_FLAGS=-fstack-usage \
+		-DCMAKE_CXX_FLAGS=-fstack-usage \
+		$(if $(SENTRY_BACKEND),-DSENTRY_BACKEND=$(SENTRY_BACKEND),-U SENTRY_BACKEND) \
+		-DSENTRY_BUILD_TESTS=OFF
+	@cmake --build stack-frames-build \
+		--target sentry --parallel
+	@# reoder bytes first for sorting ("<file>:<line>:<column>:<function>\t<bytes>\t<qualifiers>")
+	@find stack-frames-build/CMakeFiles/sentry.dir -name '*.su' \
+		-exec awk -F '\t' -v OFS='\t' -v root="$(CURDIR)/" '{ print $$2, substr($$1, length(root) + 1), $$3 }' {} + \
+		| sort -k1,1nr -k2,2 \
+		| head -n $(or $(N),20)
+.PHONY: stack-frames
+
 clean: build/Makefile
 	@$(MAKE) -C build clean
 .PHONY: clean

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -14,3 +14,11 @@ function(sentry_add_version_resource TGT FILE_DESCRIPTION)
 	# Finally add the generated resource file to the target sources
 	target_sources("${TGT}" PRIVATE "${RESOURCE_PATH}")
 endfunction()
+
+function(sentry_get_property NAME)
+	get_target_property(prop sentry "${NAME}")
+	if(NOT prop)
+		set(prop)
+	endif()
+	set("SENTRY_${NAME}" "${prop}" PARENT_SCOPE)
+endfunction()

--- a/src/backends/native/sentry_crash_handler.c
+++ b/src/backends/native/sentry_crash_handler.c
@@ -291,6 +291,7 @@ safe_build_stack_path(
 static void
 crash_signal_handler(int signum, siginfo_t *info, void *context)
 {
+    sentry__enter_crash_handler();
     ucontext_t *uctx = (ucontext_t *)context;
 
 #    if defined(SENTRY_PLATFORM_LINUX) && !defined(SENTRY_PLATFORM_ANDROID)
@@ -307,6 +308,7 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
         // case this was not a native crash for Sentry to capture.
         if (ip != sentry__ucontext_get_ip(uctx)
             || sp != sentry__ucontext_get_sp(uctx)) {
+            sentry__exit_crash_handler();
             return;
         }
     }
@@ -321,6 +323,7 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
             invoke_previous_signal_handler(signum, info, context);
         }
         // The previous handler returned, fall back to default termination
+        sentry__exit_crash_handler();
         reraise_signal(signum);
         return;
     }
@@ -329,6 +332,7 @@ crash_signal_handler(int signum, siginfo_t *info, void *context)
     static volatile long handling_crash = 0;
     if (!sentry__atomic_compare_swap(&handling_crash, 0, 1)) {
         // Already handling a crash, just exit immediately
+        sentry__exit_crash_handler();
         _exit(1);
     }
 
@@ -834,6 +838,7 @@ daemon_handling:
     }
 
     // Re-enable previous signal handlers before re-raising to prevent loops
+    sentry__exit_crash_handler();
     reset_signal_handlers();
 
     if (g_handler_strategy != SENTRY_HANDLER_STRATEGY_CHAIN_AT_START) {
@@ -979,16 +984,19 @@ crash_sigabrt_handler(EXCEPTION_POINTERS *exception_pointers)
 static LONG WINAPI
 crash_exception_filter(EXCEPTION_POINTERS *exception_info)
 {
+    sentry__enter_crash_handler();
     // Only handle crash once
     static volatile long handling_crash = 0;
     if (!sentry__atomic_compare_swap(&handling_crash, 0, 1)) {
         // Already handling a crash (no logging - exception filter context)
+        sentry__exit_crash_handler();
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
     sentry_crash_ipc_t *ipc = g_crash_ipc;
     if (!ipc || !ipc->shmem) {
         // No IPC or shared memory (no logging - exception filter context)
+        sentry__exit_crash_handler();
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
@@ -1049,6 +1057,7 @@ crash_exception_filter(EXCEPTION_POINTERS *exception_info)
     }
 
     // Continue to default handler (which will terminate the process)
+    sentry__exit_crash_handler();
     return EXCEPTION_CONTINUE_SEARCH;
 }
 

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -112,6 +112,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
     sentry__page_allocator_enable();
     (void)!sentry__enter_signal_handler();
 #endif
+    sentry__enter_crash_handler();
 
     sentry_path_t *dump_path = nullptr;
 #ifdef SENTRY_PLATFORM_WINDOWS
@@ -285,6 +286,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
     }
     SENTRY_SIGNAL_SAFE_LOG("INFO crash has been captured");
 
+    sentry__exit_crash_handler();
 #ifndef SENTRY_PLATFORM_WINDOWS
     sentry__leave_signal_handler();
 #endif

--- a/src/backends/sentry_backend_crashpad.cpp
+++ b/src/backends/sentry_backend_crashpad.cpp
@@ -450,6 +450,7 @@ crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
     sentry__page_allocator_enable();
     (void)!sentry__enter_signal_handler();
 #    endif
+    sentry__enter_crash_handler();
     // Disable logging during crash handling if the option is set
     SENTRY_WITH_OPTIONS (options) {
         if (!options->enable_logging_when_crashed) {
@@ -556,6 +557,7 @@ crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
     // * we should adapt the SetFirstChanceExceptionHandler interface in
     // crashpad
     if (!should_dump) {
+        sentry__exit_crash_handler();
 #    ifdef SENTRY_PLATFORM_WINDOWS
         TerminateProcess(GetCurrentProcess(),
             crashpad::TerminationCodes::kTerminationCodeCrashNoDump);
@@ -564,6 +566,7 @@ crashpad_handler(int signum, siginfo_t *info, ucontext_t *user_context)
 #    endif
     }
 
+    sentry__exit_crash_handler();
 #    ifndef SENTRY_PLATFORM_WINDOWS
     sentry__leave_signal_handler();
 #    endif

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -1209,8 +1209,10 @@ handler_thread_main(void *UNUSED(data))
             continue;
         }
 
+        sentry__enter_crash_handler();
         process_ucontext_deferred(
             &g_handler_state.uctx, g_handler_state.sig_slot, false);
+        sentry__exit_crash_handler();
         sentry__atomic_store(&g_handler_has_work, 0);
 #ifdef SENTRY_PLATFORM_UNIX
         if (g_handler_ack_pipe[1] >= 0) {
@@ -1594,6 +1596,7 @@ process_ucontext(const sentry_ucontext_t *uctx)
     }
 #endif
 
+    sentry__enter_crash_handler();
 #ifdef SENTRY_PLATFORM_UNIX
     int handler_depth = sentry__enter_signal_handler();
     if (handler_depth >= 3) {
@@ -1625,6 +1628,7 @@ process_ucontext(const sentry_ucontext_t *uctx)
             "handler thread not ready, falling through to previous handler");
         reset_signal_handlers();
         sentry__atomic_store(&g_preloaded, 0);
+        sentry__exit_crash_handler();
         sentry__leave_signal_handler();
         invoke_signal_handler(
             uctx->signum, uctx->siginfo, (void *)uctx->user_context);
@@ -1666,6 +1670,7 @@ process_ucontext(const sentry_ucontext_t *uctx)
     // Signal handlers are already reset by the handling thread, so
     // re-executing the crashing instruction will hit the default handler.
     if (!is_handling_thread) {
+        sentry__exit_crash_handler();
         return;
     }
 
@@ -1682,6 +1687,7 @@ cleanup:
     // are unregistered, re-executing their crash will hit the default handler.
     sentry__atomic_store(&g_crash_handling_state, CRASH_STATE_DONE);
 
+    sentry__exit_crash_handler();
     sentry__leave_signal_handler();
     if (g_backend_config.handler_strategy
         != SENTRY_HANDLER_STRATEGY_CHAIN_AT_START) {
@@ -1693,6 +1699,7 @@ cleanup:
     // done. They can now return EXCEPTION_CONTINUE_SEARCH from their UEF,
     // allowing the exception to propagate and terminate the process.
     sentry__atomic_store(&g_crash_handling_state, CRASH_STATE_DONE);
+    sentry__exit_crash_handler();
 #endif
 }
 

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -120,6 +120,34 @@ unregister_integrations(sentry_scope_t *scope, const sentry_options_t *options)
     }
 }
 
+void
+sentry__enter_crash_handler(void)
+{
+    const sentry_options_t *options = g_options;
+    if (options) {
+        for (size_t i = 0; i < options->num_integrations; i++) {
+            sentry_integration_t *integration = options->integrations[i];
+            if (integration->crash_handler_enter_func) {
+                integration->crash_handler_enter_func(integration->data);
+            }
+        }
+    }
+}
+
+void
+sentry__exit_crash_handler(void)
+{
+    const sentry_options_t *options = g_options;
+    if (options) {
+        for (size_t i = options->num_integrations; i > 0; i--) {
+            sentry_integration_t *integration = options->integrations[i - 1];
+            if (integration->crash_handler_exit_func) {
+                integration->crash_handler_exit_func(integration->data);
+            }
+        }
+    }
+}
+
 // TODO: remove sentry__native_init after console SDKs have been migrated to
 // platform integrations
 #if (defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)                \

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -151,6 +151,9 @@ void sentry__apply_to_telemetry(const sentry_scope_t *scope,
 bool sentry__launch_external_crash_reporter(
     const sentry_options_t *options, sentry_envelope_t *envelope);
 
+void sentry__enter_crash_handler(void);
+void sentry__exit_crash_handler(void);
+
 #define SENTRY_WITH_OPTIONS(Options)                                           \
     for (const sentry_options_t *Options = sentry__options_getref(); Options;  \
         sentry_options_free((sentry_options_t *)Options), Options = NULL)

--- a/src/sentry_integration.h
+++ b/src/sentry_integration.h
@@ -12,6 +12,8 @@ typedef struct sentry_integration_s {
     void (*unregister_func)(
         void *data, sentry_scope_t *scope, const sentry_options_t *options);
     void (*free_func)(void *data);
+    void (*crash_handler_enter_func)(void *data); // must be async-signal-safe
+    void (*crash_handler_exit_func)(void *data); // must be async-signal-safe
 } sentry_integration_t;
 
 #ifdef SENTRY_INTEGRATION_PLATFORM

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,9 +1,12 @@
 import os
 import shutil
+import subprocess
+import sys
 
 import pytest
 
 from . import lib_name, make_dsn, run
+from .conditions import has_breakpad, has_crashpad, has_native
 
 
 def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label, runs=1):
@@ -100,4 +103,69 @@ def test_benchmark_libsize(backend, cmake, gmeasurement):
         "bytes",
         f"Size {size}b",
         range="linear",
+    )
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "inproc",
+        pytest.param(
+            "breakpad",
+            marks=pytest.mark.skipif(
+                not has_breakpad, reason="breakpad backend not available"
+            ),
+        ),
+        pytest.param(
+            "crashpad",
+            marks=[
+                pytest.mark.skipif(
+                    not has_crashpad, reason="crashpad backend not available"
+                ),
+                pytest.mark.skipif(
+                    sys.platform == "darwin",
+                    reason="crashpad has no first-chance handler on macOS",
+                ),
+            ],
+        ),
+        pytest.param(
+            "native",
+            marks=pytest.mark.skipif(
+                not has_native, reason="native backend not available"
+            ),
+        ),
+    ],
+)
+def test_benchmark_stack_usage(backend, cmake, gmeasurement):
+    tmp_path = cmake(
+        ["sentry_stack_usage"],
+        {
+            "SENTRY_BACKEND": backend,
+            "SENTRY_BUILD_BENCHMARKS": "ON",
+        },
+    )
+
+    result = run(
+        tmp_path,
+        "sentry_stack_usage",
+        [],
+        expect_failure=True,
+        stdout=subprocess.PIPE,
+    )
+
+    prefix = b"[STACK] "
+    suffix = b" bytes"
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert all(line.startswith(prefix) and line.endswith(suffix) for line in lines)
+    measurements = [int(line[len(prefix) : -len(suffix)]) for line in lines]
+    assert measurements
+    assert all(value >= 0 for value in measurements)
+
+    peak = max(measurements)
+    assert peak > 0
+    gmeasurement(
+        peak,
+        f"Stack usage ({backend})",
+        "bytes",
+        f"Peak {peak}b, Segments {len(measurements)}",
     )

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -1,11 +1,3 @@
-function(sentry_get_property NAME)
-	get_target_property(prop sentry "${NAME}")
-	if(NOT prop)
-		set(prop)
-	endif()
-	set("SENTRY_${NAME}" "${prop}" PARENT_SCOPE)
-endfunction()
-
 sentry_get_property(SOURCES)
 sentry_get_property(COMPILE_DEFINITIONS)
 sentry_get_property(INTERFACE_INCLUDE_DIRECTORIES)

--- a/tests/fixtures/stack_usage/CMakeLists.txt
+++ b/tests/fixtures/stack_usage/CMakeLists.txt
@@ -1,0 +1,49 @@
+sentry_get_property(SOURCES)
+sentry_get_property(COMPILE_DEFINITIONS)
+sentry_get_property(INTERFACE_INCLUDE_DIRECTORIES)
+sentry_get_property(INCLUDE_DIRECTORIES)
+sentry_get_property(LINK_LIBRARIES)
+sentry_get_property(INTERFACE_LINK_LIBRARIES)
+
+list(FILTER SENTRY_SOURCES EXCLUDE REGEX "\\.rc$")
+
+add_executable(sentry_stack_usage
+	${SENTRY_SOURCES}
+	stack_usage.c
+)
+
+if(SENTRY_BACKEND_CRASHPAD)
+	add_dependencies(sentry_stack_usage crashpad::handler)
+	if(WIN32)
+		add_dependencies(sentry_stack_usage crashpad::wer)
+	endif()
+endif()
+
+if(SENTRY_BACKEND_NATIVE)
+	add_dependencies(sentry_stack_usage sentry-crash)
+	if(WIN32)
+		add_dependencies(sentry_stack_usage sentry-wer)
+	endif()
+endif()
+
+target_link_libraries(sentry_stack_usage PRIVATE
+	${SENTRY_LINK_LIBRARIES}
+	${SENTRY_INTERFACE_LINK_LIBRARIES}
+	"$<$<PLATFORM_ID:Linux>:rt>"
+)
+target_compile_definitions(sentry_stack_usage PRIVATE
+	${SENTRY_COMPILE_DEFINITIONS})
+target_include_directories(sentry_stack_usage PRIVATE
+	${SENTRY_INTERFACE_INCLUDE_DIRECTORIES}
+	${SENTRY_INCLUDE_DIRECTORIES}
+)
+
+if(MSVC)
+	target_compile_options(sentry_stack_usage PRIVATE
+		$<BUILD_INTERFACE:/wd5105>)
+endif()
+
+if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
+	set_property(TARGET sentry_stack_usage PROPERTY
+		MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()

--- a/tests/fixtures/stack_usage/stack_usage.c
+++ b/tests/fixtures/stack_usage/stack_usage.c
@@ -1,0 +1,189 @@
+#include "sentry_boot.h"
+
+#include "sentry.h"
+#include "sentry_alloc.h"
+#include "sentry_integration.h"
+#include "sentry_options.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef SENTRY_PLATFORM_WINDOWS
+#    include <io.h>
+#else
+#    include <unistd.h>
+#endif
+
+#ifndef STDOUT_FILENO
+#    define STDOUT_FILENO 1
+#endif
+
+#if defined(_MSC_VER)
+#    define NOINLINE __declspec(noinline)
+#    define THREAD_LOCAL __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__)
+#    define NOINLINE __attribute__((noinline))
+#    define THREAD_LOCAL __thread
+#else
+#    define NOINLINE
+#    define THREAD_LOCAL _Thread_local
+#endif
+
+// Crash callbacks may run on a 16 KiB alternate signal stack. Paint 12 KiB
+// and leave 4 KiB for the signal frame and callback machinery.
+#define STACK_PAINT_SIZE (12 * 1024)
+#define STACK_PATTERN(offset) ((unsigned char)(0x5aU + (offset) * 131U))
+
+static THREAD_LOCAL uintptr_t g_stack_usage_low;
+static THREAD_LOCAL uintptr_t g_stack_usage_high;
+static THREAD_LOCAL unsigned int g_stack_usage_depth;
+
+static NOINLINE void
+paint_stack(void)
+{
+    // Handler calls reuse this frame after it returns, leaving a high-water
+    // mark in the pattern.
+    volatile unsigned char stack[STACK_PAINT_SIZE];
+    for (size_t i = 0; i < sizeof(stack); i++) {
+        stack[i] = STACK_PATTERN(i);
+    }
+    g_stack_usage_low = (uintptr_t)&stack[0];
+    g_stack_usage_high = (uintptr_t)&stack[sizeof(stack)];
+}
+
+static NOINLINE size_t
+measure_stack(void)
+{
+    for (uintptr_t ptr = g_stack_usage_low; ptr < g_stack_usage_high; ptr++) {
+        size_t offset = (size_t)(ptr - g_stack_usage_low);
+        if (*(volatile unsigned char *)ptr != STACK_PATTERN(offset)) {
+            return (size_t)(g_stack_usage_high - ptr);
+        }
+    }
+    return 0;
+}
+
+static NOINLINE void
+write_measurement(size_t value)
+{
+    static const char prefix[] = "[STACK] ";
+    static const char suffix[] = " bytes\n";
+    char buf[sizeof(prefix) + 3 * sizeof(size_t) + sizeof(suffix)];
+    size_t len = 0;
+    for (size_t i = 0; i < sizeof(prefix) - 1; i++) {
+        buf[len++] = prefix[i];
+    }
+
+    size_t digits_start = len;
+    do {
+        buf[len++] = (char)('0' + value % 10);
+        value /= 10;
+    } while (value);
+
+    size_t digits_len = len - digits_start;
+    for (size_t i = 0; i < digits_len / 2; i++) {
+        char tmp = buf[digits_start + i];
+        buf[digits_start + i] = buf[len - i - 1];
+        buf[len - i - 1] = tmp;
+    }
+    for (size_t i = 0; i < sizeof(suffix) - 1; i++) {
+        buf[len++] = suffix[i];
+    }
+#ifdef SENTRY_PLATFORM_WINDOWS
+    (void)!_write(STDOUT_FILENO, buf, (unsigned int)len);
+#else
+    (void)!write(STDOUT_FILENO, buf, len);
+#endif
+}
+
+static void
+enter_crash_handler(void *ptr)
+{
+    (void)ptr;
+    if (g_stack_usage_depth++ == 0) {
+        paint_stack();
+    }
+}
+
+static void
+exit_crash_handler(void *ptr)
+{
+    (void)ptr;
+    if (!g_stack_usage_depth || --g_stack_usage_depth) {
+        return;
+    }
+
+    size_t used = measure_stack();
+    g_stack_usage_low = 0;
+    g_stack_usage_high = 0;
+    write_measurement(used);
+}
+
+static sentry_integration_t *
+stack_usage_integration_new(void)
+{
+    sentry_integration_t *integration = SENTRY_MAKE(sentry_integration_t);
+    if (!integration) {
+        return NULL;
+    }
+
+    integration->crash_handler_enter_func = enter_crash_handler;
+    integration->crash_handler_exit_func = exit_crash_handler;
+    return integration;
+}
+
+static void *invalid_mem = (void *)1;
+
+static sentry_value_t
+on_crash(const sentry_ucontext_t *uctx, sentry_value_t event, void *data)
+{
+    (void)uctx;
+    (void)data;
+    return event;
+}
+
+static sentry_http_client_t *
+dummy_http_client_factory(void *data)
+{
+    return (sentry_http_client_t *)data;
+}
+
+static int
+dummy_http_client_send(sentry_http_client_t *client,
+    sentry_http_request_t *request, sentry_http_response_t *response)
+{
+    (void)client;
+    (void)request;
+    sentry_http_response_set_status_code(response, 200);
+    return 1;
+}
+
+int
+main(void)
+{
+    static char dummy_http_client;
+    sentry_options_t *options = sentry_options_new();
+    sentry__options_add_integration(options, stack_usage_integration_new());
+    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    sentry_options_set_database_path(options, ".sentry-native");
+    sentry_options_set_auto_session_tracking(options, false);
+    sentry_options_set_debug(options, 1);
+    sentry_options_set_on_crash(options, on_crash, NULL);
+
+    // Keep the HTTP transport's queue drain in the measured crash path. A
+    // function transport skips that work, while this client avoids network I/O.
+    sentry_options_set_transport(options,
+        sentry_http_transport_new(dummy_http_client_factory, &dummy_http_client,
+            dummy_http_client_send, NULL));
+
+    if (sentry_init(options) != 0) {
+        return 1;
+    }
+
+    sentry_attachment_t *bytes
+        = sentry_attach_bytes("\xc0\xff\xee", 3, "bytes.bin");
+    sentry_attachment_set_content_type(bytes, "application/octet-stream");
+    sentry_start_session();
+    sentry_crash();
+    return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,13 +1,3 @@
-function(sentry_get_property NAME)
-	get_target_property(prop sentry "${NAME}")
-
-	if(NOT prop)
-		set(prop)
-	endif()
-
-	set("SENTRY_${NAME}" "${prop}" PARENT_SCOPE)
-endfunction()
-
 sentry_get_property(SOURCES)
 sentry_get_property(COMPILE_DEFINITIONS)
 sentry_get_property(INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
Measure how much stack each crash backend uses while processing a fatal error.

<details><summary>Boring details for the curious</summary>

When a thread first enters crash handling, the fixture fills a 12 KiB local array with a recognizable byte pattern. The helper then returns, leaving the pattern in stack space available for reuse. As the real crash handler runs, its call frames overwrite that pattern.

Before the thread leaves crash handling, the fixture scans the remaining pattern. The deepest overwritten position is reported as `[STACK] N bytes`. Nested entries on the same thread form one measurement, while separate handler intervals or threads may produce multiple values. The benchmark records the largest value because these are independent stack peaks, not additive memory usage.

Crash callbacks may run on alternate signal stacks as small as 16 KiB. Painting 12 KiB leaves the remaining 4 KiB for the signal frame and callback machinery while `paint_stack` is active. Painting the full 16 KiB would risk overflowing the stack before measurement begins.

Add integration callbacks around each backend's crash-handling work so the fixture can apply the same measurement consistently. These callbacks must remain async-signal-safe because some backends invoke them from a signal handler.

Use a dummy custom HTTP client so the measured path includes the HTTP transport's crash-time queue drain without depending on network I/O.

Share the SDK target-property helper used by source-compiling test targets instead of duplicating it in each CMake file.
</details>

The stack usage measurements are published in benchmark charts and monitored over time:

<img
  width="2070"
  height="1010"
  alt="Screenshot From 2026-08-27 17-23-15"
  src="https://github.com/user-attachments/assets/150e0d0c-a23c-4368-aaed-5903c925070f"
/>

To inspect stack usage locally:

```sh
$ cmake -S . -B build -DSENTRY_BACKEND=inproc -DSENTRY_BUILD_TESTS=ON -DSENTRY_BUILD_BENCHMARKS=ON
$ cmake --build build --target sentry_stack_usage
$ ./build/tests/fixtures/stack_usage/sentry_stack_usage
[...]
[STACK] 0 bytes
[...]
[STACK] 7512 bytes
[STACK] 336 bytes
Segmentation fault (core dumped)
```

The number and values of the measurements depend on the backend and platform. The final crash is intentional.

Separately, add `make stack-frames` for manual inspection of the functions compiled into `libsentry`. It builds the selected backend with `-fstack-usage` and prints the 20 largest compiler-reported function frames. This does not measure a call chain or runtime high-water mark and is not published as a benchmark result.

```sh
$ make stack-frames SENTRY_BACKEND=inproc N=50
4192    src/unwinder/sentry_unwinder_libunwind.c:66:5:find_mem_range_from_fd    static
[...]
```

Close: #997