### PR TITLE
feat(examples): dedicated feedback example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add `sentry_is_enabled` for checking whether the SDK has been initialized. ([#2045](https://github.com/getsentry/sentry-native/pull/2045))
 - Add `sentry_event_set_level` for setting the level of an individual event. ([#2038](https://github.com/getsentry/sentry-native/pull/2038))
+- Add `sentry_envelope_get_event_id` for reading the event ID from an envelope. ([#2076](https://github.com/getsentry/sentry-native/pull/2076))
+- New examples:
+  - `examples/feedback.c`: [#2076](https://github.com/getsentry/sentry-native/pull/2076)
 
 **Fixes**:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1099,8 +1099,14 @@ endif()
 
 if(SENTRY_BUILD_EXAMPLES)
 	add_executable(sentry_example examples/example.c)
+	set(SENTRY_EXAMPLE_TARGETS sentry_example)
+	foreach(example feedback)
+		add_executable(sentry_example_${example} examples/${example}.c)
+		target_link_libraries(sentry_example_${example} PRIVATE sentry)
+		list(APPEND SENTRY_EXAMPLE_TARGETS sentry_example_${example})
+	endforeach()
 	if(XBOX)
-		set_target_properties(sentry_example PROPERTIES VS_USER_PROPS gdk_build.props)
+		set_target_properties(${SENTRY_EXAMPLE_TARGETS} PROPERTIES VS_USER_PROPS gdk_build.props)
 	endif()
 	target_link_libraries(sentry_example PRIVATE sentry)
 
@@ -1124,11 +1130,11 @@ if(SENTRY_BUILD_EXAMPLES)
 
 	# set static runtime if enabled
 	if(SENTRY_BUILD_RUNTIMESTATIC AND MSVC)
-		set_property(TARGET sentry_example PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+		set_property(TARGET ${SENTRY_EXAMPLE_TARGETS} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	endif()
 
 	if(DEFINED SENTRY_FOLDER)
-		set_target_properties(sentry_example PROPERTIES FOLDER ${SENTRY_FOLDER})
+		set_target_properties(${SENTRY_EXAMPLE_TARGETS} PROPERTIES FOLDER ${SENTRY_FOLDER})
 	endif()
 
 	if(CMAKE_GENERATOR STREQUAL "Xcode")

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ In addition to platform support, the "Advanced Usage" section of the SDK docs no
 - `sentry_example`: This is a small example program highlighting the API, which
   can be controlled via command-line parameters, and is also used for
   integration tests.
+- `sentry_example_*`: Standalone [examples](examples/README.md).
 
 ## Runtime Configuration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+Set the `SENTRY_DSN` environment variable.
+
+Build from the repository root:
+
+```sh
+cmake -S . -B build -DSENTRY_BUILD_EXAMPLES=ON
+cmake --build build --config RelWithDebInfo
+```
+
+Run `sentry_example_<name>` from the build output directory.
+
+- [`feedback`](feedback.c): Sends feedback for an existing event.
+  Usage: `sentry_example_feedback <envelope> <message> [email] [name] [attachment ...]`

--- a/examples/example.c
+++ b/examples/example.c
@@ -328,16 +328,6 @@ discarding_before_send_metric_callback(sentry_value_t metric, void *user_data)
 }
 
 static sentry_value_t
-discarding_before_send_feedback_callback(
-    sentry_value_t feedback, sentry_hint_t *hint, void *user_data)
-{
-    (void)hint;
-    (void)user_data;
-    sentry_value_decref(feedback);
-    return sentry_value_new_null();
-}
-
-static sentry_value_t
 before_breadcrumb_callback(sentry_value_t breadcrumb, void *user_data)
 {
     (void)user_data;
@@ -909,11 +899,6 @@ main(int argc, char **argv)
             options, discarding_before_send_metric_callback, NULL);
     }
 
-    if (has_arg(argc, argv, "discarding-before-send-feedback")) {
-        sentry_options_set_before_send_feedback(
-            options, discarding_before_send_feedback_callback, NULL);
-    }
-
     if (has_arg(argc, argv, "before-breadcrumb")) {
         sentry_options_set_before_breadcrumb(
             options, before_breadcrumb_callback, NULL);
@@ -1360,41 +1345,6 @@ main(int argc, char **argv)
         sentry_event_add_exception(event, exc);
 
         sentry_capture_event(event);
-    }
-    if (has_arg(argc, argv, "capture-user-feedback")) {
-        sentry_value_t user_feedback = sentry_value_new_feedback(
-            "some-message", "some-email", "some-name", NULL);
-
-        sentry_capture_feedback(user_feedback);
-    }
-    if (has_arg(argc, argv, "capture-user-feedback-with-attachment")) {
-        sentry_value_t user_feedback = sentry_value_new_feedback(
-            "some-message", "some-email", "some-name", NULL);
-
-        // Create a hint and attach both file and byte data
-        sentry_hint_t *hint = sentry_hint_new();
-
-        // Create a temporary file for the attachment
-        const char *attachment_path = ".sentry-test-feedback-attachment";
-        FILE *f = fopen(attachment_path, "w");
-        if (f) {
-            fprintf(f, "This is feedback attachment content");
-            fclose(f);
-        }
-
-        // Attach a file
-        sentry_hint_attach_file(hint, attachment_path);
-
-        // Attach bytes data (e.g., binary data from memory)
-        const char *binary_data = "binary attachment data";
-        sentry_hint_attach_bytes(
-            hint, binary_data, strlen(binary_data), "additional-info.txt");
-
-        // Capture feedback with attachments
-        sentry_capture_feedback_with_hint(user_feedback, hint);
-
-        // Clean up the temporary file
-        remove(attachment_path);
     }
     if (has_arg(argc, argv, "capture-user-report")) {
         sentry_value_t event = sentry_value_new_message_event(

--- a/examples/feedback.c
+++ b/examples/feedback.c
@@ -1,0 +1,65 @@
+#include "sentry.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static sentry_value_t
+before_send_feedback(sentry_value_t event, sentry_hint_t *hint, void *user_data)
+{
+    (void)hint;
+    (void)user_data;
+
+    sentry_value_t feedback = sentry_value_get_by_key(
+        sentry_value_get_by_key(event, "contexts"), "feedback");
+    const char *email = sentry_value_as_string(
+        sentry_value_get_by_key(feedback, "contact_email"));
+    if (strcmp(email, "spam@example.com") == 0) {
+        sentry_value_decref(event);
+        return sentry_value_new_null();
+    }
+
+    return event;
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc < 3) {
+        fprintf(stderr,
+            "Usage: %s <envelope> <message> [email] [name] [attachment ...]\n",
+            argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    const char *path = argv[1];
+    sentry_envelope_t *envelope = sentry_envelope_read_from_file(path);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
+    sentry_envelope_free(envelope);
+    if (sentry_uuid_is_nil(&event_id)) {
+        fprintf(stderr, "Error: invalid event %s\n", path);
+        return EXIT_FAILURE;
+    }
+
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_debug(options, true);
+    sentry_options_set_before_send_feedback(
+        options, before_send_feedback, NULL);
+
+    if (sentry_init(options) != 0) {
+        return EXIT_FAILURE;
+    }
+
+    const char *message = argv[2];
+    const char *email = argc > 3 ? argv[3] : NULL;
+    const char *name = argc > 4 ? argv[4] : NULL;
+    sentry_value_t feedback
+        = sentry_value_new_feedback(message, email, name, &event_id);
+    sentry_hint_t *hint = sentry_hint_new();
+    for (int i = 5; i < argc; i++) {
+        sentry_hint_attach_file(hint, argv[i]);
+    }
+    sentry_capture_feedback_with_hint(feedback, hint);
+
+    sentry_close();
+}

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -845,6 +845,15 @@ SENTRY_API sentry_value_t sentry_envelope_get_event(
     const sentry_envelope_t *envelope);
 
 /**
+ * Returns the event ID from the envelope header.
+ *
+ * Returns a nil UUID if `envelope` is NULL or the event ID is missing or
+ * invalid.
+ */
+SENTRY_API sentry_uuid_t sentry_envelope_get_event_id(
+    const sentry_envelope_t *envelope);
+
+/**
  * Given an Envelope, returns the embedded Transaction if there is one.
  *
  * This returns a borrowed value to the Transaction in the Envelope.

--- a/src/backends/sentry_backend_breakpad.cpp
+++ b/src/backends/sentry_backend_breakpad.cpp
@@ -186,7 +186,7 @@ breakpad_backend_callback(const google_breakpad::MinidumpDescriptor &descriptor,
             sentry_envelope_t *envelope = sentry__prepare_event(
                 options, event, nullptr, !options->on_crash_func, nullptr);
             if (envelope) {
-                event_id = sentry__envelope_get_event_id(envelope);
+                event_id = sentry_envelope_get_event_id(envelope);
             }
             sentry_session_t *session = sentry__end_current_session_with_status(
                 SENTRY_SESSION_STATUS_CRASHED);

--- a/src/backends/sentry_backend_inproc.c
+++ b/src/backends/sentry_backend_inproc.c
@@ -1104,7 +1104,7 @@ process_ucontext_deferred(const sentry_ucontext_t *uctx,
             sentry_envelope_t *envelope = sentry__prepare_event(options, event,
                 NULL, !options->on_crash_func && !skip_hooks, NULL);
             if (envelope) {
-                event_id = sentry__envelope_get_event_id(envelope);
+                event_id = sentry_envelope_get_event_id(envelope);
             }
             sentry_session_t *session = sentry__end_current_session_with_status(
                 SENTRY_SESSION_STATUS_CRASHED);

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -552,7 +552,7 @@ void
 sentry__capture_envelope(sentry_transport_t *transport,
     sentry_envelope_t *envelope, const sentry_options_t *options)
 {
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (!sentry_uuid_is_nil(&event_id)) {
         SENTRY_WITH_SCOPE_MUT_NO_FLUSH (scope) {
             scope->last_event_id = event_id;
@@ -1993,7 +1993,7 @@ sentry__launch_external_crash_reporter(
         sentry__run_write_cache(options->run, envelope, -1);
     }
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     char *envelope_filename = sentry__uuid_as_filename(&event_id, ".envelope");
     if (!envelope_filename) {
         return false;

--- a/src/sentry_database.c
+++ b/src/sentry_database.c
@@ -248,7 +248,7 @@ sentry__run_free(sentry_run_t *run)
 static bool
 write_envelope(const sentry_path_t *path, const sentry_envelope_t *envelope)
 {
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
 
     // Generate a random UUID for the filename if the envelope has no event_id
     // this avoids collisions on NIL-UUIDs
@@ -403,7 +403,7 @@ sentry__cache_attachment_ref(sentry_envelope_t *envelope,
         return false;
     }
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (sentry_uuid_is_nil(&event_id)) {
         return false;
     }
@@ -424,7 +424,7 @@ sentry__cache_attachment_refs(sentry_envelope_t *envelope,
         return;
     }
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (sentry_uuid_is_nil(&event_id)) {
         return;
     }
@@ -481,7 +481,7 @@ sentry__run_write_cache(
         return sentry__envelope_write_to_cache(envelope, run->cache_path) == 0;
     }
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (sentry_uuid_is_nil(&event_id)) {
         event_id = sentry_uuid_new_v4();
     }
@@ -683,7 +683,7 @@ sentry__process_run_envelopes(
         }
         sentry_envelope_t *envelope = sentry__envelope_from_path(file);
         if (envelope) {
-            sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+            sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
             sentry_path_t *marker = run_crash_marker_path(run_path, &event_id);
             // remove before invoking to prevent repeated callbacks
             if (marker && sentry__path_is_file(marker)

--- a/src/sentry_envelope.c
+++ b/src/sentry_envelope.c
@@ -296,7 +296,7 @@ sentry__envelope_from_path(const sentry_path_t *path)
 }
 
 sentry_uuid_t
-sentry__envelope_get_event_id(const sentry_envelope_t *envelope)
+sentry_envelope_get_event_id(const sentry_envelope_t *envelope)
 {
     if (!envelope) {
         return sentry_uuid_nil();
@@ -1275,7 +1275,7 @@ sentry__envelope_write_to_cache(
         return 1;
     }
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (sentry_uuid_is_nil(&event_id)) {
         event_id = sentry_uuid_new_v4();
     }

--- a/src/sentry_envelope.h
+++ b/src/sentry_envelope.h
@@ -42,13 +42,6 @@ sentry_envelope_t *sentry__envelope_new_with_dsn(const sentry_dsn_t *dsn);
 sentry_envelope_t *sentry__envelope_from_path(const sentry_path_t *path);
 
 /**
- * This returns the UUID of the event associated with this envelope.
- * If `envelope` is NULL or there is no event inside it, the empty nil UUID will
- * be returned.
- */
-sentry_uuid_t sentry__envelope_get_event_id(const sentry_envelope_t *envelope);
-
-/**
  * Set the event ID header for this envelope.
  */
 void sentry__envelope_set_event_id(

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -1340,7 +1340,7 @@ sentry__scope_capture_envelope(sentry_scope_t *scope,
     sentry_transport_t *transport, sentry_envelope_t *envelope,
     const sentry_options_t *options)
 {
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (!sentry_uuid_is_nil(&event_id)) {
         scope->last_event_id = event_id;
     }

--- a/src/transports/sentry_http_transport.c
+++ b/src/transports/sentry_http_transport.c
@@ -835,7 +835,7 @@ http_send_task(void *_envelope, void *_state)
     sentry_envelope_t *envelope = _envelope;
     http_transport_state_t *state = _state;
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     if (!materialize_attachment_refs(envelope)) {
         sentry__cache_remove_siblings(state->run, &event_id);
         return;

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -4,6 +4,7 @@ import json
 import platform
 import re
 import sys
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, UTC
 from pathlib import Path
@@ -52,7 +53,7 @@ def assert_session(
         assert_matches(session, extra_assertion)
 
 
-def assert_user_feedback(envelope):
+def assert_user_feedback(envelope, event_id=None):
     user_feedback = None
     for item in envelope:
         if item.headers.get("type") == "feedback" and item.payload.json is not None:
@@ -62,6 +63,8 @@ def assert_user_feedback(envelope):
     assert user_feedback["name"] == "some-name"
     assert user_feedback["contact_email"] == "some-email"
     assert user_feedback["message"] == "some-message"
+    if event_id is not None:
+        assert user_feedback["associated_event_id"] == uuid.UUID(event_id).hex
 
 
 def assert_user_report(envelope):

--- a/tests/cmake.py
+++ b/tests/cmake.py
@@ -92,6 +92,7 @@ class CMake:
                 # to the object files, we need to do it per-test
                 objects = [
                     exe_name("sentry_example"),
+                    exe_name("sentry_example_feedback"),
                     exe_name("sentry_test_unit"),
                     lib_name("sentry"),
                     exe_name("sentry-crash"),

--- a/tests/test_integration_client_reports.py
+++ b/tests/test_integration_client_reports.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from . import make_dsn, run, Envelope
+from . import make_dsn, run, Envelope, check_output
 from .assertions import (
     assert_client_report,
     assert_event,
@@ -231,29 +231,32 @@ def test_client_report_before_send_metric(cmake, httpserver):
 
 
 def test_client_report_before_send_feedback(cmake, httpserver):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+    tmp_path = cmake(
+        ["sentry_example", "sentry_example_feedback"], {"SENTRY_BACKEND": "none"}
+    )
+    source = check_output(tmp_path, "sentry_example", ["stdout", "capture-event"])
+    (tmp_path / "event.envelope").write_bytes(source)
 
     httpserver.expect_request("/api/123456/envelope/").respond_with_data("OK")
-    env = dict(os.environ, SENTRY_DSN=make_dsn(httpserver))
+    env = dict(
+        os.environ,
+        SENTRY_DSN=make_dsn(httpserver),
+        SENTRY_RELEASE="test-example-release",
+    )
 
     # Feedback is discarded by before_send_feedback. The session at
     # shutdown carries the client report.
     run(
         tmp_path,
-        "sentry_example",
-        [
-            "log",
-            "start-session",
-            "capture-user-feedback",
-            "discarding-before-send-feedback",
-        ],
+        "sentry_example_feedback",
+        ["event.envelope", "Buy cheap stuff!", "spam@example.com", "Spammer"],
         env=env,
     )
 
     assert len(httpserver.log) == 1
     envelope = Envelope.deserialize(httpserver.log[0][0].get_data())
 
-    assert_session(envelope)
+    assert_session(envelope, environment=env.get("SENTRY_ENVIRONMENT", "production"))
     assert_client_report(
         envelope,
         [{"reason": "before_send", "category": "feedback", "quantity": 1}],

--- a/tests/test_integration_http.py
+++ b/tests/test_integration_http.py
@@ -10,6 +10,7 @@ from flaky import flaky
 from . import (
     make_dsn,
     run,
+    check_output,
     stage_replay,
     Envelope,
     split_log_request_cond,
@@ -223,7 +224,12 @@ def test_capture_and_session_http(cmake, httpserver):
 
 
 def test_user_feedback_http(cmake, httpserver):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+    tmp_path = cmake(
+        ["sentry_example", "sentry_example_feedback"], {"SENTRY_BACKEND": "none"}
+    )
+    source = check_output(tmp_path, "sentry_example", ["stdout", "capture-event"])
+    (tmp_path / "event.envelope").write_bytes(source)
+    event_id = Envelope.deserialize(source).headers["event_id"]
 
     httpserver.expect_request(
         "/api/123456/envelope/",
@@ -233,20 +239,33 @@ def test_user_feedback_http(cmake, httpserver):
 
     run(
         tmp_path,
-        "sentry_example",
-        ["log", "capture-user-feedback"],
+        "sentry_example_feedback",
+        ["event.envelope", "some-message", "some-email", "some-name"],
         env=env,
     )
 
-    assert len(httpserver.log) == 1
-    output = httpserver.log[0][0].get_data()
-    envelope = Envelope.deserialize(output)
-
-    assert_user_feedback(envelope)
+    assert (tmp_path / "event.envelope").read_bytes() == source
+    assert all(
+        Envelope.deserialize(req.get_data()).get_event() is None
+        for req, _ in httpserver.log
+    )
+    feedback_request, _ = extract_request(httpserver.log, is_feedback_envelope)
+    envelope = Envelope.deserialize(feedback_request.get_data())
+    assert len(envelope.items) == 1
+    assert_user_feedback(envelope, event_id=event_id)
 
 
 def test_user_feedback_with_attachments_http(cmake, httpserver):
-    tmp_path = cmake(["sentry_example"], {"SENTRY_BACKEND": "none"})
+    tmp_path = cmake(
+        ["sentry_example", "sentry_example_feedback"], {"SENTRY_BACKEND": "none"}
+    )
+    source = check_output(tmp_path, "sentry_example", ["stdout", "capture-event"])
+    (tmp_path / "event.envelope").write_bytes(source)
+    event_id = Envelope.deserialize(source).headers["event_id"]
+    attachment = tmp_path / "application.log"
+    attachment.write_text("ERROR Failed to save document")
+    diagnostics = tmp_path / "diagnostics.txt"
+    diagnostics.write_text("Additional diagnostics")
 
     httpserver.expect_request(
         "/api/123456/envelope/",
@@ -256,17 +275,23 @@ def test_user_feedback_with_attachments_http(cmake, httpserver):
 
     run(
         tmp_path,
-        "sentry_example",
-        ["log", "capture-user-feedback-with-attachment"],
+        "sentry_example_feedback",
+        [
+            "event.envelope",
+            "some-message",
+            "some-email",
+            "some-name",
+            attachment.name,
+            diagnostics.name,
+        ],
         env=env,
     )
 
-    assert len(httpserver.log) == 1
-    output = httpserver.log[0][0].get_data()
-    envelope = Envelope.deserialize(output)
+    feedback_request, _ = extract_request(httpserver.log, is_feedback_envelope)
+    envelope = Envelope.deserialize(feedback_request.get_data())
 
     # Verify the feedback is present
-    assert_user_feedback(envelope)
+    assert_user_feedback(envelope, event_id=event_id)
 
     # Verify attachments are present
     attachment_count = 0
@@ -274,8 +299,18 @@ def test_user_feedback_with_attachments_http(cmake, httpserver):
         if item.headers.get("type") == "attachment":
             attachment_count += 1
 
-    # Should have 2 attachments (one file, one bytes)
+    # Should have 2 attachments
     assert attachment_count == 2
+
+    attachments = {
+        item.headers["filename"]: item.payload.bytes
+        for item in envelope
+        if item.headers.get("type") == "attachment"
+    }
+    assert attachments == {
+        "application.log": b"ERROR Failed to save document",
+        "diagnostics.txt": b"Additional diagnostics",
+    }
 
 
 def test_user_report_http(cmake, httpserver):

--- a/tests/unit/test_envelopes.c
+++ b/tests/unit/test_envelopes.c
@@ -396,7 +396,7 @@ SENTRY_TEST(write_raw_envelope_to_file)
 
 SENTRY_TEST(raw_envelope_event_id)
 {
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(NULL);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(NULL);
     TEST_CHECK(sentry_uuid_is_nil(&event_id));
 
     sentry_envelope_t *envelope = create_test_envelope();
@@ -409,7 +409,7 @@ SENTRY_TEST(raw_envelope_event_id)
         = sentry__envelope_from_path(test_file_path);
     TEST_CHECK(!!raw_envelope);
 
-    event_id = sentry__envelope_get_event_id(raw_envelope);
+    event_id = sentry_envelope_get_event_id(raw_envelope);
     char event_id_str[37];
     sentry_uuid_as_string(&event_id, event_id_str);
     TEST_CHECK_STRING_EQUAL(
@@ -430,7 +430,7 @@ SENTRY_TEST(raw_envelope_event_id)
         0);
     raw_envelope = sentry__envelope_from_path(test_file_path);
     TEST_CHECK(!!raw_envelope);
-    event_id = sentry__envelope_get_event_id(raw_envelope);
+    event_id = sentry_envelope_get_event_id(raw_envelope);
     TEST_CHECK(sentry_uuid_is_nil(&event_id));
     sentry__path_remove(test_file_path);
     sentry__path_free(test_file_path);
@@ -445,7 +445,7 @@ SENTRY_TEST(raw_envelope_event_id)
         0);
     raw_envelope = sentry__envelope_from_path(test_file_path);
     TEST_CHECK(!!raw_envelope);
-    event_id = sentry__envelope_get_event_id(raw_envelope);
+    event_id = sentry_envelope_get_event_id(raw_envelope);
     sentry_uuid_as_string(&event_id, event_id_str);
     TEST_CHECK_STRING_EQUAL(
         event_id_str, "c993afb6-b4ac-48a6-b61b-2558e601d65d");
@@ -475,7 +475,7 @@ SENTRY_TEST(read_envelope_from_file)
                                 envelope, "event_id")),
         "c993afb6-b4ac-48a6-b61b-2558e601d65d");
 
-    sentry_uuid_t event_id = sentry__envelope_get_event_id(envelope);
+    sentry_uuid_t event_id = sentry_envelope_get_event_id(envelope);
     char event_id_str[37];
     sentry_uuid_as_string(&event_id, event_id_str);
     TEST_CHECK_STRING_EQUAL(


### PR DESCRIPTION
Move feedback capturing out of `sentry_example` into a separate small, feedback-focused `sentry_example_feedback` target. Includes a `before_send_feedback` hook and optional attachments.

Usage: `sentry_example_feedback <envelope> <message> [email] [name] [attachment ...]`

Ref: #2044