### PR TITLE
ci: retry depencency downloads

### DIFF
--- a/scripts/install-llvm-mingw.ps1
+++ b/scripts/install-llvm-mingw.ps1
@@ -9,8 +9,11 @@ $LLVM_MINGW_DL_PATH = "${DL_BASEDIR}\llvm-mingw.zip"
 if (!(Test-Path -Path "$DL_BASEDIR")) { New-Item -ItemType Directory -Force -Path "$DL_BASEDIR" }
 
 # Download LLVM-mingw
-$CurlArguments = '-s', '-Lf', '-o', "${LLVM_MINGW_DL_PATH}", "${LLVM_MINGW_DL_URL}"
+$CurlArguments = '-sS', '-Lf', '--retry', '5', '--retry-all-errors', '--retry-delay', '1', '-o', "${LLVM_MINGW_DL_PATH}", "${LLVM_MINGW_DL_URL}"
 & curl.exe @CurlArguments
+if ($LASTEXITCODE -ne 0) {
+	throw "Failed to download ${LLVM_MINGW_DL_URL}"
+}
 $dl_zip_hash = Get-FileHash -LiteralPath "${LLVM_MINGW_DL_PATH}" -Algorithm SHA256
 if ($dl_zip_hash.Hash -eq $LLVM_MINGW_DL_SHA256) {
 	Write-Host "Successfully downloaded LLVM-mingw .zip"
@@ -35,8 +38,11 @@ Write-Host "Path to LLVM-mingw bin folder: ${LLVM_MINGW_INSTALL_PATH}\bin"
 $NINJA_DL_URL = "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip"
 $NINJA_DL_SHA512 = "d6715c6458d798bcb809f410c0364dabd937b5b7a3ddb4cd5aba42f9fca45139b2a8a3e7fd9fbd88fd75d298ed99123220b33c7bdc8966a9d5f2a1c9c230955f"
 $NINJA_DL_PATH = "${DL_BASEDIR}\ninja-win.zip"
-$CurlArguments = '-s', '-Lf', '-o', "${NINJA_DL_PATH}", "${NINJA_DL_URL}"
+$CurlArguments = '-sS', '-Lf', '--retry', '5', '--retry-all-errors', '--retry-delay', '1', '-o', "${NINJA_DL_PATH}", "${NINJA_DL_URL}"
 & curl.exe @CurlArguments
+if ($LASTEXITCODE -ne 0) {
+	throw "Failed to download ${NINJA_DL_URL}"
+}
 $ninja_zip_hash = Get-FileHash -LiteralPath "${NINJA_DL_PATH}" -Algorithm SHA512
 if ($ninja_zip_hash.Hash -eq $NINJA_DL_SHA512) {
 	Write-Host "Successfully downloaded Ninja-Build .zip"

--- a/scripts/install-zlib.ps1
+++ b/scripts/install-zlib.ps1
@@ -6,8 +6,11 @@ $ZLIB_RELEASE_ASSET = "zlib131.zip"
 $ZLIB_DL_URL = "https://github.com/madler/zlib/releases/download/v${ZLIB_RELEASE}/${ZLIB_RELEASE_ASSET}"
 $ZLIB_DL_SHA512 = "1f171880153b0120e1364baaf7d0a17f65086eff279f8f8c8538e5950097d1feee37cc173181676ba1e2aeb4565ba68749c814cd3e25bfb06271bea02feb7d94"
 $ZLIB_DL_PATH = "${DL_BASEDIR}\${ZLIB_RELEASE_ASSET}"
-$CurlArguments = '-s', '-Lf', '-o', "${ZLIB_DL_PATH}", "${ZLIB_DL_URL}"
+$CurlArguments = '-sS', '-Lf', '--retry', '5', '--retry-all-errors', '--retry-delay', '1', '-o', "${ZLIB_DL_PATH}", "${ZLIB_DL_URL}"
 & curl.exe @CurlArguments
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to download ${ZLIB_DL_URL}"
+}
 $zlib_zip_hash = Get-FileHash -LiteralPath "${ZLIB_DL_PATH}" -Algorithm SHA512
 if ($zlib_zip_hash.Hash -eq $ZLIB_DL_SHA512) {
     Write-Host "Successfully downloaded ${ZLIB_RELEASE_ASSET}"


### PR DESCRIPTION
Allow curl to retry on transient network errors, make curl diagnostics visible, and print a clear error message with the download URL if even that fails.

### Before (no retries)
```
Run . "scripts\install-zlib.ps1"
...
Resolve-Path : Cannot find path 'D:\a\sentry-native\sentry-native\dl\zlib131.zip' because it does not exist.
...
```
https://github.com/getsentry/sentry-native/actions/runs/33754337620/job/100644994785

### After (5 retries)

```
Run . "scripts\install-zlib.ps1"
...
curl(22): The requested URL returned error: 503
...
Failed to download https://github.com/madler/zlib/releases/download/v1.3.1/zlib131.zip
...
```