### PR TITLE
ref: make use of `sentry__string_empty()`

### DIFF
--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -421,9 +421,9 @@ add_attachment_refs(sentry_envelope_t *envelope,
             sentry__path_free(attachment.filename);
             continue;
         }
-        attachment.type
-            = (char *)((attachment_type && *attachment_type) ? attachment_type
-                                                             : NULL);
+        attachment.type = sentry__string_empty(attachment_type)
+            ? NULL
+            : (char *)attachment_type;
         attachment.content_type
             = sentry__string_empty(content_type) ? NULL : (char *)content_type;
         if (!sentry__attachment_is_placeholder(&attachment, options)) {
@@ -2756,7 +2756,7 @@ walk_stack_with_dbghelp(HANDLE hProcess, DWORD crashed_tid,
             sentry__stringbuilder_append_buf(&sb, path, dir_len);
         }
         char *path_utf8 = sentry__stringbuilder_into_string(&sb);
-        if (path_utf8 && path_utf8[0]) {
+        if (!sentry__string_empty(path_utf8)) {
             s_sym_search_path = sentry__string_to_wstr(path_utf8);
         }
         sentry_free(path_utf8);
@@ -3377,7 +3377,7 @@ build_native_event(const sentry_crash_context_t *ctx,
 {
     // Read base event from parent's file
     sentry_value_t event = sentry_value_new_null();
-    if (event_file_path && event_file_path[0]) {
+    if (!sentry__string_empty(event_file_path)) {
         sentry_path_t *ev_path = sentry__path_from_str(event_file_path);
         if (ev_path) {
             size_t event_size = 0;
@@ -3860,7 +3860,7 @@ write_envelope_with_native_stacktrace(const sentry_options_t *options,
     sentry_free(event_json);
 
     // Add minidump as attachment if provided
-    if (minidump_path && minidump_path[0]) {
+    if (!sentry__string_empty(minidump_path)) {
 #if defined(SENTRY_PLATFORM_UNIX)
         int minidump_fd = open(minidump_path, O_RDONLY);
 #elif defined(SENTRY_PLATFORM_WINDOWS)

--- a/src/backends/sentry_backend_native.c
+++ b/src/backends/sentry_backend_native.c
@@ -1077,7 +1077,7 @@ native_backend_write_attachments(const sentry_path_t *event_path)
                 sentry_value_set_by_key(
                     attach_info, "filename", sentry_value_new_string(filename));
                 const char *type = sentry__attachment_get_type(it);
-                if (type && *type) {
+                if (!sentry__string_empty(type)) {
                     sentry_value_set_by_key(attach_info, "attachment_type",
                         sentry_value_new_string(type));
                 }

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -704,7 +704,7 @@ sentry__envelope_add_attachment_ref(sentry_envelope_t *envelope,
         sentry__envelope_item_set_header(
             item, "filename", sentry_value_new_string(filename));
     }
-    if (attachment_type && *attachment_type) {
+    if (!sentry__string_empty(attachment_type)) {
         sentry__envelope_item_set_header(
             item, "attachment_type", sentry_value_new_string(attachment_type));
     }
@@ -744,7 +744,7 @@ sentry__envelope_add_attachment(
         return NULL;
     }
     const char *type = sentry__attachment_get_type(attachment);
-    if (type && *type) {
+    if (!sentry__string_empty(type)) {
         sentry__envelope_item_set_header(
             item, "attachment_type", sentry_value_new_string(type));
     }
@@ -1624,7 +1624,7 @@ bool
 sentry__envelope_item_resolve_attachment_ref(
     sentry_envelope_item_t *item, const char *location)
 {
-    if (!sentry__guarded_strlen(location)) {
+    if (sentry__string_empty(location)) {
         return false;
     }
     sentry_attachment_ref_t ref;
@@ -1632,14 +1632,14 @@ sentry__envelope_item_resolve_attachment_ref(
         return false;
     }
     sentry_attachment_ref_t resolved = { 0 };
-    if (sentry__guarded_strlen(ref.path)) {
+    if (!sentry__string_empty(ref.path)) {
         resolved.path = ref.path;
     }
-    if (sentry__guarded_strlen(ref.attachment_type)) {
+    if (!sentry__string_empty(ref.attachment_type)) {
         resolved.attachment_type = ref.attachment_type;
     }
     resolved.location = location;
-    if (sentry__guarded_strlen(ref.content_type)) {
+    if (!sentry__string_empty(ref.content_type)) {
         resolved.content_type = ref.content_type;
     }
     bool ok = set_attachment_ref_payload(item, &resolved);

--- a/src/sentry_options.c
+++ b/src/sentry_options.c
@@ -318,10 +318,10 @@ sentry_options_set_org_id(sentry_options_t *opts, const char *org_id)
 const char *
 sentry__options_get_org_id(const sentry_options_t *opts)
 {
-    if (opts->org_id && *opts->org_id) {
+    if (!sentry__string_empty(opts->org_id)) {
         return opts->org_id;
     }
-    if (opts->dsn && opts->dsn->org_id && *opts->dsn->org_id) {
+    if (opts->dsn && !sentry__string_empty(opts->dsn->org_id)) {
         return opts->dsn->org_id;
     }
     return NULL;

--- a/src/sentry_tracing.c
+++ b/src/sentry_tracing.c
@@ -397,8 +397,8 @@ sentry__trace_can_continue(
     const char *sdk_org_id = sentry__options_get_org_id(options);
     const char *incoming_org_id
         = sentry_value_as_string(sentry_value_get_by_key(incoming, "org_id"));
-    bool sdk_has = sdk_org_id && *sdk_org_id;
-    bool inc_has = incoming_org_id && *incoming_org_id;
+    bool sdk_has = !sentry__string_empty(sdk_org_id);
+    bool inc_has = !sentry__string_empty(incoming_org_id);
     if (sdk_has && inc_has) {
         return strcmp(sdk_org_id, incoming_org_id) == 0;
     }

--- a/src/sentry_utils.c
+++ b/src/sentry_utils.c
@@ -243,7 +243,7 @@ sentry__dsn_new_n(const char *raw_dsn, size_t raw_dsn_len)
     dsn->refcount = 1;
 
     dsn->raw = sentry__string_clone_n(raw_dsn, raw_dsn_len);
-    if (!dsn->raw || !dsn->raw[0]
+    if (sentry__string_empty(dsn->raw)
         || sentry__url_parse(&url, dsn->raw, true) != 0) {
         goto exit;
     }
@@ -286,7 +286,7 @@ sentry__dsn_new_n(const char *raw_dsn, size_t raw_dsn_len)
     }
 
     project_id = strrchr(url.path, '/');
-    if (!project_id || strlen(project_id + 1) == 0) {
+    if (!project_id || sentry__string_empty(project_id + 1)) {
         goto exit;
     }
 

--- a/src/session_replay/sentry_session_replay.c
+++ b/src/session_replay/sentry_session_replay.c
@@ -70,7 +70,7 @@ build_replay_event(sentry_value_t meta, const char *replay_id, double start_sec,
         event, "type", sentry_value_new_string("replay_event"));
     sentry_value_set_by_key(event, "replay_type",
         sentry_value_new_string(
-            replay_type && replay_type[0] ? replay_type : "buffer"));
+            !sentry__string_empty(replay_type) ? replay_type : "buffer"));
     sentry_value_set_by_key(
         event, "segment_id", sentry_value_new_int32(segment_id));
     sentry_value_set_by_key(
@@ -135,7 +135,7 @@ append_breadcrumb_events(sentry_value_t recording, sentry_value_t breadcrumbs,
         sentry_value_t crumb = sentry_value_get_by_index(breadcrumbs, i);
         const char *ts = sentry_value_as_string(
             sentry_value_get_by_key(crumb, "timestamp"));
-        if (!ts || !ts[0]) {
+        if (sentry__string_empty(ts)) {
             continue;
         }
         const uint64_t usec = sentry__iso8601_to_usec(ts);
@@ -152,7 +152,7 @@ append_breadcrumb_events(sentry_value_t recording, sentry_value_t breadcrumbs,
             = sentry_value_as_string(sentry_value_get_by_key(crumb, "type"));
         sentry_value_set_by_key(payload, "type",
             sentry_value_new_string(
-                crumb_type && crumb_type[0] ? crumb_type : "default"));
+                !sentry__string_empty(crumb_type) ? crumb_type : "default"));
         // the rrweb payload timestamp is in seconds, the outer one in ms
         sentry_value_set_by_key(
             payload, "timestamp", sentry_value_new_double(ts_sec));
@@ -257,7 +257,7 @@ build_replay_envelope(const sentry_options_t *options, sentry_value_t meta,
 
     const char *replay_id
         = sentry_value_as_string(sentry_value_get_by_key(meta, "replayId"));
-    if (!replay_id || !replay_id[0]) {
+    if (sentry__string_empty(replay_id)) {
         return NULL;
     }
 
@@ -399,7 +399,7 @@ sentry__session_replay_flush_pending(const sentry_options_t *options,
             sentry_value_get_by_key(scope_source, "contexts"), "replay");
         const char *rid = sentry_value_as_string(
             sentry_value_get_by_key(replay_ctx, "replay_id"));
-        if (rid && rid[0]) {
+        if (!sentry__string_empty(rid)) {
             replay_id = rid;
         }
     }
@@ -431,7 +431,7 @@ sentry__session_replay_flush_pending(const sentry_options_t *options,
         double end_sec = 0.0;
         const char *ts = sentry_value_as_string(
             sentry_value_get_by_key(scope_source, "timestamp"));
-        if (ts && ts[0]) {
+        if (!sentry__string_empty(ts)) {
             uint64_t usec = sentry__iso8601_to_usec(ts);
             if (usec) {
                 end_sec = (double)usec / 1000000.0;


### PR DESCRIPTION
Replace compound NULL/empty checks and boolean length checks with the dedicated and easier-to-read helper for checking empty strings, preserving pointer guards and fallback behavior.