### PR TITLE
ci: sync e2e-test.yml triggers with ci.yml

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,7 +5,12 @@ on:
     branches:
       - master
       - "release/**"
+    paths-ignore:
+      - "*.md"
   pull_request:
+    paths-ignore:
+      - "*.md"
+  workflow_dispatch:
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Allow manual workflow dispatch and ignore markdown-only changes to avoid running E2E tests for such changes:
- https://github.com/getsentry/sentry-native/pull/2060