### PR TITLE
fix(windows): reject misleading export fallback symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Validate session replay IDs before accessing staged files to prevent path traversal and unintended file uploads or deletions. ([#2071](https://github.com/getsentry/sentry-native/pull/2071))
 - Native/Windows: resolve the WER module relative to `handler_path`, so it is found when the crash handler is installed outside the executable's directory. ([#2073](https://github.com/getsentry/sentry-native/pull/2073))
 - Native: prevent buffer attachments from being written outside their UUID run directory. ([#2072](https://github.com/getsentry/sentry-native/pull/2072))
+- Native/Windows: reject misleading export fallback symbols in stack traces when PDB files are unavailable. ([#2075](https://github.com/getsentry/sentry-native/pull/2075))
 
 **Thank you**:
 

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -187,6 +187,11 @@ vma_capture(pid_t pid)
 #    include <sys/stat.h>
 #    include <windows.h>
 
+// https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-symbol_info
+#    ifndef SYMFLAG_EXPORT
+#        define SYMFLAG_EXPORT 0x00000200
+#    endif
+
 // Global handle for ReadProcessMemory callback and shared stack-walk session
 static HANDLE g_stack_walk_process = NULL;
 

--- a/src/backends/native/sentry_crash_daemon.c
+++ b/src/backends/native/sentry_crash_daemon.c
@@ -2824,8 +2824,10 @@ walk_stack_with_dbghelp(HANDLE hProcess, DWORD crashed_tid,
             sym_info->SizeOfStruct = sizeof(SYMBOL_INFOW);
             sym_info->MaxNameLen = MAX_SYM_NAME;
 
+            // reject SYMFLAG_EXPORT: export fallback can misidentify functions
             if (SymFromAddrW(
-                    hProcess, stack_frame.AddrPC.Offset, NULL, sym_info)) {
+                    hProcess, stack_frame.AddrPC.Offset, NULL, sym_info)
+                && !(sym_info->Flags & SYMFLAG_EXPORT)) {
                 frames[frame_count].symbol
                     = sentry__string_from_wstr(sym_info->Name);
                 frames[frame_count].symbol_addr

--- a/src/symbolizer/sentry_symbolizer_windows.c
+++ b/src/symbolizer/sentry_symbolizer_windows.c
@@ -31,7 +31,9 @@ sentry__symbolize(
     symbol_info->MaxNameLen = MAX_SYM_NAME;
     symbol_info->SizeOfStruct = sizeof(SYMBOL_INFOW);
 
-    if (!SymFromAddrW(proc, (uintptr_t)addr, NULL, symbol_info)) {
+    // reject SYMFLAG_EXPORT: export fallback can misidentify functions
+    if (!SymFromAddrW(proc, (uintptr_t)addr, NULL, symbol_info)
+        || (symbol_info->Flags & SYMFLAG_EXPORT)) {
         return false;
     }
 

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -244,7 +244,7 @@ def assert_stacktrace(
         assert any(
             frame.get("function") is not None and frame.get("package") is not None
             for frame in frames
-        )
+        ), "missing symbolicated frames"
 
     if check_package:
         for frame in frames:

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -90,6 +90,12 @@ auth_header = (
         ({"SENTRY_TRANSPORT_COMPRESSION": "On"}),
     ],
 )
+@pytest.mark.xfail(
+    bool(os.environ.get("TEST_MINGW")),
+    reason="DbgHelp cannot read MinGW DWARF symbols",
+    raises=pytest.RaisesExc(AssertionError, match="^missing symbolicated frames"),
+    strict=True,
+)
 def test_capture_http(cmake, httpserver, build_args):
     build_args.update({"SENTRY_BACKEND": "none"})
     tmp_path = cmake(["sentry_example"], build_args)
@@ -511,6 +517,12 @@ def test_external_crash_reporter_consent_flush(cmake, httpserver, build_args):
 
 
 @pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
+@pytest.mark.xfail(
+    bool(os.environ.get("TEST_MINGW")),
+    reason="DbgHelp cannot read MinGW DWARF symbols",
+    raises=pytest.RaisesExc(AssertionError, match="^missing symbolicated frames"),
+    strict=True,
+)
 def test_exception_and_session_http(cmake, httpserver):
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
 

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -1438,10 +1438,14 @@ def test_native_pdb(cmake, httpserver, build_args, run_args):
 
     envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
     event = envelope.get_event()
-    if "crash" in run_args:
-        stack = event["exception"]["values"][0]["stacktrace"]
-    else:
-        stack = event["threads"]["values"][0]["stacktrace"]
+    stacks = [
+        value.get("stacktrace", {})
+        for value in (
+            event.get("threads", {}).get("values", [])
+            + event.get("exception", {}).get("values", [])
+        )
+    ]
+    assert stacks
     image = next(
         image
         for image in event["debug_meta"]["images"]
@@ -1451,7 +1455,8 @@ def test_native_pdb(cmake, httpserver, build_args, run_args):
     end = start + image["image_size"]
     frames = [
         frame
-        for frame in stack["frames"]
+        for stack in stacks
+        for frame in stack.get("frames", [])
         if start <= int(frame["instruction_addr"], 16) < end
     ]
     assert frames

--- a/tests/test_integration_native.py
+++ b/tests/test_integration_native.py
@@ -17,6 +17,7 @@ import pytest
 from . import (
     is_feedback_envelope,
     is_replay_envelope,
+    lib_name,
     make_dsn,
     run,
     run_crash,
@@ -1279,6 +1280,14 @@ def test_crash_mode_minidump_only(cmake, httpserver):
     assert has_minidump, "Minidump mode should include minidump"
 
 
+@pytest.mark.xfail(
+    bool(os.environ.get("TEST_MINGW")),
+    reason="DbgHelp cannot read MinGW DWARF symbols",
+    raises=pytest.RaisesExc(
+        AssertionError, match="^missing symbolicated function names"
+    ),
+    strict=True,
+)
 def test_crash_mode_native_only(cmake, httpserver):
     """Mode 2: Should produce envelope with native stacktrace, no minidump"""
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
@@ -1321,7 +1330,7 @@ def test_crash_mode_native_only(cmake, httpserver):
     # At least some frames should have symbolicated function names
     assert any(
         frame.get("function") is not None for frame in exc["stacktrace"]["frames"]
-    )
+    ), "missing symbolicated function names"
 
     # Should have debug_meta
     assert "debug_meta" in event
@@ -1330,6 +1339,14 @@ def test_crash_mode_native_only(cmake, httpserver):
         assert_debug_meta_images_do_not_overlap(event)
 
 
+@pytest.mark.xfail(
+    bool(os.environ.get("TEST_MINGW")),
+    reason="DbgHelp cannot read MinGW DWARF symbols",
+    raises=pytest.RaisesExc(
+        AssertionError, match="^missing symbolicated function names"
+    ),
+    strict=True,
+)
 def test_crash_mode_native_with_minidump(cmake, httpserver):
     """Mode 3 (default): Should have both native stacktrace AND minidump"""
     tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "native"})
@@ -1368,12 +1385,82 @@ def test_crash_mode_native_with_minidump(cmake, httpserver):
     # At least some frames should have symbolicated function names
     assert any(
         frame.get("function") is not None for frame in exc["stacktrace"]["frames"]
-    )
+    ), "missing symbolicated function names"
 
     # Should have debug_meta
     assert "debug_meta" in event
     if sys.platform == "darwin":
         assert_debug_meta_images_do_not_overlap(event)
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32" or bool(os.environ.get("TEST_MINGW")),
+    reason="PDB tests are only available in MSVC Windows builds",
+)
+@pytest.mark.parametrize(
+    "build_args",
+    [
+        {},  # with PDBs
+        {
+            # without PDBs (remove CMake's MSVC /debug defaults to disable PDBs)
+            "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "",
+            "CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO": "",
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "run_args",
+    [
+        ["capture-event", "add-stacktrace"],
+        ["log", "crash"],
+    ],
+)
+def test_native_pdb(cmake, httpserver, build_args, run_args):
+    build_args.update({"SENTRY_BACKEND": "native"})
+    tmp_path = cmake(["sentry_example"], build_args)
+
+    has_pdb = build_args.get("CMAKE_SHARED_LINKER_FLAGS_DEBUG") != ""
+    if has_pdb:
+        assert (tmp_path / "sentry.pdb").is_file()
+    else:
+        assert not (tmp_path / "sentry.pdb").is_file()
+
+    httpserver.expect_oneshot_request("/api/123456/envelope/").respond_with_data("OK")
+    with httpserver.wait(timeout=10) as waiting:
+        runner = run_crash if "crash" in run_args else run
+        runner(
+            tmp_path,
+            "sentry_example",
+            run_args,
+            env=dict(os.environ, SENTRY_DSN=make_dsn(httpserver)),
+        )
+    assert waiting.result
+
+    envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
+    event = envelope.get_event()
+    if "crash" in run_args:
+        stack = event["exception"]["values"][0]["stacktrace"]
+    else:
+        stack = event["threads"]["values"][0]["stacktrace"]
+    image = next(
+        image
+        for image in event["debug_meta"]["images"]
+        if image["code_file"].lower().endswith("\\" + lib_name("sentry"))
+    )
+    start = int(image["image_addr"], 16)
+    end = start + image["image_size"]
+    frames = [
+        frame
+        for frame in stack["frames"]
+        if start <= int(frame["instruction_addr"], 16) < end
+    ]
+    assert frames
+    if has_pdb:
+        assert any("function" in frame for frame in frames), frames
+        assert any("symbol_addr" in frame for frame in frames), frames
+    else:
+        assert all("function" not in frame for frame in frames), frames
+        assert all("symbol_addr" not in frame for frame in frames), frames
 
 
 def test_native_restart_on_crash(cmake, httpserver):

--- a/tests/test_integration_stdout.py
+++ b/tests/test_integration_stdout.py
@@ -26,6 +26,12 @@ from .conditions import has_breakpad, has_files, is_qemu, is_wine
 
 
 @pytest.mark.skipif(is_qemu, reason="unreliable under qemu-user")
+@pytest.mark.xfail(
+    bool(os.environ.get("TEST_MINGW")),
+    reason="DbgHelp cannot read MinGW DWARF symbols",
+    raises=pytest.RaisesExc(AssertionError, match="^missing symbolicated frames"),
+    strict=True,
+)
 def test_capture_stdout(cmake):
     tmp_path = cmake(
         ["sentry_example"],


### PR DESCRIPTION
Reject `DbgHelp` export fallback symbols ([`SYMFLAG_EXPORT`](https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-symbol_info)), which can misidentify functions when PDBs are unavailable.

| Before /w PDB <sup>[1]</sup> | Before /wo PDB <sup>[2]</sup> | After /wo PDB <sup>[3]</sup> |
|---|---|---|
| <img width="1485" height="1038" alt="image" src="https://github.com/user-attachments/assets/47a55057-50e0-4872-9cfd-90eb6c4bfe82" /> | <img width="1485" height="1038" alt="image" src="https://github.com/user-attachments/assets/1c971134-e52a-45d7-a686-28623a28019b" /> | <img width="1485" height="1038" alt="image" src="https://github.com/user-attachments/assets/53bb069b-43b8-4372-828e-750038628a92" /> |

<sup>[1]</sup> `crashplugin.pdb` present alongside `crashplugin.dll` -> correct `CrashPlugin::crash` symbol (before and after fix)
<sup>[2]</sup> `crashplugin.pdb` not preset -> accepted misleading `qt_plugin_instance` export fallback symbol (before fix)
<sup>[3]</sup> `crashplugin.pdb` not preset -> rejects misleading `qt_plugin_instance` export fallback symbol (after fix)

TODO:
- [x] verify on Xbox: https://github.com/getsentry/sentry-xbox/pull/175

Fixes: #2051