### PR TITLE
fix: guard size arithmetic against overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Prevent backend state races when `sentry_reinstall_backend` runs concurrently with scope observer callbacks. ([#2041](https://github.com/getsentry/sentry-native/pull/2041))
 - `sentry_set_trace` omits `parent_span_id` when the caller does not provide one, instead of serializing it as `null`. ([#2047](https://github.com/getsentry/sentry-native/pull/2047))
 - Native/Linux i386: write valid thread stack descriptors to minidumps when stack addresses use the upper half of the 32-bit address space. ([#2054](https://github.com/getsentry/sentry-native/pull/2054))
+- Guard size arithmetic when parsing envelopes and Linux OS release data, copying slices, and allocating memory during crash handling. ([#2059](https://github.com/getsentry/sentry-native/pull/2059))
 
 ## 0.16.5
 

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -1085,7 +1085,7 @@ deserialize_into(sentry_envelope_t *envelope, const char *buf, size_t buf_len)
         // item headers
         const char *item_headers_end = memchr(ptr, '\n', (size_t)(end - ptr));
         if (!item_headers_end) {
-            item_headers_end = end;
+            return false;
         }
         size_t item_headers_len = (size_t)(item_headers_end - ptr);
         sentry_value_decref(item->headers);
@@ -1123,8 +1123,8 @@ deserialize_into(sentry_envelope_t *envelope, const char *buf, size_t buf_len)
             item->payload_len = (size_t)payload_len;
         }
         if (item->payload_len > 0) {
-            if (ptr + item->payload_len > end
-                || item->payload_len >= SIZE_MAX) {
+            if (item->payload_len >= SIZE_MAX
+                || item->payload_len > (size_t)(end - ptr)) {
                 return false;
             }
             item->payload = sentry_malloc(item->payload_len + 1);

--- a/src/sentry_os.c
+++ b/src/sentry_os.c
@@ -712,7 +712,8 @@ parse_os_release_line(const char *line, char *key, char *value)
         = { .ptr = equals + 1, .len = strlen(equals + 1) };
 
     // some values are wrapped in double quotes
-    if (value_slice.ptr[0] == '\"') {
+    if (value_slice.len >= 2 && value_slice.ptr[0] == '\"'
+        && value_slice.ptr[value_slice.len - 1] == '\"') {
         value_slice.ptr++;
         value_slice.len -= 2;
     }

--- a/src/sentry_slice.c
+++ b/src/sentry_slice.c
@@ -22,6 +22,9 @@ sentry__slice_to_owned(sentry_slice_t slice)
 void
 sentry__slice_to_buffer(sentry_slice_t slice, char *buffer, size_t buffer_len)
 {
+    if (buffer_len == 0) {
+        return;
+    }
     size_t copy_len = MIN(slice.len, buffer_len - 1);
     strncpy(buffer, slice.ptr, copy_len);
     buffer[copy_len] = 0;

--- a/src/sentry_unix_pageallocator.c
+++ b/src/sentry_unix_pageallocator.c
@@ -91,7 +91,17 @@ sentry__page_allocator_alloc(size_t size)
 
     // make sure the requested size is correctly aligned
     size_t diff = size % ALIGN;
-    size = size + ALIGN - diff;
+    size_t padding = ALIGN - diff;
+    if (size > SIZE_MAX - padding) {
+        return NULL;
+    }
+    size += padding;
+
+    if (size > SIZE_MAX - sizeof(struct page_header)
+        || size + sizeof(struct page_header)
+            > SIZE_MAX - g_alloc->page_size + 1) {
+        return NULL;
+    }
 
     char *rv = NULL;
 

--- a/tests/fixtures/os_releases/malformed_quotes
+++ b/tests/fixtures/os_releases/malformed_quotes
@@ -1,0 +1,2 @@
+ID="
+VERSION_ID=""

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -1171,6 +1171,8 @@ SENTRY_TEST(deserialize_envelope_invalid)
     char buf[128];
     snprintf(buf, sizeof(buf), "{}\n{\"length\":%zu}\n", SIZE_MAX);
     TEST_CHECK(!sentry_envelope_deserialize(buf, strlen(buf)));
+    snprintf(buf, sizeof(buf), "{}\n{\"length\":%zu}\n", SIZE_MAX - 1);
+    TEST_CHECK(!sentry_envelope_deserialize(buf, strlen(buf)));
 }
 
 SENTRY_TEST(envelope_can_add_client_report)

--- a/tests/unit/test_os.c
+++ b/tests/unit/test_os.c
@@ -102,6 +102,7 @@ const struct distro test_dists[] = {
     { .name = "fedora", .version = "31" },
     { .name = "pop", .version = "22.04" },
     { .name = "sled", .version = "12.3" },
+    { .name = "\"", .version = "" },
 };
 
 const size_t num_test_dists = sizeof(test_dists) / sizeof(struct distro);

--- a/tests/unit/test_slice.c
+++ b/tests/unit/test_slice.c
@@ -14,6 +14,14 @@ SENTRY_TEST(slice)
     TEST_CHECK(sentry__slice_eq(str1, str2));
     TEST_CHECK(!sentry__slice_eq(str1, my));
 
+    char copy[4];
+    sentry__slice_to_buffer(str1, copy, sizeof(copy));
+    TEST_CHECK_STRING_EQUAL(copy, "str");
+
+    char untouched = 'x';
+    sentry__slice_to_buffer(str1, &untouched, 0);
+    TEST_CHECK(untouched == 'x');
+
     char *owned = sentry__slice_to_owned(str1);
     TEST_ASSERT(!!owned);
     TEST_CHECK_STRING_EQUAL(owned, "string");

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -313,6 +313,7 @@ SENTRY_TEST(page_allocator)
         p_before[i] = i % 255;
     }
     sentry__page_allocator_enable();
+    TEST_CHECK(!sentry_malloc(SIZE_MAX));
 
     char *p_after = sentry_malloc(size);
     TEST_ASSERT(!!p_after);


### PR DESCRIPTION
Validate envelope payload bounds with subtraction and handle malformed os-release values and zero-length slice buffers. Reject page allocator requests that cannot be aligned or rounded safely.

Fixes: NATIVE-225