### PR TITLE
feat: prepare new API for value-based attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Features**:
+
+- Add `sentry_attachment_from_file/bytes` (and their wide-string variants) for creating attachment values that can be fully configured before they are added. ([#2079](https://github.com/getsentry/sentry-native/pull/2079))
+- Add `sentry_add_attachment`, `sentry_scope_add_attachment`, and `sentry_hint_add_attachment` for adding configured attachments to the global scope, a specific scope, or a hint. ([#2079](https://github.com/getsentry/sentry-native/pull/2079))
+
 ## 0.16.6
 
 **Features**:

--- a/include/sentry.h
+++ b/include/sentry.h
@@ -3414,6 +3414,43 @@ struct sentry_attachment_s;
 typedef struct sentry_attachment_s sentry_attachment_t;
 
 /**
+ * Creates an attachment from a file.
+ *
+ * The path is copied and the filename is derived from it.
+ *
+ * Returns an owned attachment, or `NULL` on error.
+ *
+ * See https://develop.sentry.dev/sdk/data-model/envelope-items/#attachment
+ */
+SENTRY_API sentry_attachment_t *sentry_attachment_from_file(const char *path);
+SENTRY_API sentry_attachment_t *sentry_attachment_from_file_n(
+    const char *path, size_t path_len);
+#ifdef SENTRY_PLATFORM_WINDOWS
+SENTRY_API sentry_attachment_t *sentry_attachment_from_filew(
+    const wchar_t *path);
+SENTRY_API sentry_attachment_t *sentry_attachment_from_filew_n(
+    const wchar_t *path, size_t path_len);
+#endif
+
+/**
+ * Creates an attachment from bytes.
+ *
+ * The bytes and filename are copied.
+ *
+ * Returns an owned attachment, or `NULL` on error.
+ */
+SENTRY_API sentry_attachment_t *sentry_attachment_from_bytes(
+    const char *buf, size_t buf_len, const char *filename);
+SENTRY_API sentry_attachment_t *sentry_attachment_from_bytes_n(
+    const char *buf, size_t buf_len, const char *filename, size_t filename_len);
+#ifdef SENTRY_PLATFORM_WINDOWS
+SENTRY_API sentry_attachment_t *sentry_attachment_from_bytesw(
+    const char *buf, size_t buf_len, const wchar_t *filename);
+SENTRY_API sentry_attachment_t *sentry_attachment_from_bytesw_n(const char *buf,
+    size_t buf_len, const wchar_t *filename, size_t filename_len);
+#endif
+
+/**
  * Attaches a file to be sent along with events.
  *
  * `path` is assumed to be in a platform-specific filesystem path encoding.
@@ -3562,6 +3599,19 @@ SENTRY_API void sentry_attachment_set_filenamew_n(
     sentry_attachment_t *attachment, const wchar_t *filename,
     size_t filename_len);
 #endif
+
+/**
+ * Adds a configured attachment.
+ *
+ * Consumes `attachment` and returns an SDK-owned pointer, or `NULL` on error.
+ * If an equivalent file attachment already exists, returns the existing
+ * attachment. The returned pointer remains valid until the attachment is
+ * removed or its owning scope is freed.
+ */
+SENTRY_API sentry_attachment_t *sentry_add_attachment(
+    sentry_attachment_t *attachment);
+SENTRY_API sentry_attachment_t *sentry_scope_add_attachment(
+    sentry_scope_t *scope, sentry_attachment_t *attachment);
 
 /* -- Session APIs -- */
 
@@ -4137,6 +4187,16 @@ typedef struct sentry_hint_s sentry_hint_t;
  * - `sentry_scope_capture_feedback`
  */
 SENTRY_API sentry_hint_t *sentry_hint_new(void);
+
+/**
+ * Adds a configured attachment to a hint.
+ *
+ * Consumes `attachment` and returns a hint-owned pointer, or `NULL` on error.
+ * If an equivalent file attachment already exists, returns the existing
+ * attachment. The returned pointer remains valid until the hint is freed.
+ */
+SENTRY_API sentry_attachment_t *sentry_hint_add_attachment(
+    sentry_hint_t *hint, sentry_attachment_t *attachment);
 
 /**
  * Attaches a file to a hint.

--- a/src/sentry_attachment.c
+++ b/src/sentry_attachment.c
@@ -224,6 +224,68 @@ sentry__attachment_free(sentry_attachment_t *attachment)
     sentry_free(attachment);
 }
 
+sentry_attachment_t *
+sentry_attachment_from_file(const char *path)
+{
+    return sentry_attachment_from_file_n(path, sentry__guarded_strlen(path));
+}
+
+sentry_attachment_t *
+sentry_attachment_from_file_n(const char *path, size_t path_len)
+{
+    return sentry__attachment_from_path(
+        sentry__path_from_str_n(path, path_len));
+}
+
+sentry_attachment_t *
+sentry_attachment_from_bytes(
+    const char *buf, size_t buf_len, const char *filename)
+{
+    return sentry_attachment_from_bytes_n(
+        buf, buf_len, filename, sentry__guarded_strlen(filename));
+}
+
+sentry_attachment_t *
+sentry_attachment_from_bytes_n(
+    const char *buf, size_t buf_len, const char *filename, size_t filename_len)
+{
+    return sentry__attachment_from_buffer(
+        buf, buf_len, sentry__path_from_str_n(filename, filename_len));
+}
+
+#ifdef SENTRY_PLATFORM_WINDOWS
+sentry_attachment_t *
+sentry_attachment_from_filew(const wchar_t *path)
+{
+    size_t path_len = path ? wcslen(path) : 0;
+    return sentry_attachment_from_filew_n(path, path_len);
+}
+
+sentry_attachment_t *
+sentry_attachment_from_filew_n(const wchar_t *path, size_t path_len)
+{
+    return sentry__attachment_from_path(
+        sentry__path_from_wstr_n(path, path_len));
+}
+
+sentry_attachment_t *
+sentry_attachment_from_bytesw(
+    const char *buf, size_t buf_len, const wchar_t *filename)
+{
+    size_t filename_len = filename ? wcslen(filename) : 0;
+    return sentry_attachment_from_bytesw_n(
+        buf, buf_len, filename, filename_len);
+}
+
+sentry_attachment_t *
+sentry_attachment_from_bytesw_n(const char *buf, size_t buf_len,
+    const wchar_t *filename, size_t filename_len)
+{
+    return sentry__attachment_from_buffer(
+        buf, buf_len, sentry__path_from_wstr_n(filename, filename_len));
+}
+#endif
+
 size_t
 sentry__attachment_get_size(const sentry_attachment_t *attachment)
 {

--- a/src/sentry_core.c
+++ b/src/sentry_core.c
@@ -2138,8 +2138,8 @@ sentry_capture_minidump_n(const char *path, size_t path_len)
     return capture_minidump(dump_path);
 }
 
-static sentry_attachment_t *
-add_attachment(sentry_attachment_t *attachment)
+sentry_attachment_t *
+sentry_add_attachment(sentry_attachment_t *attachment)
 {
     if (!attachment) {
         return NULL;
@@ -2165,8 +2165,7 @@ sentry_attach_file(const char *path)
 sentry_attachment_t *
 sentry_attach_file_n(const char *path, size_t path_len)
 {
-    return add_attachment(
-        sentry__attachment_from_path(sentry__path_from_str_n(path, path_len)));
+    return sentry_add_attachment(sentry_attachment_from_file_n(path, path_len));
 }
 
 sentry_attachment_t *
@@ -2180,8 +2179,8 @@ sentry_attachment_t *
 sentry_attach_bytes_n(
     const char *buf, size_t buf_len, const char *filename, size_t filename_len)
 {
-    return add_attachment(sentry__attachment_from_buffer(
-        buf, buf_len, sentry__path_from_str_n(filename, filename_len)));
+    return sentry_add_attachment(
+        sentry_attachment_from_bytes_n(buf, buf_len, filename, filename_len));
 }
 
 void
@@ -2237,8 +2236,8 @@ sentry_attach_filew(const wchar_t *path)
 sentry_attachment_t *
 sentry_attach_filew_n(const wchar_t *path, size_t path_len)
 {
-    return add_attachment(
-        sentry__attachment_from_path(sentry__path_from_wstr_n(path, path_len)));
+    return sentry_add_attachment(
+        sentry_attachment_from_filew_n(path, path_len));
 }
 
 sentry_attachment_t *
@@ -2252,8 +2251,8 @@ sentry_attachment_t *
 sentry_attach_bytesw_n(const char *buf, size_t buf_len, const wchar_t *filename,
     size_t filename_len)
 {
-    return add_attachment(sentry__attachment_from_buffer(
-        buf, buf_len, sentry__path_from_wstr_n(filename, filename_len)));
+    return sentry_add_attachment(
+        sentry_attachment_from_bytesw_n(buf, buf_len, filename, filename_len));
 }
 
 sentry_uuid_t

--- a/src/sentry_hint.c
+++ b/src/sentry_hint.c
@@ -28,6 +28,17 @@ sentry__hint_free(sentry_hint_t *hint)
 }
 
 sentry_attachment_t *
+sentry_hint_add_attachment(sentry_hint_t *hint, sentry_attachment_t *attachment)
+{
+    if (!hint) {
+        sentry__attachment_free(attachment);
+        return NULL;
+    }
+
+    return sentry__attachments_add(&hint->attachments, attachment);
+}
+
+sentry_attachment_t *
 sentry_hint_attach_file(sentry_hint_t *hint, const char *path)
 {
     return sentry_hint_attach_file_n(hint, path, sentry__guarded_strlen(path));
@@ -37,11 +48,8 @@ sentry_attachment_t *
 sentry_hint_attach_file_n(
     sentry_hint_t *hint, const char *path, size_t path_len)
 {
-    if (!hint) {
-        return NULL;
-    }
-    return sentry__attachments_add_path(&hint->attachments,
-        sentry__path_from_str_n(path, path_len), NULL, NULL);
+    return sentry_hint_add_attachment(
+        hint, sentry_attachment_from_file_n(path, path_len));
 }
 
 sentry_attachment_t *
@@ -56,12 +64,8 @@ sentry_attachment_t *
 sentry_hint_attach_bytes_n(sentry_hint_t *hint, const char *buf, size_t buf_len,
     const char *filename, size_t filename_len)
 {
-    if (!hint) {
-        return NULL;
-    }
-    return sentry__attachments_add(&hint->attachments,
-        sentry__attachment_from_buffer(
-            buf, buf_len, sentry__path_from_str_n(filename, filename_len)));
+    return sentry_hint_add_attachment(hint,
+        sentry_attachment_from_bytes_n(buf, buf_len, filename, filename_len));
 }
 
 #ifdef SENTRY_PLATFORM_WINDOWS
@@ -76,11 +80,8 @@ sentry_attachment_t *
 sentry_hint_attach_filew_n(
     sentry_hint_t *hint, const wchar_t *path, size_t path_len)
 {
-    if (!hint) {
-        return NULL;
-    }
-    return sentry__attachments_add_path(&hint->attachments,
-        sentry__path_from_wstr_n(path, path_len), NULL, NULL);
+    return sentry_hint_add_attachment(
+        hint, sentry_attachment_from_filew_n(path, path_len));
 }
 
 sentry_attachment_t *
@@ -96,11 +97,7 @@ sentry_attachment_t *
 sentry_hint_attach_bytesw_n(sentry_hint_t *hint, const char *buf,
     size_t buf_len, const wchar_t *filename, size_t filename_len)
 {
-    if (!hint) {
-        return NULL;
-    }
-    return sentry__attachments_add(&hint->attachments,
-        sentry__attachment_from_buffer(
-            buf, buf_len, sentry__path_from_wstr_n(filename, filename_len)));
+    return sentry_hint_add_attachment(hint,
+        sentry_attachment_from_bytesw_n(buf, buf_len, filename, filename_len));
 }
 #endif

--- a/src/sentry_scope.c
+++ b/src/sentry_scope.c
@@ -1168,6 +1168,18 @@ sentry_scope_remove_attachment(
 }
 
 sentry_attachment_t *
+sentry_scope_add_attachment(
+    sentry_scope_t *scope, sentry_attachment_t *attachment)
+{
+    if (!scope) {
+        sentry__attachment_free(attachment);
+        return NULL;
+    }
+
+    return sentry__scope_add_attachment(scope, attachment);
+}
+
+sentry_attachment_t *
 sentry_scope_attach_file(sentry_scope_t *scope, const char *path)
 {
     return sentry_scope_attach_file_n(
@@ -1178,8 +1190,8 @@ sentry_attachment_t *
 sentry_scope_attach_file_n(
     sentry_scope_t *scope, const char *path, size_t path_len)
 {
-    return sentry__scope_add_attachment(scope,
-        sentry__attachment_from_path(sentry__path_from_str_n(path, path_len)));
+    return sentry_scope_add_attachment(
+        scope, sentry_attachment_from_file_n(path, path_len));
 }
 
 sentry_attachment_t *
@@ -1194,9 +1206,8 @@ sentry_attachment_t *
 sentry_scope_attach_bytes_n(sentry_scope_t *scope, const char *buf,
     size_t buf_len, const char *filename, size_t filename_len)
 {
-    return sentry__scope_add_attachment(scope,
-        sentry__attachment_from_buffer(
-            buf, buf_len, sentry__path_from_str_n(filename, filename_len)));
+    return sentry_scope_add_attachment(scope,
+        sentry_attachment_from_bytes_n(buf, buf_len, filename, filename_len));
 }
 
 #ifdef SENTRY_PLATFORM_WINDOWS
@@ -1211,8 +1222,8 @@ sentry_attachment_t *
 sentry_scope_attach_filew_n(
     sentry_scope_t *scope, const wchar_t *path, size_t path_len)
 {
-    return sentry__scope_add_attachment(scope,
-        sentry__attachment_from_path(sentry__path_from_wstr_n(path, path_len)));
+    return sentry_scope_add_attachment(
+        scope, sentry_attachment_from_filew_n(path, path_len));
 }
 
 sentry_attachment_t *
@@ -1228,9 +1239,8 @@ sentry_attachment_t *
 sentry_scope_attach_bytesw_n(sentry_scope_t *scope, const char *buf,
     size_t buf_len, const wchar_t *filename, size_t filename_len)
 {
-    return sentry__scope_add_attachment(scope,
-        sentry__attachment_from_buffer(
-            buf, buf_len, sentry__path_from_wstr_n(filename, filename_len)));
+    return sentry_scope_add_attachment(scope,
+        sentry_attachment_from_bytesw_n(buf, buf_len, filename, filename_len));
 }
 #endif
 


### PR DESCRIPTION
Another non-breaking preparation step for the upcoming value-based attachments: expose file and byte attachment constructors etc. while retaining `sentry_attachment_t` pointers for the time being, so that #1974 can focus on changing attachment types without needing to introduce new API alongside the noisy type changes.

Note to agents: Yes, there's a small, intentional gap in the API. No intermediate `sentry_attachment_free` is being introduced because it won't be needed in #1974.