### PR TITLE
ref: remove legacy console init wrapper

### DIFF
--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -147,17 +147,8 @@ sentry__exit_crash_handler(void)
     }
 }
 
-// TODO: remove sentry__native_init after console SDKs have been migrated to
-// platform integrations
-#if (defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)                \
-    || defined(SENTRY_PLATFORM_XBOX))                                          \
-    && !defined(SENTRY_INTEGRATION_PLATFORM)
-int
-sentry__native_init(sentry_options_t *options)
-#else
 int
 sentry_init(sentry_options_t *options)
-#endif
 {
     // pre-init here, so we can consistently use bailing out to :fail
     sentry_transport_t *transport = NULL;

--- a/src/sentry_core.h
+++ b/src/sentry_core.h
@@ -165,12 +165,4 @@ bool sentry__should_send_transaction(
     sentry_value_t tx_ctx, sentry_sampling_context_t *sampling_ctx);
 #endif
 
-// TODO: remove sentry__native_init after console SDKs have been migrated to
-// platform integrations
-#if (defined(SENTRY_PLATFORM_NX) || defined(SENTRY_PLATFORM_PS)                \
-    || defined(SENTRY_PLATFORM_XBOX))                                          \
-    && !defined(SENTRY_INTEGRATION_PLATFORM)
-int sentry__native_init(sentry_options_t *options);
-#endif
-
 #endif


### PR DESCRIPTION
Console SDKs now register platform integrations and call `sentry_init()` directly, so remove the conditional `sentry__native_init()` entry point wrapper.

See also:
- https://github.com/getsentry/sentry-native/pull/2005
- https://github.com/getsentry/sentry-playstation/pull/161
- https://github.com/getsentry/sentry-switch/pull/177
- https://github.com/getsentry/sentry-xbox/pull/165
