### PR TITLE
test(benchmark): library size

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 
-from . import make_dsn, run
+from . import lib_name, make_dsn, run
 
 
 def run_benchmark(target, backend, cmake, httpserver, gbenchmark, label, runs=1):
@@ -78,4 +78,26 @@ def test_benchmark_logs(threads, cmake, httpserver, gbenchmark):
         httpserver,
         gbenchmark,
         f"Logs ({threads} thread{'s' if threads > 1 else ''})",
+    )
+
+
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
+def test_benchmark_libsize(backend, cmake, gmeasurement):
+    tmp_path = cmake(
+        ["sentry"],
+        {
+            "SENTRY_BACKEND": backend,
+            "CMAKE_BUILD_TYPE": "Release",
+        },
+    )
+
+    library = tmp_path / lib_name("sentry")
+    size = library.stat().st_size
+    assert size > 0
+    gmeasurement(
+        size,
+        f"Library size ({backend})",
+        "bytes",
+        f"Size {size}b",
+        range="linear",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ LABEL = "label"
 TIME_UNIT = "time_unit"
 REAL_TIME = "real_time"
 CPU_TIME = "cpu_time"
+VALUE = "value"
+EXTRA = "extra"
+RANGE = "range"
 
 gbenchmarks = {}
 
@@ -147,6 +150,7 @@ def gbenchmark():
                 TIME_UNIT: "",
                 REAL_TIME: [],
                 CPU_TIME: [],
+                RANGE: "logarithmic",
             }
 
         for benchmark in data["benchmarks"]:
@@ -160,10 +164,43 @@ def gbenchmark():
     return _load
 
 
+@pytest.fixture
+def gmeasurement():
+    def _record(value, label, unit, extra="", test_name=None, range=None):
+        if test_name is None:
+            test_name = (
+                os.environ.get("PYTEST_CURRENT_TEST")
+                .split(" ")[0]
+                .replace("[", "_")
+                .replace("]", "")
+            )
+
+        gbenchmarks[test_name] = {
+            LABEL: label,
+            TIME_UNIT: unit,
+            VALUE: value,
+            EXTRA: extra,
+            RANGE: range,
+        }
+
+    return _record
+
+
 def _get_benchmark(name, separator):
     data = gbenchmarks.get(name)
     if data is None:
         return None
+
+    if VALUE in data:
+        benchmark = {
+            "name": data[LABEL],
+            "unit": data[TIME_UNIT],
+            "value": data[VALUE],
+            "extra": data[EXTRA],
+        }
+        if data[RANGE] is not None:
+            benchmark[RANGE] = data[RANGE]
+        return benchmark
 
     unit = data[TIME_UNIT]
     real_time = data[REAL_TIME] if data[REAL_TIME] else []
@@ -181,12 +218,15 @@ def _get_benchmark(name, separator):
         f"CPU {statistics.mean(cpu_time):.3f}{unit}" if sys.platform != "win32" else "",
     ]
 
-    return {
+    benchmark = {
         "name": data[LABEL],
         "unit": unit,
         "value": statistics.median(real_time),
         "extra": separator.join(e for e in extra if e),
     }
+    if data.get(RANGE) is not None:
+        benchmark[RANGE] = data[RANGE]
+    return benchmark
 
 
 def pytest_report_teststatus(report, config):


### PR DESCRIPTION
New features come with a cost - increased library size. This PR adds a simple benchmark to track the library size over time.

The starting point looks like this:

<img width="2628" height="3707" alt="image" src="https://github.com/user-attachments/assets/10eef4e9-477e-400d-b17d-528294409e01" />

See also:
- https://github.com/getsentry/sentry-native/issues/700
- https://github.com/getsentry/sentry-native/pull/2031