### PR TITLE
test: fix and extend benchmarks

### DIFF
--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -192,3 +192,15 @@ def test_benchmark_stack_usage(backend, cmake, gmeasurement):
         "bytes",
         f"Peak {peak}b, Segments {len(measurements)}",
     )
+
+
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
+def test_benchmark_contexts(backend, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        "benchmark_contexts",
+        backend,
+        cmake,
+        httpserver,
+        gbenchmark,
+        f"Contexts ({backend})",
+    )

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -59,16 +59,27 @@ def test_benchmark_backend(backend, cmake, httpserver, gbenchmark):
     )
 
 
-@pytest.mark.parametrize("test_name", ["set_tag", "add_breadcrumb"])
 @pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
-def test_benchmark_scope(test_name, backend, cmake, httpserver, gbenchmark):
+def test_benchmark_tags(backend, cmake, httpserver, gbenchmark):
     run_benchmark(
-        f"benchmark_scope_{test_name}",
+        "benchmark_tags",
         backend,
         cmake,
         httpserver,
         gbenchmark,
-        f"Scope {test_name} ({backend})",
+        f"Tags ({backend})",
+    )
+
+
+@pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
+def test_benchmark_breadcrumbs(backend, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        "benchmark_breadcrumbs",
+        backend,
+        cmake,
+        httpserver,
+        gbenchmark,
+        f"Breadcrumbs ({backend})",
     )
 
 

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -84,6 +84,18 @@ def test_benchmark_logs(threads, cmake, httpserver, gbenchmark):
     )
 
 
+@pytest.mark.parametrize("threads", [1, 8, 16, 32])
+def test_benchmark_metrics(threads, cmake, httpserver, gbenchmark):
+    run_benchmark(
+        f"^benchmark_metrics.*threads:{threads}$",
+        "none",
+        cmake,
+        httpserver,
+        gbenchmark,
+        f"Metrics ({threads} thread{'s' if threads > 1 else ''})",
+    )
+
+
 @pytest.mark.parametrize("backend", ["inproc", "breakpad", "crashpad", "native"])
 def test_benchmark_libsize(backend, cmake, gmeasurement):
     tmp_path = cmake(

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(sentry_benchmark
 	benchmark_init.cpp
 	benchmark_backend.cpp
 	benchmark_logs.cpp
+	benchmark_metrics.cpp
 	benchmark_scope.cpp
 )
 

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(sentry_benchmark
 	benchmark_init.cpp
 	benchmark_backend.cpp
 	benchmark_breadcrumbs.cpp
+	benchmark_contexts.cpp
 	benchmark_logs.cpp
 	benchmark_metrics.cpp
 	benchmark_tags.cpp

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -11,9 +11,10 @@ add_executable(sentry_benchmark
 	${SENTRY_SOURCES}
 	benchmark_init.cpp
 	benchmark_backend.cpp
+	benchmark_breadcrumbs.cpp
 	benchmark_logs.cpp
 	benchmark_metrics.cpp
-	benchmark_scope.cpp
+	benchmark_tags.cpp
 )
 
 if(SENTRY_BACKEND_CRASHPAD)

--- a/tests/benchmark/benchmark_breadcrumbs.cpp
+++ b/tests/benchmark/benchmark_breadcrumbs.cpp
@@ -1,0 +1,29 @@
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#include "sentry_core.h"
+#include "sentry_options.h"
+#include "sentry_scope.h"
+}
+
+static void
+benchmark_breadcrumbs(benchmark::State &state)
+{
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    sentry_init(options);
+
+    int i = 0;
+    for (auto _ : state) {
+        char msg[32];
+        snprintf(msg, sizeof(msg), "message%d", i);
+        sentry_add_breadcrumb(sentry_value_new_breadcrumb(NULL, msg));
+        i++;
+    }
+
+    sentry_close();
+}
+
+BENCHMARK(benchmark_breadcrumbs)
+    ->Iterations(1000)
+    ->Unit(benchmark::kMillisecond);

--- a/tests/benchmark/benchmark_contexts.cpp
+++ b/tests/benchmark/benchmark_contexts.cpp
@@ -1,0 +1,35 @@
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#include "sentry_core.h"
+#include "sentry_options.h"
+#include "sentry_scope.h"
+}
+
+static void
+benchmark_contexts(benchmark::State &state)
+{
+    sentry_options_t *options = sentry_options_new();
+    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
+    // flush both __sentry-event and the external crash report
+    sentry_options_set_external_crash_reporter_path(options, ".");
+    sentry_options_set_debug(options, true);
+    sentry_init(options);
+
+    int i = 0;
+    for (auto _ : state) {
+        char key[32], val[32];
+        snprintf(key, sizeof(key), "context%d", i);
+        snprintf(val, sizeof(val), "value%d", i);
+        sentry_value_t context = sentry_value_new_object();
+        sentry_value_set_by_key(context, "value", sentry_value_new_string(val));
+        sentry_set_context(key, context);
+        i++;
+    }
+
+    sentry_close();
+}
+
+BENCHMARK(benchmark_contexts)
+    ->Iterations(1000)
+    ->Unit(benchmark::kMillisecond);

--- a/tests/benchmark/benchmark_metrics.cpp
+++ b/tests/benchmark/benchmark_metrics.cpp
@@ -11,13 +11,12 @@ discard_envelope(sentry_envelope_t *envelope, void *)
 }
 
 static void
-setup_logs(const benchmark::State &)
+setup_metrics(const benchmark::State &)
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
     sentry_options_set_release(options, "benchmark@1.0");
     sentry_options_set_environment(options, "test");
-    sentry_options_set_logs_with_attributes(options, true);
     sentry_options_set_auto_session_tracking(options, 0);
     sentry_options_set_transport(
         options, sentry_transport_new(discard_envelope));
@@ -28,24 +27,23 @@ setup_logs(const benchmark::State &)
 }
 
 static void
-teardown_logs(const benchmark::State &)
+teardown_metrics(const benchmark::State &)
 {
     sentry_close();
 }
 
 static void
-benchmark_logs(benchmark::State &state)
+benchmark_metrics(benchmark::State &state)
 {
     sentry_value_t attributes = sentry_value_new_object();
-    sentry_value_set_by_key(attributes, "local",
-        sentry_value_new_attribute(sentry_value_new_string("attribute"), NULL));
+    sentry_value_set_by_key(attributes, "asset.type",
+        sentry_value_new_attribute(sentry_value_new_string("texture"), NULL));
 
-    int i = 0;
     int failed = 0;
     for (auto _ : state) {
-        if (sentry_log_info(
-                "log %d", sentry_value_incref(attributes), i++, NULL)
-            != SENTRY_LOG_RETURN_SUCCESS) {
+        if (sentry_metrics_distribution("asset.load.duration", 12.5,
+                SENTRY_UNIT_MILLISECOND, sentry_value_incref(attributes))
+            != SENTRY_METRICS_RESULT_SUCCESS) {
             failed++;
         }
     }
@@ -55,7 +53,7 @@ benchmark_logs(benchmark::State &state)
     sentry_value_decref(attributes);
 }
 
-BENCHMARK(benchmark_logs)
+BENCHMARK(benchmark_metrics)
     ->Threads(1)
     ->Threads(8)
     ->Threads(16)
@@ -63,5 +61,5 @@ BENCHMARK(benchmark_logs)
     ->Iterations(32) // 32x32=1024 (peak) > 10x100=1000 (capacity)
     ->UseRealTime()
     ->Unit(benchmark::kMillisecond)
-    ->Setup(setup_logs)
-    ->Teardown(teardown_logs);
+    ->Setup(setup_metrics)
+    ->Teardown(teardown_metrics);

--- a/tests/benchmark/benchmark_tags.cpp
+++ b/tests/benchmark/benchmark_tags.cpp
@@ -7,7 +7,7 @@ extern "C" {
 }
 
 static void
-benchmark_scope_set_tag(benchmark::State &state)
+benchmark_tags(benchmark::State &state)
 {
     sentry_options_t *options = sentry_options_new();
     sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
@@ -28,28 +28,6 @@ benchmark_scope_set_tag(benchmark::State &state)
     sentry_close();
 }
 
-BENCHMARK(benchmark_scope_set_tag)
-    ->Iterations(1000)
-    ->Unit(benchmark::kMillisecond);
-
-static void
-benchmark_scope_add_breadcrumb(benchmark::State &state)
-{
-    sentry_options_t *options = sentry_options_new();
-    sentry_options_set_dsn(options, "https://foo@sentry.invalid/42");
-    sentry_init(options);
-
-    int i = 0;
-    for (auto _ : state) {
-        char msg[32];
-        snprintf(msg, sizeof(msg), "message%d", i);
-        sentry_add_breadcrumb(sentry_value_new_breadcrumb(NULL, msg));
-        i++;
-    }
-
-    sentry_close();
-}
-
-BENCHMARK(benchmark_scope_add_breadcrumb)
+BENCHMARK(benchmark_tags)
     ->Iterations(1000)
     ->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
<!--
Add `benchmark_metrics` for multi-threaded metrics throughput alongside the existing `benchmark_logs`.

The logs benchmark previously attempted 32x100 logs at peak concurrency, far exceeding the benchmark's configured 10x100 buffer capacity. Overflows caused quick log discards to dominate, making the results look artificially good. It is a good moment to fix the benchmark before the upcoming optimizations (#2042).

Reduce iterations per thread to 32, so the peak of 1,024 logs only slightly exceeds the max 1000-log item capacity. Track enqueue failures and count only successful enqueues as processed items to make drops visible in the results. Use real time to measure elapsed time across concurrent threads: https://google.github.io/benchmark/user_guide.html#multithreaded-benchmarks
-->

- Fix logs benchmark before the upcoming optimizations (#2042)
  - 32×100 attempts exceeded the 10×100 buffer capacity, so quick discards made results artificially good. Reduce iterations per thread to 32, bringing the peak to 1024 against a 1000-item capacity.
- Report enqueue failures and count only successful enqueues as processed items for logs and metrics.
- Use [real time](https://google.github.io/benchmark/user_guide.html#multithreaded-benchmarks) to measure elapsed time across concurrent threads.
- Add distribution metrics benchmarks with 1, 8, 16, and 32 threads.
- Add contexts benchmarks across all four backends.
- Split scope benchmarks into dedicated tags and breadcrumbs benchmarks.

Ref: #1862 