### PR TITLE
build: forward SENTRY_BACKEND/TRANSPORT Make variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ update-test-discovery:
 	@perl -ne 'print if s/SENTRY_TEST\(([^)]+)\).*/XX(\1)/' tests/unit/*.c | LC_ALL=C sort | grep -v define | uniq > tests/unit/tests.inc
 .PHONY: update-test-discovery
 
-build/Makefile: CMakeLists.txt
+build/Makefile configure: CMakeLists.txt
 	@mkdir -p build
-	@cd build; cmake ..
+	@cmake -S . -B build $(if $(SENTRY_BACKEND),-DSENTRY_BACKEND=$(SENTRY_BACKEND)) $(if $(SENTRY_TRANSPORT),-DSENTRY_TRANSPORT=$(SENTRY_TRANSPORT))
+.PHONY: configure
 
-build: build/Makefile
+build: configure
 	@cmake --build build --parallel
 .PHONY: build
 


### PR DESCRIPTION
The `make build` target is super convenient for quickly testing the sentry-native example in such environments as headless Docker containers and RPI over SSH. However, as soon as you need anything else besides the default backend or transport, one needs to fall back to configuring CMake by hand.

This proposal allows selecting a specific backend and/or transport while enjoying the convenience of `make build`:
```sh
$ make build SENTRY_BACKEND=native
```
or whichever way you prefer:
```sh
$ SENTRY_TRANSPORT=none make build
```
