### PR TITLE
fix(native): validate buffer attachment paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Guard size arithmetic when parsing envelopes and Linux OS release data, copying slices, and allocating memory during crash handling. ([#2059](https://github.com/getsentry/sentry-native/pull/2059))
 - macOS: prevent out-of-bounds reads while parsing Mach-O load commands. ([#2065](https://github.com/getsentry/sentry-native/pull/2065))
 - Prevent out-of-bounds reads when parsing JSON numbers from length-delimited buffers. ([#2067](https://github.com/getsentry/sentry-native/pull/2067))
+- Native: prevent buffer attachments from being written outside their UUID run directory. ([#2072](https://github.com/getsentry/sentry-native/pull/2072))
 
 **Thank you**:
 

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -1247,8 +1247,7 @@ ensure_attachment_path(sentry_attachment_t *attachment)
         }
     }
 
-    if (!base_path || sentry__path_create_dir_all(base_path) != 0) {
-        sentry__path_free(base_path);
+    if (!base_path) {
         return false;
     }
 
@@ -1257,12 +1256,13 @@ ensure_attachment_path(sentry_attachment_t *attachment)
     sentry_path_t *parent = path ? sentry__path_dir(path) : NULL;
     bool valid = parent && sentry__path_eq(parent, base_path);
     sentry__path_free(parent);
-    sentry__path_free(base_path);
-    if (!valid) {
+    if (!valid || sentry__path_create_dir_all(base_path) != 0) {
         sentry__path_free(path);
+        sentry__path_free(base_path);
         return false;
     }
 
+    sentry__path_free(base_path);
     sentry__path_free(attachment->path);
     attachment->path = path;
     return true;

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -1252,13 +1252,20 @@ ensure_attachment_path(sentry_attachment_t *attachment)
         return false;
     }
 
-    sentry_path_t *old_path = attachment->path;
-    attachment->path = sentry__path_join_str(
+    sentry_path_t *path = sentry__path_join_str(
         base_path, sentry__path_filename(attachment->filename));
-
+    sentry_path_t *parent = path ? sentry__path_dir(path) : NULL;
+    bool valid = parent && sentry__path_eq(parent, base_path);
+    sentry__path_free(parent);
     sentry__path_free(base_path);
-    sentry__path_free(old_path);
-    return attachment->path != NULL;
+    if (!valid) {
+        sentry__path_free(path);
+        return false;
+    }
+
+    sentry__path_free(attachment->path);
+    attachment->path = path;
+    return true;
 }
 
 static void

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -1260,6 +1260,11 @@ ensure_attachment_path(sentry_attachment_t *attachment)
         return false;
     }
 
+    const char *filename = sentry__path_filename(attachment->filename);
+    if (sentry__string_empty(filename)) {
+        return false;
+    }
+
     // Generate UUID for unique path
     sentry_uuid_t uuid = sentry_uuid_new_v4();
     char uuid_str[37];
@@ -1276,8 +1281,7 @@ ensure_attachment_path(sentry_attachment_t *attachment)
         return false;
     }
 
-    sentry_path_t *path = sentry__path_join_str(
-        base_path, sentry__path_filename(attachment->filename));
+    sentry_path_t *path = sentry__path_join_str(base_path, filename);
     sentry_path_t *parent = path ? sentry__path_dir(path) : NULL;
     bool valid = parent && sentry__path_eq(parent, base_path);
     sentry__path_free(parent);


### PR DESCRIPTION
Reject paths whose direct parent is not the UUID run directory.